### PR TITLE
Fix directory usage

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -125,15 +125,15 @@ As described in the [PREREQUISITE][] section, the recommended way to perform ini
 The YaST RMT module will take care of configuring SCC credentials, setting up the database and creating SSL certificates.
 However, if you want to reconfigure specific settings manually, this section tells you how.
 
-All available configuration options can be found in the `/etc/rmt.conf` file.
+All available configuration options can be found in the `/etc/rmt/rmt.conf` file.
 
 **SSL certificates & HTTPS**
 
 By default access to API endpoints consumed by `SUSEConnect` is limited to HTTPS only.
 nginx is configured to use SSL certificate and private key from the following locations:
 
-- Certificate: `/usr/share/rmt/ssl/rmt-server.crt`
-- Private key: `/usr/share/rmt/ssl/rmt-server.key`
+- Certificate: `/etc/rmt/ssl/rmt-server.crt`
+- Private key: `/etc/rmt/ssl/rmt-server.key`
 
 
 YaST RMT module generates a custom certificate authority which is used to sign HTTPS certificates, which means that in order to register, this certificate authority must be trusted by the client machines:

--- a/MIGRATE.md
+++ b/MIGRATE.md
@@ -52,10 +52,10 @@ server or note its path if the same server will be used.
 
 1. Make sure your rmt installation is up-to-date. `rmt-data-import` is available in RMT versions >= 1.0.0.
 2. Unpack the tarball containing SMT data to some directory, e.g. `/root/smt-data`.
-3. If you chose to export SMT's SSL certificates, copy the SMT CA private key and certificate to `/usr/share/rmt/ssl/`:
+3. If you chose to export SMT's SSL certificates, copy the SMT CA private key and certificate to `/etc/rmt/ssl/`:
     ```
-    cp /root/smt-data/ssl/cacert.key /usr/share/rmt/ssl/rmt-ca.key
-    cp /root/smt-data/ssl/cacert.pem /usr/share/rmt/ssl/rmt-ca.crt
+    cp /root/smt-data/ssl/cacert.key /etc/rmt/ssl/rmt-ca.key
+    cp /root/smt-data/ssl/cacert.pem /etc/rmt/ssl/rmt-ca.crt
     ```
 4. Run YaST RMT configuration module from YaST command center or by running `yast2 rmt` on the command line.
 5. Proceed through the YaST module. If you want to support your old SMT hostname in your new SSL certificate, you can add it as an alternative common name on the SSL setup page.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ After installation configure your RMT instance:
     FLUSH PRIVILEGES;
     EOFF
     ```
-* See the "Configuration" section for how to configure the options in `/etc/rmt.conf`.
+* See the "Configuration" section for how to configure the options in `/etc/rmt/rmt.conf`.
 * Start RMT by running `systemctl start rmt-server`. This will start the RMT server at http://localhost:4224.
 * By default, mirrored repositories are saved under `/usr/share/rmt/public`, which is a symlink that points to
 `/var/lib/rmt/public`. In order to change destination directory, recreate `/usr/share/rmt/public` symlink to point to the

--- a/lib/rmt.rb
+++ b/lib/rmt.rb
@@ -1,5 +1,5 @@
 module RMT
-  VERSION ||= '1.0.5'.freeze
+  VERSION ||= '1.0.6'.freeze
 
   DEFAULT_USER = '_rmt'.freeze
   DEFAULT_GROUP = 'nginx'.freeze

--- a/lib/rmt/cli/base.rb
+++ b/lib/rmt/cli/base.rb
@@ -45,12 +45,12 @@ class RMT::CLI::Base < Thor
     rescue Mysql2::Error => e
       if e.message =~ /^Access denied/
         raise RMT::CLI::Error.new(
-          "Cannot connect to database server. Make sure its credentials are configured in '/etc/rmt.conf'.",
+          "Cannot connect to database server. Make sure its credentials are configured in '/etc/rmt/rmt.conf'.",
           RMT::CLI::Error::ERROR_DB
         )
       elsif e.message =~ /^Can't connect/
         raise RMT::CLI::Error.new(
-          "Cannot connect to database server. Make sure it is running and its credentials are configured in '/etc/rmt.conf'.",
+          "Cannot connect to database server. Make sure it is running and its credentials are configured in '/etc/rmt/rmt.conf'.",
           RMT::CLI::Error::ERROR_DB
         )
       else
@@ -64,7 +64,7 @@ class RMT::CLI::Base < Thor
       )
     rescue RMT::SCC::CredentialsError, ::SUSE::Connect::Api::InvalidCredentialsError
       raise RMT::CLI::Error.new(
-        "The SCC credentials are not configured correctly in '/etc/rmt.conf'. You can obtain them from https://scc.suse.com/organization",
+        "The SCC credentials are not configured correctly in '/etc/rmt/rmt.conf'. You can obtain them from https://scc.suse.com/organization",
         RMT::CLI::Error::ERROR_SCC
       )
     rescue RMT::Lockfile::ExecutionLockedError => e

--- a/lib/rmt/config.rb
+++ b/lib/rmt/config.rb
@@ -6,7 +6,7 @@ Config.setup do |config|
 end
 
 Config.load_and_set_settings(
-  '/etc/rmt.conf',
+  '/etc/rmt/rmt.conf',
   File.join(__dir__, '../../config/rmt.yml'),
   File.join(__dir__, '../../config/rmt.local.yml')
 )

--- a/lib/suse/connect/api.rb
+++ b/lib/suse/connect/api.rb
@@ -8,7 +8,7 @@ module SUSE
 
       class InvalidCredentialsError < StandardError; end
       CONNECT_API_URL = 'https://scc.suse.com/connect'.freeze
-      UUID_FILE_LOCATION = File.expand_path('../../../config/system_uuid', __dir__).freeze
+      UUID_FILE_LOCATION = "/var/lib/rmt/system_uuid".freeze
 
       def initialize(username, password)
         @username = username

--- a/package/nginx-https.conf
+++ b/package/nginx-https.conf
@@ -10,8 +10,8 @@ server {
     error_log   /var/log/nginx/rmt_https_error.log;
     root        /usr/share/rmt/public;
 
-    ssl_certificate     /usr/share/rmt/ssl/rmt-server.crt;
-    ssl_certificate_key /usr/share/rmt/ssl/rmt-server.key;
+    ssl_certificate     /etc/rmt/ssl/rmt-server.crt;
+    ssl_certificate_key /etc/rmt/ssl/rmt-server.key;
     ssl_protocols       TLSv1.2 TLSv1.3;
 
     location / {
@@ -37,6 +37,6 @@ server {
 
     # An alias to RMT CA certificate, so that it can be downloaded to client machines.
     location /rmt.crt {
-        alias /usr/share/rmt/ssl/rmt-ca.crt;
+        alias /etc/rmt/ssl/rmt-ca.crt;
     }
 }

--- a/package/rmt-server.changes
+++ b/package/rmt-server.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Aug  2 16:19:35 UTC 2018 - fschnizlein@suse.com
+
+- Version 1.0.6
+- Change file paths to new locations to make RMT work with
+  read-only rootfs (bsc#1102198)
+
+-------------------------------------------------------------------
 Thu Jul 19 12:27:23 UTC 2018 - wstephenson@suse.com
 
 - Version 1.0.5

--- a/package/rmt-server.spec
+++ b/package/rmt-server.spec
@@ -26,7 +26,7 @@
 %define is_sle_12_family 1
 %endif
 Name:           rmt-server
-Version:        1.0.5
+Version:        1.0.6
 Release:        0
 Summary:        Repository mirroring tool and registration proxy for SCC
 License:        GPL-2.0-or-later

--- a/spec/lib/rmt/cli/main_spec.rb
+++ b/spec/lib/rmt/cli/main_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe RMT::CLI::Main, :with_fakefs do
 
           it 'outputs custom error message' do
             expect { command }.to output(
-              "Cannot connect to database server. Make sure its credentials are configured in '/etc/rmt.conf'.\n"
+              "Cannot connect to database server. Make sure its credentials are configured in '/etc/rmt/rmt.conf'.\n"
             ).to_stderr
           end
         end
@@ -127,7 +127,7 @@ RSpec.describe RMT::CLI::Main, :with_fakefs do
 
           it 'outputs custom error message' do
             expect { command }.to output(
-              "Cannot connect to database server. Make sure it is running and its credentials are configured in '/etc/rmt.conf'.\n"
+              "Cannot connect to database server. Make sure it is running and its credentials are configured in '/etc/rmt/rmt.conf'.\n"
             ).to_stderr
           end
         end
@@ -147,7 +147,7 @@ RSpec.describe RMT::CLI::Main, :with_fakefs do
 
           it 'outputs custom error message' do
             expect { command }.to output(
-              "The SCC credentials are not configured correctly in '/etc/rmt.conf'. You can obtain them from https://scc.suse.com/organization\n"
+              "The SCC credentials are not configured correctly in '/etc/rmt/rmt.conf'. You can obtain them from https://scc.suse.com/organization\n"
             ).to_stderr
           end
         end
@@ -157,7 +157,7 @@ RSpec.describe RMT::CLI::Main, :with_fakefs do
 
           it 'outputs custom error message' do
             expect { command }.to output(
-              "The SCC credentials are not configured correctly in '/etc/rmt.conf'. You can obtain them from https://scc.suse.com/organization\n"
+              "The SCC credentials are not configured correctly in '/etc/rmt/rmt.conf'. You can obtain them from https://scc.suse.com/organization\n"
             ).to_stderr
           end
         end


### PR DESCRIPTION
Change configuration, ssl and uuid path to make sure rmt also works on a read-only installation
https://github.com/SUSE/yast2-rmt/pull/26

Path changes:
`/usr/share/rmt/ssl` -> `/etc/rmt/ssl`
`/usr/share/rmt/config/system_uuid` -> `/var/lib/rmt/system_uuid`
`/etc/rmt.conf` -> `/etc/rmt/rmt.conf`