### PR TITLE
Fix products wrongly showing as enabled for mirroring

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -66,16 +66,14 @@ class Product < ApplicationRecord
   end
 
   def mirror?
+    enabled = repositories.select(&:enabled).to_a
+    disabled = repositories.reject(&:enabled).to_a
 
-    enabled_repositories = repositories.where(enabled: true)
-    unless enabled_repositories.empty?
-      return enabled_repositories.where(mirroring_enabled: false).empty?
-    end
+    # If we have enabled repositories, return true if any are enabled to be mirrored.
+    return enabled.reject(&:mirroring_enabled).empty? unless enabled.empty?
 
-    disabled_repositories = repositories.where(enabled: false)
-    unless disabled_repositories.empty?
-      disabled_repositories.where(mirroring_enabled: false).empty?
-    end
+    # If we only have disabled repositories, return true if any are enabled to be mirrored.
+    return disabled.reject(&:mirroring_enabled).empty? unless disabled.empty?
 
     false
   end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -66,7 +66,18 @@ class Product < ApplicationRecord
   end
 
   def mirror?
-    repositories.where(enabled: true, mirroring_enabled: false).empty?
+
+    enabled_repositories = repositories.where(enabled: true)
+    unless enabled_repositories.empty?
+      return enabled_repositories.where(mirroring_enabled: false).empty?
+    end
+
+    disabled_repositories = repositories.where(enabled: false)
+    unless disabled_repositories.empty?
+      disabled_repositories.where(mirroring_enabled: false).empty?
+    end
+
+    false
   end
 
   def last_mirrored_at

--- a/package/rmt-server.changes
+++ b/package/rmt-server.changes
@@ -1,12 +1,17 @@
 -------------------------------------------------------------------
+Tue Dec 11 17:04:00 UTC 2018 - tmuntaner@suse.com
+
+- Fix listing of enabled for mirroring for non-mirrored products. (bsc#1102193)
+
+-------------------------------------------------------------------
 Tue Dec 11 14:48:27 UTC 2018 - skotov@suse.com
 
- Include online migration paths into offline migration (bsc#1117106)
+- Include online migration paths into offline migration (bsc#1117106)
 
 -------------------------------------------------------------------
 Tue Dec 11 10:42:33 UTC 2018 - skotov@suse.com
 
-- Sync products that do not have base product (bsc#1109307) 
+- Sync products that do not have base product (bsc#1109307)
 
 -------------------------------------------------------------------
 Fri Dec 7 15:39:00 UTC 2018 - tmuntaner@suse.com

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -94,6 +94,22 @@ FactoryGirl.define do
       end
     end
 
+    trait :with_disabled_mirrored_repositories do
+      after :create do |product, _evaluator|
+        unless Service.find_by(product_id: product.id)
+          FactoryGirl.create(:service, :with_disabled_repositories, product: product, mirroring_enabled: true)
+        end
+      end
+    end
+
+    trait :with_disabled_not_mirrored_repositories do
+      after :create do |product, _evaluator|
+        unless Service.find_by(product_id: product.id)
+          FactoryGirl.create(:service, :with_disabled_repositories, product: product, mirroring_enabled: false)
+        end
+      end
+    end
+
     trait :with_not_mirrored_repositories do
       after :create do |product, _evaluator|
         unless Service.find_by(product_id: product.id)

--- a/spec/factories/services.rb
+++ b/spec/factories/services.rb
@@ -30,5 +30,32 @@ FactoryGirl.define do
         ]
       end
     end
+
+    trait :with_disabled_repositories do
+      transient do
+        mirroring_enabled false
+      end
+
+      after :create do |service, evaluator|
+        name_prefix = service.product.name
+
+        service.repositories << [
+          FactoryGirl.create(
+            :repository,
+            name: "#{name_prefix}-Installer-Updates",
+            mirroring_enabled: evaluator.mirroring_enabled,
+            installer_updates: true,
+            enabled: false
+          ),
+          FactoryGirl.create(
+            :repository,
+            name: "#{name_prefix}-Debuginfo-Updates",
+            mirroring_enabled: evaluator.mirroring_enabled,
+            installer_updates: false,
+            enabled: false
+          )
+        ]
+      end
+    end
   end
 end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -31,6 +31,18 @@ RSpec.describe Product, type: :model do
       it { is_expected.to be false }
     end
 
+    context 'with disabled mirrored repositories' do
+      let(:product) { create :product, :with_disabled_mirrored_repositories }
+
+      it { is_expected.to be true }
+    end
+
+    context 'with disabled not mirrored repositories' do
+      let(:product) { create :product, :with_disabled_not_mirrored_repositories }
+
+      it { is_expected.to be false }
+    end
+
     context 'with_not_mirrored_repositories' do
       let(:product) { create :product, :with_not_mirrored_repositories }
 

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Product, type: :model do
     context 'without any repositories' do
       let(:product) { create :product }
 
-      it { is_expected.to be true }
+      it { is_expected.to be false }
     end
 
     context 'with_not_mirrored_repositories' do


### PR DESCRIPTION
See Bugzilla bug #1102193 for reference.

To avoid confusion: When a repository is enabled or not, we talk about
zypper (RPM) repositories, which ship with a default, either `enabled`
or `disabled`. As an example, typically "debug symbols" are `disabled`
by default.

Before, if there were no `enabled` repositories for a product (which
happens for very old products), `mirror?` would return true even though
there was nothing mirrored. This kinda made sense since we accept a
__product__ as `enabled` when all the __repos__ that are `enabled` by
default are "enabled for mirroring", because that's usually everything
one needs (by definition, since they other repos on the clients are
`disabled` by default anyway).

Now it will first check if there are repositories that are `enabled` by
default. And if that is true, it then checks if these are all "enabled
for mirroring". If there are no repositories that are `enabled` by
default, it will check if there are repositories that are `disabled` by
default, and consider the product `enabled` if all those repositories
are "enabled for mirroring". If there are no repositories at all, it
will just return `false`, since a product without repositories is not
understood by RMT anyway.