### PR TITLE
Emulate on_headers callback when the request failed

### DIFF
--- a/lib/rmt/fiber_request.rb
+++ b/lib/rmt/fiber_request.rb
@@ -17,6 +17,7 @@ class RMT::FiberRequest < RMT::HttpRequest
       @download_path.write(chunk)
     end
     on_complete do |response|
+      @request_fiber.resume(response) unless (response.return_code == :ok)
       @request_fiber.resume(response) if @request_fiber.alive?
     end
   end

--- a/lib/rmt/fiber_request.rb
+++ b/lib/rmt/fiber_request.rb
@@ -17,7 +17,7 @@ class RMT::FiberRequest < RMT::HttpRequest
       @download_path.write(chunk)
     end
     on_complete do |response|
-      @request_fiber.resume(response) unless (response.return_code == :ok)
+      @request_fiber.resume(response) unless response.return_code == :ok # otherwise skips on_headers resume when the request has failed
       @request_fiber.resume(response) if @request_fiber.alive?
     end
   end

--- a/package/rmt-server.changes
+++ b/package/rmt-server.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Sep 27 15:35:29 UTC 2018 - ikapelyukhin@suse.com
+
+- Improved exception handling when HTTP request fails due to
+  a network or SSL validity issue
+
+-------------------------------------------------------------------
 Thu Aug  2 16:19:35 UTC 2018 - fschnizlein@suse.com
 
 - Version 1.0.6


### PR DESCRIPTION
If the HTTP client fails to connect or there's an SSL issue, `on_headers` callback isn't invoked, but `on_complete` is called instead -- which never fires the error handling on the response.

This should fix the flow of things and produce meaningful error messages, e.g.:

```
WARN -- : Error while mirroring metadata: repodata/repomd.xml - return code couldnt_connect
WARN -- : Error while mirroring metadata: repodata/repomd.xml - return code ssl_cacert
```