### PR TITLE
Sync products without base product

### DIFF
--- a/package/rmt-server.changes
+++ b/package/rmt-server.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Dec 11 10:42:33 UTC 2018 - skotov@suse.com
+
+- Sync products that do not have base product (bsc#1109307) 
+
+-------------------------------------------------------------------
 Fri Dec 7 15:39:00 UTC 2018 - tmuntaner@suse.com
 
 - Repository table using context relevant values instead of true and

--- a/spec/lib/rmt/scc_spec.rb
+++ b/spec/lib/rmt/scc_spec.rb
@@ -166,7 +166,10 @@ describe RMT::SCC do
           arch: 'x86_64',
           name: 'Extension without base',
           friendly_name: 'Extension without base',
-          repositories: [ extra_repo ]
+          repositories: [ extra_repo ],
+          extensions: [],
+          online_predecessor_ids: [],
+          offline_predecessor_ids: []
         }
       end
       let(:repositories_with_extra_repos) { all_repositories + [extra_repo] }
@@ -179,8 +182,8 @@ describe RMT::SCC do
         described_class.new.sync
       end
 
-      it "doesn't save extensions without base products" do
-        expect { Product.find(extra_product[:id]) }.to raise_error(ActiveRecord::RecordNotFound)
+      it 'saves extensions without base products' do
+        expect(Product.find(extra_product[:id]).identifier).to eq(extra_product[:identifier])
       end
 
       it "doesn't save repos of extensions without base products" do


### PR DESCRIPTION
Some of the products do not have base one (for example SUMA). However, it should be possible to mirror some of them.

Right now products like that are filtered out by RMT during `sync` (SMT does not).

I suggest that we remove the check which syncs products only when they are base products so that it would be possible to mirror them.