### PR TITLE
Fix link to configuration section

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ After installation configure your RMT instance:
     FLUSH PRIVILEGES;
     EOFF
     ```
-* See the "Configuration" section for how to configure the options in `/etc/rmt.conf`.
+* See [RMT Configuration Files](https://www.suse.com/documentation/sles-15/book_rmt/data/sec_rmt_config.html)
+  in the official RMT documentation for information about `/etc/rmt.conf`.
 * Start RMT by running `systemctl start rmt-server`. This will start the RMT server at http://localhost:4224.
 * By default, mirrored repositories are saved under `/usr/share/rmt/public`, which is a symlink that points to
 `/var/lib/rmt/public`. In order to change destination directory, recreate `/usr/share/rmt/public` symlink to point to the


### PR DESCRIPTION
We should still document the config better, but this fixes the broken reference.