### PR TITLE
Use the recommended systemd config

### DIFF
--- a/package/rmt-server.spec
+++ b/package/rmt-server.spec
@@ -103,13 +103,11 @@ mkdir -p %{buildroot}%{data_dir}
 mkdir -p %{buildroot}%{lib_dir}
 mkdir -p %{buildroot}%{app_dir}
 
-mv log %{buildroot}%{data_dir}
 mv tmp %{buildroot}%{data_dir}
 mv public %{buildroot}%{data_dir}
 mv vendor %{buildroot}%{lib_dir}
 
 cp -ar . %{buildroot}%{app_dir}
-ln -s %{data_dir}/log %{buildroot}%{app_dir}/log
 ln -s %{data_dir}/tmp %{buildroot}%{app_dir}/tmp
 ln -s %{data_dir}/public %{buildroot}%{app_dir}/public
 mkdir -p %{buildroot}%{_bindir}

--- a/package/rmt.service
+++ b/package/rmt.service
@@ -5,12 +5,12 @@ Requires=rmt-migration.service
 After=rmt-migration.service
 
 [Service]
-Type=forking
+Type=simple
 User=_rmt
+PrivateTmp=yes
+Environment=RAILS_LOG_TO_STDOUT=1
 WorkingDirectory=/usr/share/rmt
-ExecStart=/usr/share/rmt/bin/rails server -e production --daemon
-ExecStop=/usr/bin/kill -15 $MAINPID
-PIDFile=/usr/share/rmt/tmp/pids/server.pid
+ExecStart=/usr/share/rmt/bin/rails server -e production
 Restart=always
 
 [Install]


### PR DESCRIPTION
Puma specifies a recommended way of starting it with systemd at:
https://github.com/puma/puma/blob/5fb2df9144803f0f80ec1d9fb19d20d433706fef/docs/systemd.md#service-configuration

Type=simple can be used, and then there's not need to --daemon the Rails
server.
Additionally, we set the RAILS_LOG_TO_STDOUT variable, so that Rails
outputs its log to stdout. This allows for the logs to be saved and
visible in journalctl.

The PrivateTmp option "sets up a new file system namespace for the
executed processes and mounts private /tmp and /var/tmp directories
inside it that is not shared by processes outside of the namespace.
(...) all temporary files created by a service in these directories will
be removed after the service is stopped."

Since RMT creates some temporary directories while mirroring, with this
option we isolate them and make sure they get deleted when RMT is
stopped.