### PR TITLE
Skip repos check when deactivating a module/extension

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,3 +35,6 @@ Naming/UncommunicativeMethodParamName:
   AllowedNames:
   - to
   - id
+
+RSpec/NestedGroups:
+  MaxNesting: 4

--- a/app/controllers/api/connect/v3/systems/products_controller.rb
+++ b/app/controllers/api/connect/v3/systems/products_controller.rb
@@ -2,7 +2,7 @@ class Api::Connect::V3::Systems::ProductsController < Api::Connect::BaseControll
 
   before_action :authenticate_system
   before_action :require_product, only: %i[show activate upgrade destroy]
-  before_action :check_product_service_and_repositories, only: %i[show activate upgrade]
+  before_action :check_product_service_and_repositories, only: %i[show activate]
   before_action :check_base_product_dependencies, only: %i[activate upgrade show]
 
   def activate

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -5,7 +5,7 @@ class Repository < ApplicationRecord
   has_many :systems, through: :services
   has_many :products, -> { distinct }, through: :services
 
-  scope :only_installer_updates, -> { unscope(where: :installer_updates).where(installer_updates: true) }
+  scope :only_installer_updates, -> { where(installer_updates: true) }
   scope :only_mirrored, -> { where(mirroring_enabled: true) }
   scope :only_enabled, -> { where(enabled: true) }
   scope :only_custom, -> { where(scc_id: nil) }

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -7,6 +7,7 @@ class Repository < ApplicationRecord
 
   scope :only_installer_updates, -> { unscope(where: :installer_updates).where(installer_updates: true) }
   scope :only_mirrored, -> { where(mirroring_enabled: true) }
+  scope :only_enabled, -> { where(enabled: true) }
   scope :only_custom, -> { where(scc_id: nil) }
   scope :only_scc, -> { where.not(scc_id: nil) }
 

--- a/package/rmt-server.changes
+++ b/package/rmt-server.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri May 11 15:54:46 UTC 2018 - hschmidt@suse.com
+
+- Don't check if a product has repos and that they are mirrored
+  when deactivating.
+  See: https://github.com/SUSE/rmt/pull/168
+
+-------------------------------------------------------------------
 Tue May  8 09:58:29 UTC 2018 - tmuntaner@suse.com
 
 - Rename of service files

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -16,6 +16,61 @@ RSpec.describe Repository, type: :model do
   it { is_expected.to have_db_column(:name).of_type(:string).with_options(null: false) }
   it { is_expected.to have_db_column(:external_url).of_type(:string).with_options(null: false) }
 
+  describe 'scopes' do
+    describe '.only_mirrored' do
+      it 'returns only mirrored repos' do
+        mirrored = create :repository, mirroring_enabled: true
+        create :repository, mirroring_enabled: false
+
+        expect(Repository.only_mirrored).to contain_exactly(mirrored)
+      end
+    end
+
+    describe '.only_enabled' do
+      it 'returns only enabled repos' do
+        enabled = create :repository, enabled: true
+        create :repository, enabled: false
+
+        expect(Repository.only_enabled).to contain_exactly(enabled)
+      end
+    end
+
+    describe '.only_installer_updates' do
+      it 'returns only repos that are installer updates' do
+        installer_updates = create :repository, installer_updates: true
+        create :repository, installer_updates: false
+
+        expect(Repository.only_installer_updates).to contain_exactly(installer_updates)
+      end
+
+      # NOTE: It's unknown to me (Hernan) why this scope does this.
+      it 'clears existing where-clauses' do
+        installer_updates = create :repository, installer_updates: true
+        create :repository, installer_updates: false
+
+        expect(Repository.where(installer_updates: false).only_installer_updates).to contain_exactly(installer_updates)
+      end
+    end
+
+    describe '.only_scc' do
+      it 'returns only official repositories' do
+        official = create :repository, scc_id: 1
+        create :repository, scc_id: nil
+
+        expect(Repository.only_scc).to contain_exactly(official)
+      end
+    end
+
+    describe '.only_custom' do
+      it 'returns only custom repositories' do
+        custom = create :repository, scc_id: nil
+        create :repository, scc_id: 1
+
+        expect(Repository.only_custom).to contain_exactly(custom)
+      end
+    end
+  end
+
   describe '.make_local_path' do
     subject { described_class.make_local_path(url) }
 

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Repository, type: :model do
 
   describe 'scopes' do
     describe '.only_mirrored' do
-      subject { Repository.only_mirrored }
+      subject { described_class.only_mirrored }
 
       let!(:mirrored) { create :repository, mirroring_enabled: true }
 
@@ -28,7 +28,7 @@ RSpec.describe Repository, type: :model do
     end
 
     describe '.only_enabled' do
-      subject { Repository.only_enabled }
+      subject { described_class.only_enabled }
 
       let!(:enabled) { create :repository, enabled: true }
 
@@ -38,7 +38,7 @@ RSpec.describe Repository, type: :model do
     end
 
     describe '.only_installer_updates' do
-      subject { Repository.only_installer_updates }
+      subject { described_class.only_installer_updates }
 
       let!(:installer_updates) { create :repository, installer_updates: true }
 
@@ -47,14 +47,14 @@ RSpec.describe Repository, type: :model do
       it { is_expected.to contain_exactly(installer_updates) }
 
       context 'with an existing where clause' do
-        subject { Repository.where(installer_updates: false).only_installer_updates }
+        subject { described_class.where(installer_updates: false).only_installer_updates }
 
         it { is_expected.to contain_exactly(installer_updates) }
       end
     end
 
     describe '.only_scc' do
-      subject { Repository.only_scc }
+      subject { described_class.only_scc }
 
       let!(:official) { create :repository, scc_id: 1 }
 
@@ -64,7 +64,7 @@ RSpec.describe Repository, type: :model do
     end
 
     describe '.only_custom' do
-      subject { Repository.only_custom }
+      subject { described_class.only_custom }
 
       let!(:custom) { create :repository, scc_id: nil }
 

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -36,23 +36,41 @@ RSpec.describe Repository, type: :model do
 
       it { is_expected.to eq('/repo/dummy_repo/') }
     end
+
+    context 'with no subpath and no trailing slash' do
+      let(:url) { 'http://localhost.com' }
+
+      it { is_expected.to eq '/' }
+    end
+
+    context 'with no subpath but with a trailing slash' do
+      let(:url) { 'http://localhost.com/' }
+
+      it { is_expected.to eq '/' }
+    end
+
+    context 'with a subpath and no trailing slash' do
+      let(:url) { 'http://localhost.com/foo/bar' }
+
+      it { is_expected.to eq '/foo/bar' }
+    end
   end
 
-  describe '#remove_repository' do
-    let(:custom_repository) { create :repository, :custom }
-    let(:suse_repository) { create :repository }
+  describe '#destroy' do
+    context 'when it is an official repository' do
+      subject { repository.destroy }
 
-    it('has custom repository') { expect(Repository.find_by(id: custom_repository.id)).not_to be_nil }
-    it('removes custom repositories') { expect(custom_repository.destroy).not_to be_falsey }
+      let!(:repository) { create :repository }
 
-    it('has non-custom repository') { expect(Repository.find_by(id: suse_repository.id)).not_to be_nil }
-    it('does not remove non-custom repositories') { expect(suse_repository.destroy).to be_falsey }
-  end
+      it { is_expected.to be_falsey }
+    end
 
-  describe 'local_path' do
-    it(:handles_empty_root) { expect(Repository.make_local_path('http://localhost.com')).to eq('/') }
-    it(:handles_empty_root_trailing_slash) { expect(Repository.make_local_path('http://localhost.com/')).to eq('/') }
-    it(:handles_subpath) { expect(Repository.make_local_path('http://localhost.com/foo/bar')).to eq('/foo/bar') }
-    it(:handles_subpath_trailing_slash) { expect(Repository.make_local_path('http://localhost.com/foo/bar/')).to eq('/foo/bar/') }
+    context 'when it is a custom repository' do
+      subject { repository.destroy }
+
+      let!(:repository) { create :repository, :custom }
+
+      it { is_expected.to be_truthy }
+    end
   end
 end

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -45,12 +45,6 @@ RSpec.describe Repository, type: :model do
       before { create :repository, installer_updates: false }
 
       it { is_expected.to contain_exactly(installer_updates) }
-
-      context 'with an existing where clause' do
-        subject { described_class.where(installer_updates: false).only_installer_updates }
-
-        it { is_expected.to contain_exactly(installer_updates) }
-      end
     end
 
     describe '.only_scc' do

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -18,56 +18,59 @@ RSpec.describe Repository, type: :model do
 
   describe 'scopes' do
     describe '.only_mirrored' do
-      it 'returns only mirrored repos' do
-        mirrored = create :repository, mirroring_enabled: true
-        create :repository, mirroring_enabled: false
+      subject { Repository.only_mirrored }
 
-        expect(Repository.only_mirrored).to contain_exactly(mirrored)
-      end
+      let!(:mirrored) { create :repository, mirroring_enabled: true }
+
+      before { create :repository, mirroring_enabled: false }
+
+      it { is_expected.to contain_exactly(mirrored) }
     end
 
     describe '.only_enabled' do
-      it 'returns only enabled repos' do
-        enabled = create :repository, enabled: true
-        create :repository, enabled: false
+      subject { Repository.only_enabled }
 
-        expect(Repository.only_enabled).to contain_exactly(enabled)
-      end
+      let!(:enabled) { create :repository, enabled: true }
+
+      before { create :repository, enabled: false }
+
+      it { is_expected.to contain_exactly(enabled) }
     end
 
     describe '.only_installer_updates' do
-      it 'returns only repos that are installer updates' do
-        installer_updates = create :repository, installer_updates: true
-        create :repository, installer_updates: false
+      subject { Repository.only_installer_updates }
 
-        expect(Repository.only_installer_updates).to contain_exactly(installer_updates)
-      end
+      let!(:installer_updates) { create :repository, installer_updates: true }
 
-      # NOTE: It's unknown to me (Hernan) why this scope does this.
-      it 'clears existing where-clauses' do
-        installer_updates = create :repository, installer_updates: true
-        create :repository, installer_updates: false
+      before { create :repository, installer_updates: false }
 
-        expect(Repository.where(installer_updates: false).only_installer_updates).to contain_exactly(installer_updates)
+      it { is_expected.to contain_exactly(installer_updates) }
+
+      context 'with an existing where clause' do
+        subject { Repository.where(installer_updates: false).only_installer_updates }
+
+        it { is_expected.to contain_exactly(installer_updates) }
       end
     end
 
     describe '.only_scc' do
-      it 'returns only official repositories' do
-        official = create :repository, scc_id: 1
-        create :repository, scc_id: nil
+      subject { Repository.only_scc }
 
-        expect(Repository.only_scc).to contain_exactly(official)
-      end
+      let!(:official) { create :repository, scc_id: 1 }
+
+      before { create :repository, scc_id: nil }
+
+      it { is_expected.to contain_exactly(official) }
     end
 
     describe '.only_custom' do
-      it 'returns only custom repositories' do
-        custom = create :repository, scc_id: nil
-        create :repository, scc_id: 1
+      subject { Repository.only_custom }
 
-        expect(Repository.only_custom).to contain_exactly(custom)
-      end
+      let!(:custom) { create :repository, scc_id: nil }
+
+      before { create :repository, scc_id: 1 }
+
+      it { is_expected.to contain_exactly(custom) }
     end
   end
 

--- a/spec/requests/api/connect/v3/systems/products_controller_spec.rb
+++ b/spec/requests/api/connect/v3/systems/products_controller_spec.rb
@@ -22,21 +22,8 @@ RSpec.describe Api::Connect::V3::Systems::ProductsController do
       let(:verb) { 'post' }
     end
 
-    context 'when product mandatory repos aren\'t mirrored' do
-      subject { response }
-
-      let(:product) { FactoryGirl.create(:product, :with_not_mirrored_repositories) }
-      let(:error_json) do
-        {
-          type: 'error',
-          error: "Not all mandatory repositories are mirrored for product #{product.friendly_name}",
-          localized_error: "Not all mandatory repositories are mirrored for product #{product.friendly_name}"
-        }.to_json
-      end
-
-      before { post url, headers: headers, params: payload }
-      its(:code) { is_expected.to eq('422') }
-      its(:body) { is_expected.to eq(error_json) }
+    it_behaves_like 'product must have mirrored repositories' do
+      let(:verb) { 'post' }
     end
 
     context 'when product has unmet dependencies' do
@@ -100,6 +87,10 @@ RSpec.describe Api::Connect::V3::Systems::ProductsController do
     let(:activation) { FactoryGirl.create(:activation, :with_mirrored_product) }
 
     it_behaves_like 'products controller action' do
+      let(:verb) { 'get' }
+    end
+
+    it_behaves_like 'product must have mirrored repositories' do
       let(:verb) { 'get' }
     end
 
@@ -182,6 +173,9 @@ RSpec.describe Api::Connect::V3::Systems::ProductsController do
       let(:verb) { 'put' }
     end
 
+    it_behaves_like 'product must have mirrored repositories' do
+      let(:verb) { 'put' }
+    end
 
     context 'with not activated product' do
       before { put url, headers: headers, params: payload }

--- a/spec/requests/api/connect/v3/systems/products_controller_spec.rb
+++ b/spec/requests/api/connect/v3/systems/products_controller_spec.rb
@@ -173,10 +173,6 @@ RSpec.describe Api::Connect::V3::Systems::ProductsController do
       let(:verb) { 'put' }
     end
 
-    it_behaves_like 'product must have mirrored repositories' do
-      let(:verb) { 'put' }
-    end
-
     context 'with not activated product' do
       before { put url, headers: headers, params: payload }
       subject { response }

--- a/spec/requests/api/connect/v4/systems/products_controller_spec.rb
+++ b/spec/requests/api/connect/v4/systems/products_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Api::Connect::V4::Systems::ProductsController, type: :request do
       let(:verb) { 'delete' }
     end
 
-    context 'when product is base product has repos' do
+    context 'when the product is a base product' do
       subject { response }
 
       let(:product) { FactoryGirl.create(:product, :with_mirrored_repositories) }
@@ -30,13 +30,14 @@ RSpec.describe Api::Connect::V4::Systems::ProductsController, type: :request do
       end
     end
 
-    context 'when product has repos, is an extension' do
+    context 'when the product is an extension' do
       subject { response }
 
       let(:payload) { { identifier: product.identifier, version: product.version, arch: product.arch } }
 
       before { delete url, headers: headers, params: payload }
-      context 'and is not activated' do
+
+      context 'and it is not activated' do
         let(:product) { FactoryGirl.create(:product, :extension, :with_mirrored_repositories) }
 
         its(:code) { is_expected.to eq('422') }
@@ -48,7 +49,7 @@ RSpec.describe Api::Connect::V4::Systems::ProductsController, type: :request do
         end
       end
 
-      context 'has products depending on it and is activated' do
+      context 'and the system has other extensions that depend on this one' do
         let(:product) do
           product = FactoryGirl.create(:product, :extension, :with_mirrored_repositories, :activated, system: system)
           FactoryGirl.create(:product, :extension, :with_mirrored_repositories, :activated, system: system, base_products: [product])
@@ -64,7 +65,7 @@ RSpec.describe Api::Connect::V4::Systems::ProductsController, type: :request do
         end
       end
 
-      context 'and is activated' do
+      context 'and it is activated' do
         let(:system) { FactoryGirl.create(:system) }
         let(:product) { FactoryGirl.create(:product, :extension, :with_mirrored_repositories, :activated, system: system) }
         let(:serialized_json) do


### PR DESCRIPTION
Needed for the use case described here https://github.com/SUSE/connect/pull/365#issuecomment-387789520

> 1. Register base product, basesystem module and server applications module on the client;
> 1. Disable server applications on RMT;
> 1. Try to de-register server applications -- I think it would also break.
> - @ikapelyukhin

Spoiler alert: It does break:

```
# bin/SUSEConnect -d -p sle-module-server-applications/15/x86_64
Error: Registration server returned 'Not all mandatory repositories are mirrored for product Server Applications Module 15 x86_64 (BETA)' (422)
```