### PR TITLE
Added libmariadb-devel to Dockerfile Dependencies - Card 4476

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM opensuse/amd64:42.3
 RUN zypper --non-interactive install --no-recommend timezone \
 gcc libffi48-devel make git-core zlib-devel libxml2-devel libxslt-devel \
 ruby2.4-rubygem-bundler ruby2.4-rubygem-mini_portile2 ruby2.4-rubygem-nio4r \
-ruby2.4-rubygem-websocket-driver ruby2.4-devel ruby2.4-rubygem-pg cron
+ruby2.4-rubygem-websocket-driver ruby2.4-devel ruby2.4-rubygem-pg cron libmariadb-devel
 
 RUN bundle config build.nokogiri --use-system-libraries
 


### PR DESCRIPTION
In Docker:
Without libmariadb-devel, the ruby gem mysql2 could not be installed.