### PR TITLE
Remove :online and :offline scopes

### DIFF
--- a/app/models/product_predecessor_association.rb
+++ b/app/models/product_predecessor_association.rb
@@ -4,8 +4,4 @@ class ProductPredecessorAssociation < ApplicationRecord
   enum kind: { online: 0, offline: 1 }
 
   validates :product_id, :predecessor_id, :kind, presence: true
-
-  scope :online, -> { where(kind: :online) }
-  scope :offline, -> { where(kind: :offline) }
-
 end


### PR DESCRIPTION
They are provided automatically by `enum` so there's no need to
explicitly define them.