### PR TITLE
Enable Recommended Products - Card 170

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -88,8 +88,12 @@ class Product < ApplicationRecord
 
   def self.available_or_recommended_modules(root_product_ids)
     joins(:product_extensions_associations).free.module.where(products_extensions: { root_product_id: root_product_ids }).or(
-      joins(:product_extensions_associations).where(products_extensions: { recommended: true, root_product_id: root_product_ids })
+      recommended_extensions(root_product_ids)
     ).distinct
+  end
+
+  def self.recommended_extensions(root_product_ids)
+    joins(:product_extensions_associations).where(products_extensions: { recommended: true, root_product_id: root_product_ids })
   end
 
   def service

--- a/lib/rmt/cli/products.rb
+++ b/lib/rmt/cli/products.rb
@@ -49,9 +49,10 @@ class RMT::CLI::Products < RMT::CLI::Base
       identifier, version, arch = target.split('/')
       conditions = { identifier: identifier, version: version }
       conditions[:arch] = arch if arch
-      products = Product.where(conditions)
+      products = Product.where(conditions).to_a
     end
 
+    products = products.flat_map { |product| [product] + Product.recommended_extensions(product.id).to_a }.uniq
     repo_count = repository_service.change_mirroring_by_product!(set_enabled, products)
     puts "#{repo_count} repo(s) successfully #{set_enabled ? 'enabled' : 'disabled'}."
   rescue ActiveRecord::RecordNotFound

--- a/lib/rmt/cli/products.rb
+++ b/lib/rmt/cli/products.rb
@@ -52,11 +52,13 @@ class RMT::CLI::Products < RMT::CLI::Base
       products = Product.where(conditions).to_a
     end
 
-    products.each do |product|
-      extensions = Product.recommended_extensions(product.id).to_a
-      next if extensions.empty?
-      puts "The following required extensions for #{product.product_string} have been enabled: #{extensions.pluck(:name).join(', ')}."
-      products.push(*extensions)
+    if set_enabled
+      products.each do |product|
+        extensions = Product.recommended_extensions(product.id).to_a
+        next if extensions.empty?
+        puts "The following required extensions for #{product.product_string} have been enabled: #{extensions.pluck(:name).join(', ')}."
+        products.push(*extensions)
+      end
     end
 
     repo_count = repository_service.change_mirroring_by_product!(set_enabled, products.uniq)

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -61,6 +61,14 @@ FactoryGirl.define do
       end
     end
 
+    trait :with_recommended_extensions do
+      after :create do |product, _evaluator|
+        5.times do
+          create(:product, :extension, :with_not_mirrored_repositories, base_products: [product], recommended: true)
+        end
+      end
+    end
+
     trait :with_modules do
       after :create do |product, _evaluator|
         5.times do

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -61,14 +61,6 @@ FactoryGirl.define do
       end
     end
 
-    trait :with_recommended_extensions do
-      after :create do |product, _evaluator|
-        5.times do
-          create(:product, :extension, :with_not_mirrored_repositories, base_products: [product], recommended: true)
-        end
-      end
-    end
-
     trait :with_modules do
       after :create do |product, _evaluator|
         5.times do

--- a/spec/lib/rmt/cli/products_spec.rb
+++ b/spec/lib/rmt/cli/products_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe RMT::CLI::Products do
           "#{repo_count} repo(s) successfully enabled.\n"
         end
 
-        it 'enables the mandatory product repositories' do
+        it 'enables product and recommended products repositories' do
           products.flat_map(&:repositories).each do |repository|
             expect(repository.mirroring_enabled).to eq(repository.enabled)
           end
@@ -203,7 +203,7 @@ RSpec.describe RMT::CLI::Products do
         let(:product) { create :product, :with_mirrored_repositories, :with_recommended_extensions }
         let(:extensions) { Product.recommended_extensions(product).to_a }
 
-        it 'disabled the mandatory product repositories' do
+        it 'does not disable extension repositories' do
           product.repositories.each do |repository|
             expect(repository.mirroring_enabled).to eq(false)
           end

--- a/spec/lib/rmt/cli/products_spec.rb
+++ b/spec/lib/rmt/cli/products_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe RMT::CLI::Products do
         end
       end
 
-      context 'with recommended products' do
+      context 'with recommended extensions' do
         let(:product) { create :product, :with_not_mirrored_repositories, :with_recommended_extensions }
         let(:extensions) { Product.recommended_extensions(product).to_a }
         let(:products) { [product] + extensions }
@@ -196,6 +196,22 @@ RSpec.describe RMT::CLI::Products do
       it 'disabled the mandatory product repositories' do
         product.repositories.each do |repository|
           expect(repository.mirroring_enabled).to eq(false)
+        end
+      end
+
+      context 'with recommended extensions' do
+        let(:product) { create :product, :with_mirrored_repositories, :with_recommended_extensions }
+        let(:extensions) { Product.recommended_extensions(product).to_a }
+
+        it 'disabled the mandatory product repositories' do
+          product.repositories.each do |repository|
+            expect(repository.mirroring_enabled).to eq(false)
+          end
+          extensions.each do |extension|
+            extension.repositories.each do |repository|
+              expect(repository.mirroring_enabled).to eq(false)
+            end
+          end
         end
       end
     end

--- a/spec/lib/rmt/cli/products_spec.rb
+++ b/spec/lib/rmt/cli/products_spec.rb
@@ -130,8 +130,14 @@ RSpec.describe RMT::CLI::Products do
       end
 
       context 'with recommended extensions' do
-        let(:product) { create :product, :with_not_mirrored_repositories, :with_recommended_extensions }
-        let(:extensions) { Product.recommended_extensions(product).to_a }
+        let(:product) { create :product, :with_not_mirrored_repositories }
+        let(:extensions) do
+          [
+            create(:product, :extension, :with_not_mirrored_repositories, base_products: [product], recommended: true),
+            create(:product, :extension, :with_not_mirrored_repositories, base_products: [product], recommended: true),
+            create(:product, :extension, :with_not_mirrored_repositories, base_products: [product], recommended: true)
+          ]
+        end
         let(:products) { [product] + extensions }
         let(:repo_count) { products.inject(0) { |sum, product| sum + product.repositories.where(enabled: true).count } }
         let(:expected_output) do
@@ -200,8 +206,13 @@ RSpec.describe RMT::CLI::Products do
       end
 
       context 'with recommended extensions' do
-        let(:product) { create :product, :with_mirrored_repositories, :with_recommended_extensions }
-        let(:extensions) { Product.recommended_extensions(product).to_a }
+        let(:product) { create :product, :with_mirrored_repositories }
+        let(:extensions) do
+          [
+            create(:product, :extension, :with_mirrored_repositories, base_products: [product], recommended: true),
+            create(:product, :extension, :with_mirrored_repositories, base_products: [product], recommended: true)
+          ]
+        end
 
         it 'does not disable extension repositories' do
           product.repositories.each do |repository|
@@ -209,7 +220,7 @@ RSpec.describe RMT::CLI::Products do
           end
           extensions.each do |extension|
             extension.repositories.each do |repository|
-              expect(repository.mirroring_enabled).to eq(false)
+              expect(repository.mirroring_enabled).to eq(true)
             end
           end
         end

--- a/spec/lib/rmt/cli/products_spec.rb
+++ b/spec/lib/rmt/cli/products_spec.rb
@@ -131,8 +131,13 @@ RSpec.describe RMT::CLI::Products do
 
       context 'with recommended products' do
         let(:product) { create :product, :with_not_mirrored_repositories, :with_recommended_extensions }
-        let(:products) { [product] + Product.recommended_extensions(product).to_a }
+        let(:extensions) { Product.recommended_extensions(product).to_a }
+        let(:products) { [product] + extensions }
         let(:repo_count) { products.inject(0) { |sum, product| sum + product.repositories.where(enabled: true).count } }
+        let(:expected_output) do
+          "The following required extensions for #{product.product_string} have been enabled: #{extensions.pluck(:name).join(', ')}.\n" \
+          "#{repo_count} repo(s) successfully enabled.\n"
+        end
 
         it 'enables the mandatory product repositories' do
           products.flat_map(&:repositories).each do |repository|


### PR DESCRIPTION
**Who:** RMT users
**What:** need to have mirroring enabled for recommended modules when enabling mirroring for the base product
**Why**: currently if you could do the following:

* enable `sles/15/x86_64` 
* do not enable `basesystem` or any other module
* register your client machine
* have only 3 RPM packages base product repos
* have no extensions will be listed in the output of `SUSEConnect --list-extensions`