### PR TITLE
Cleaned up if statement for is_sle_12_family

### DIFF
--- a/package/rmt-server.spec
+++ b/package/rmt-server.spec
@@ -16,7 +16,7 @@
 #
 
 
-%if (0%{?suse_version} > 0 && 0%{?suse_version} <= 1320) || (0%{?sle_version} > 0 && 0%{?sle_version} <= 120300)
+%if 0%{?suse_version} == 1315
 %define is_sle_12_family 1
 %endif
 


### PR DESCRIPTION
SR for factory was declined because the if statement here could be simpler.

https://en.opensuse.org/openSUSE:Build_Service_cross_distribution_howto#Detect_a_distribution_flavor_for_special_code