### PR TITLE
Remove uniqueness for HwInfo#uuid

### DIFF
--- a/app/models/hw_info.rb
+++ b/app/models/hw_info.rb
@@ -5,7 +5,7 @@ class HwInfo < ApplicationRecord
   before_validation :make_invalid_uuid_nil
 
   # We store UUID as a downcased string. Please take that in account in finders
-  validates :uuid, uuid_format: true, uniqueness: { allow_nil: true }
+  validates :uuid, uuid_format: true
   validates :system, uniqueness: true, presence: true
 
   before_save -> { uuid.try(:downcase!) }

--- a/db/migrate/20180420145408_remove_hw_info_uuid_index.rb
+++ b/db/migrate/20180420145408_remove_hw_info_uuid_index.rb
@@ -1,0 +1,5 @@
+class RemoveHwInfoUuidIndex < ActiveRecord::Migration[5.1]
+  def change
+    remove_index :hw_infos, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180416124217) do
+ActiveRecord::Schema.define(version: 20180420145408) do
 
   create_table "activations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.bigint "service_id", null: false
@@ -41,7 +41,6 @@ ActiveRecord::Schema.define(version: 20180416124217) do
     t.datetime "updated_at", null: false
     t.index ["hypervisor"], name: "index_hw_infos_on_hypervisor"
     t.index ["system_id"], name: "index_hw_infos_on_system_id", unique: true
-    t.index ["uuid"], name: "index_hw_infos_on_uuid", unique: true
   end
 
   create_table "product_predecessors", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|

--- a/spec/models/hw_info_spec.rb
+++ b/spec/models/hw_info_spec.rb
@@ -11,7 +11,6 @@ describe HwInfo do
 
   it 'enforces uniqueness' do
     expect(hw_info).to validate_uniqueness_of(:system)
-    expect(hw_info).to validate_uniqueness_of(:uuid)
   end
 
   describe '.uuid' do


### PR DESCRIPTION
The unique index on 'HwInfo#uuid' breaks the behaviour in case of cleanup and attempt to register again. There should be no unique index

The solution is to update the migration and fix it on ref host manually