### PR TITLE
Search original and chomped version

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -67,7 +67,7 @@ class Product < ApplicationRecord
 
   def self.clean_up_version(version)
     return unless version
-    version.tr('-', '.').chomp('.0')
+    [version, version.tr('-', '.').chomp('.0')].uniq
   end
 
   def product_string

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -50,19 +50,19 @@ RSpec.describe Product, type: :model do
     context 'without special symbols' do
       let(:version) { '42' }
 
-      it { is_expected.to eq('42') }
+      it { is_expected.to eq(['42']) }
     end
 
     context 'with a dot' do
       let(:version) { '42.0' }
 
-      it { is_expected.to eq('42') }
+      it { is_expected.to eq(%w[42.0 42]) }
     end
 
     context 'with dashes' do
       let(:version) { '42-0' }
 
-      it { is_expected.to eq('42') }
+      it { is_expected.to eq(%w[42-0 42]) }
     end
   end
 


### PR DESCRIPTION
The previous way worked well for versions like (12, 12.1, ...), but not like (1.0, 2.0, ...). This should fix that.