### PR TITLE
Change product description from string to text - Card 4476

### DIFF
--- a/db/migrate/20170919123818_change_product_description_to_text.rb
+++ b/db/migrate/20170919123818_change_product_description_to_text.rb
@@ -1,0 +1,7 @@
+class ChangeProductDescriptionToText < ActiveRecord::Migration[5.1]
+
+  def change
+    change_column :products, :description, :text
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170825145600) do
+ActiveRecord::Schema.define(version: 20170919123818) do
 
   create_table "activations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "service_id", null: false
@@ -29,7 +29,7 @@ ActiveRecord::Schema.define(version: 20170825145600) do
 
   create_table "products", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "name"
-    t.string "description"
+    t.text "description"
     t.string "friendly_name"
     t.string "shortname"
     t.string "former_identifier"


### PR DESCRIPTION
Rails sets the string column type (varchar(255)) to have a limit of 255 characters in MySQL, which is not enough to fit product descriptions. The text column type should give us enough room.