### PR TITLE
Fix rmt-server.spec to own bash-completion directories

### DIFF
--- a/package/rmt-server.spec
+++ b/package/rmt-server.spec
@@ -227,6 +227,8 @@ find %{buildroot}%{lib_dir}/vendor/bundle/ruby/*/gems/yard*/ -type f -exec chmod
 %{_unitdir}/rmt-server-mirror.timer
 %{_unitdir}/rmt-server-sync.service
 %{_unitdir}/rmt-server-sync.timer
+%dir %{_datadir}/bash-completion/
+%dir %{_datadir}/bash-completion/completions/
 %{_datadir}/bash-completion/completions/rmt-cli
 
 %{_libdir}/rmt


### PR DESCRIPTION
The builds flickered on certain older dists, because the bash-completion
directories were not yet owned by any package. Now, if they weren't
owned before, the are owned by the rmt-server package.

See similiar approach here: [IBS](https://build.suse.de/package/view_file/SUSE:SLE-15:GA/btrfsprogs/btrfsprogs.spec?expand=1)