### PR TITLE
Get users information on how to provide feedback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,4 @@ coverage/
 config/secrets.yml.key
 config/secrets.yml.enc
 config/rmt.local.yml
-
+public/repo

--- a/lib/rmt/cli/main.rb
+++ b/lib/rmt/cli/main.rb
@@ -33,6 +33,14 @@ class RMT::CLI::Main < RMT::CLI::Base
     puts RMT::VERSION
   end
 
+  desc 'feedback', 'How to provide feedback about RMT'
+  def feedback
+    puts <<-eof.squish
+      RMT project developers would love to hear from you! Please do not hesitate
+      to reach out to us via https://github.com/suse/rmt/issues'
+    eof
+  end
+
   map %w[--version -v] => :version
 
 end

--- a/spec/lib/rmt/cli/main_spec.rb
+++ b/spec/lib/rmt/cli/main_spec.rb
@@ -12,6 +12,18 @@ RSpec.describe RMT::CLI::Main do
       it 'displays help' do
         expect { command }.to output(/Commands:/).to_stdout
       end
+
+      it 'displays feedback' do
+        expect { command }.to output(/feedback/).to_stdout
+      end
+    end
+
+    context 'feedback' do
+      let(:argv) { ['feedback'] }
+
+      it 'mentions github where users can leave their feedback' do
+        expect { command }.to output(/github/).to_stdout
+      end
     end
 
     context 'version argument' do


### PR DESCRIPTION
I believe that feedback possibility should be that prominent that one cannot avoid it.
It is a small additional cli item which should give info that user can reach out to github issues to leave their feedback