### PR TITLE
Fix scope overriding private AR method warning

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -1,6 +1,7 @@
 class Subscription < ApplicationRecord
 
-  enum kind: { test: 'test', full: 'full', evaluation: 'evaluation', oem: 'oem', provisional: 'provisional', internal: 'internal' }
+  # we avoid to name enum key 'test' because it will override existing private method
+  enum kind: { is_test: 'test', full: 'full', evaluation: 'evaluation', oem: 'oem', provisional: 'provisional', internal: 'internal' }
   enum status: { expired: 'EXPIRED', active: 'ACTIVE', notactivated: 'NOTACTIVATED' }
 
   validates :regcode, presence: true


### PR DESCRIPTION
Fixes https://github.com/SUSE/rmt/issues/165

The scope seems not to be used anywhere in the code