### PR TITLE
Set the correct permissions for product.license directory

### DIFF
--- a/lib/rmt/mirror.rb
+++ b/lib/rmt/mirror.rb
@@ -147,6 +147,7 @@ class RMT::Mirror
     FileUtils.remove_entry(old_directory) if Dir.exist?(old_directory)
     FileUtils.mv(destination_dir, old_directory) if Dir.exist?(destination_dir)
     FileUtils.mv(source_dir, destination_dir)
+    FileUtils.chmod(0o755, destination_dir)
   rescue StandardError => e
     raise RMT::Mirror::Exception.new("Error while moving directory #{source_dir} to #{destination_dir}: #{e}")
   end

--- a/package/rmt-server.changes
+++ b/package/rmt-server.changes
@@ -3,6 +3,7 @@ Tue Jun 19 15:01:19 UTC 2018 - ikapelyukhin@suse.com
 
 - Version 1.0.2
 - Improved handling of errors during mirroring (bsc#1096967)
+- Set correct permissions for product.license directory (bsc#1097367)
 - Log version on service startup
 
 -------------------------------------------------------------------

--- a/spec/lib/rmt/mirror_spec.rb
+++ b/spec/lib/rmt/mirror_spec.rb
@@ -439,9 +439,10 @@ RSpec.describe RMT::Mirror do
         expect(Dir).to receive(:exist?).with(destination_dir).and_return(false)
       end
 
-      it 'removes it and moves src to dst' do
+      it 'removes it, moves src to dst and sets permissions' do
         expect(FileUtils).to receive(:remove_entry).with(old_dir)
         expect(FileUtils).to receive(:mv).with(source_dir, destination_dir)
+        expect(FileUtils).to receive(:chmod).with(0o755, destination_dir)
         replace_directory
       end
     end
@@ -452,9 +453,10 @@ RSpec.describe RMT::Mirror do
         expect(Dir).to receive(:exist?).with(destination_dir).and_return(true)
       end
 
-      it 'renames it as .old and moves src to dst' do
+      it 'renames it as .old, moves src to dst and sets permissions' do
         expect(FileUtils).to receive(:mv).with(destination_dir, old_dir)
         expect(FileUtils).to receive(:mv).with(source_dir, destination_dir)
+        expect(FileUtils).to receive(:chmod).with(0o755, destination_dir)
         replace_directory
       end
     end


### PR DESCRIPTION
From `Dir.mktmpdir` docu:

```
The directory is created with 0700 permission. Application should not change the permission to make the temporary directory accesible from other users.
```