### PR TITLE
Add: Writable option to `need_path`

### DIFF
--- a/bin/rmt-cli
+++ b/bin/rmt-cli
@@ -1,29 +1,27 @@
 #!/usr/bin/env ruby
 
-require 'etc'
-
 rmt_path = File.expand_path('..', __dir__)
 require_relative '../config/boot'
 $LOAD_PATH.unshift File.join(rmt_path, 'lib')
 
+require 'etc'
 require 'active_support'
 require 'active_record'
 require 'erb'
 require 'yaml'
 require 'rmt/config'
 
-# don't run as root
-if Process.euid == 0
+relative_load_paths = %w[lib lib/rmt app/models app/services].map { |dir| File.join(rmt_path, dir) }
+ActiveSupport::Dependencies.autoload_paths += relative_load_paths
+
+if RMT::CLI::Base.process_user_name == 'root'
   # set group and then user, otherwise user cannot change group
   Process::Sys.setegid(Etc.getgrnam(RMT::DEFAULT_GROUP).gid)
   Process::Sys.seteuid(Etc.getpwnam(RMT::DEFAULT_USER).uid)
 end
 
-relative_load_paths = %w[lib lib/rmt app/models app/services].map { |dir| File.join(rmt_path, dir) }
-ActiveSupport::Dependencies.autoload_paths += relative_load_paths
-
 if File.exist?(RMT::DEFAULT_MIRROR_DIR) && !File.writable?(RMT::DEFAULT_MIRROR_DIR)
-  warn "Mirroring base directory (#{RMT::DEFAULT_MIRROR_DIR}) is not writable by user '#{Etc.getpwuid(Process.euid).name}'"
+  warn "Mirroring base directory (#{RMT::DEFAULT_MIRROR_DIR}) is not writable by user '#{RMT::CLI::Base.process_user_name}'"
   warn 'Run as root or adjust the permissions.'
   exit RMT::CLI::Error::ERROR_OTHER
 end

--- a/lib/rmt/cli/base.rb
+++ b/lib/rmt/cli/base.rb
@@ -1,4 +1,5 @@
 require 'rmt/lockfile'
+require 'etc'
 
 class RMT::CLI::Base < Thor
 
@@ -86,12 +87,19 @@ class RMT::CLI::Base < Thor
       name.gsub(/.*::/, '').gsub(/^[A-Z]/) { |match| match[0].downcase }.gsub(/[A-Z]/) { |match| " #{match[0].downcase}" }
     end
 
+    def process_user_name
+      Etc.getpwuid(Process.euid).name
+    end
+
   end
 
   private
 
-  def needs_path(path)
+  def needs_path(path, writable: false)
     raise RMT::CLI::Error.new("#{path} is not a directory.") unless File.directory?(path)
+    if writable
+      raise RMT::CLI::Error.new("#{path} is not writable by user #{RMT::CLI::Base.process_user_name}.") unless File.writable?(path)
+    end
   end
 
 end

--- a/lib/rmt/cli/export.rb
+++ b/lib/rmt/cli/export.rb
@@ -2,13 +2,13 @@ class RMT::CLI::Export < RMT::CLI::Base
 
   desc 'data PATH', 'Store SCC data in files at given path'
   def data(path)
-    needs_path(path)
+    needs_path(path, writable: true)
     RMT::SCC.new(options).export(path)
   end
 
   desc 'settings PATH', 'Store repository settings at given path'
   def settings(path)
-    needs_path(path)
+    needs_path(path, writable: true)
     filename = File.join(path, 'repos.json')
 
     data = Repository.only_mirrored.inject([]) { |data, repo| data << { url: repo.external_url, auth_token: repo.auth_token.to_s } }
@@ -25,7 +25,7 @@ class RMT::CLI::Export < RMT::CLI::Base
   `export repos` will mirror these repositories to this PATH, usually a portable storage device.
   REPOS
   def repos(path)
-    needs_path(path)
+    needs_path(path, writable: true)
 
     logger = RMT::Logger.new(STDOUT)
     mirror = RMT::Mirror.new(mirroring_base_dir: path, logger: logger, airgap_mode: true)

--- a/spec/lib/rmt/cli/export_spec.rb
+++ b/spec/lib/rmt/cli/export_spec.rb
@@ -5,6 +5,7 @@ describe RMT::CLI::Export, :with_fakefs do
 
   describe 'settings' do
     include_examples 'handles non-existing path'
+    include_examples 'handles non-writable path'
     let(:repository) { create :repository, mirroring_enabled: true, id: 123 }
     let(:command) { described_class.start(['settings', path]) }
 
@@ -25,6 +26,7 @@ describe RMT::CLI::Export, :with_fakefs do
 
   describe 'data' do
     include_examples 'handles non-existing path'
+    include_examples 'handles non-writable path'
 
     let(:command) { described_class.start(['data', path]) }
 
@@ -38,6 +40,7 @@ describe RMT::CLI::Export, :with_fakefs do
 
   describe 'repos' do
     include_examples 'handles non-existing path'
+    include_examples 'handles non-writable path'
 
     let(:command) { described_class.start(['repos', path]) }
     let(:mirror_double) { instance_double('RMT::Mirror') }

--- a/spec/support/shared_examples/cli.rb
+++ b/spec/support/shared_examples/cli.rb
@@ -6,6 +6,16 @@ shared_examples 'handles non-existing path' do
   end
 end
 
+shared_examples 'handles non-writable path' do
+  context 'with path without write permissions for user' do
+    it 'complains and exits' do
+      expect(File).to receive(:directory?).and_return(true)
+      expect(File).to receive(:writable?).and_return(false)
+      expect { command }.to raise_error(SystemExit).and(output("#{path} is not writable by user #{RMT::CLI::Base.process_user_name}.\n").to_stderr)
+    end
+  end
+end
+
 shared_examples 'handles lockfile exception' do
   context 'with existing lockfile' do
     let(:pid) { 42 }


### PR DESCRIPTION
* add writable option to `need_path` to catch permission errors,
  which are handled more gracefully
  This fixes https://github.com/SUSE/rmt/issues/112

* for this, add function `process_user_name` to `RMT::CLI::Base` as a
  more descriptive wrapper of the actual call

* refactor `require` statements in `bin/rmt_cli` so they are all in the
  beginning and use new `process_user_name` function