### PR TITLE
Force parser bundle update in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ WORKDIR /srv/www/rmt/
 
 RUN sed -i 's/#!\/usr\/bin\/env ruby/#!\/usr\/bin\/ruby.ruby2.5/g' /srv/www/rmt/bin/rmt-cli
 RUN ln -s /srv/www/rmt/bin/rmt-cli /usr/bin
+RUN bundle update parser --patch
 RUN bundle
 
 RUN printf "database: &database\n\

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,6 @@ WORKDIR /srv/www/rmt/
 
 RUN sed -i 's/#!\/usr\/bin\/env ruby/#!\/usr\/bin\/ruby.ruby2.5/g' /srv/www/rmt/bin/rmt-cli
 RUN ln -s /srv/www/rmt/bin/rmt-cli /usr/bin
-RUN bundle update parser --patch
 RUN bundle
 
 RUN printf "database: &database\n\

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,7 +149,7 @@ GEM
       nenv (~> 0.1)
       shellany (~> 0.0)
     parallel (1.12.1)
-    parser (2.5.0.4)
+    parser (2.5.0.5)
       ast (~> 2.4.0)
     powerpack (0.1.1)
     pry (0.11.3)


### PR DESCRIPTION
Due to  [Issue #478 - Update CHANGELOG to mention pulled 2.5.0.4 version](https://github.com/whitequark/parser/issues/478) in the whitequark/parser project, running the docker-compose command as specified in the README results in an error message saying "Your bundle is locked to parser (2.5.0.4), but that version could not be found". To remedy this, simply update the parser bundle before running the `bundle` command. This has been tested to fix the problem on my machine.