### PR TITLE
Remove the "No product license found" log message

### DIFF
--- a/lib/rmt/mirror.rb
+++ b/lib/rmt/mirror.rb
@@ -100,7 +100,6 @@ class RMT::Mirror
       directory_yast = @downloader.download('directory.yast')
     rescue RMT::Downloader::Exception
       FileUtils.remove_entry(@temp_licenses_dir) # the repository would have an empty licenses directory unless removed
-      @logger.info(_('No product license found'))
       return
     end
 

--- a/package/rmt-server.changes
+++ b/package/rmt-server.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Nov 22 15:31:29 UTC 2018 - hschmidt@suse.com
+
+- Remmove the "No product license found" message when mirroring.
+  It's not useful for users, and it was just causing confusion,
+  as many people mistook it for an error.
+
+-------------------------------------------------------------------
 Wed Nov 21 10:30:44 UTC 2018 - skotov@suse.com
 
 - Modules for migration are being sorted in the correct order

--- a/spec/lib/rmt/mirror_spec.rb
+++ b/spec/lib/rmt/mirror_spec.rb
@@ -60,7 +60,6 @@ RSpec.describe RMT::Mirror do
 
       before do
         expect(logger).to receive(:info).with(/Mirroring repository/).once
-        expect(logger).to receive(:info).with('No product license found').once
         expect(logger).to receive(:info).with('Repository metadata signatures are missing').once
         expect(logger).to receive(:info).with(/↓/).at_least(1).times
         rmt_mirror.mirror(mirror_params)


### PR DESCRIPTION
Knowing whether the repository has a license file is not really
important to customers.
On the other hand, we received emails from multiple people who thought
that the message was an error (it's not).