### PR TITLE
Fix Alias Short Commands

### DIFF
--- a/lib/rmt/cli/products.rb
+++ b/lib/rmt/cli/products.rb
@@ -63,7 +63,7 @@ class RMT::CLI::Products < RMT::CLI::Base
       }
     end
   end
-  map ls: :list
+  map 'ls' => :list
 
   desc 'enable TARGETS', _('Enable mirroring of product repositories by a list of product IDs or product strings.')
   option :all_modules, type: :boolean, desc: _('Enables all free modules for a product')

--- a/lib/rmt/cli/repos.rb
+++ b/lib/rmt/cli/repos.rb
@@ -16,7 +16,7 @@ class RMT::CLI::Repos < RMT::CLI::Base
     scope = options[:all] ? :all : :enabled
     list_repositories(scope: scope)
   end
-  map ls: :list
+  map 'ls' => :list
 
   desc 'enable IDS', _('Enable mirroring of repositories by a list of repository IDs')
   long_desc _(<<-REPOS

--- a/lib/rmt/cli/repos_custom.rb
+++ b/lib/rmt/cli/repos_custom.rb
@@ -53,7 +53,7 @@ class RMT::CLI::ReposCustom < RMT::CLI::Base
       ])
     end
   end
-  map ls: :list
+  map 'ls' => :list
 
   desc 'enable ID', _('Enable mirroring of custom repository by ID')
   def enable(id)
@@ -72,7 +72,7 @@ class RMT::CLI::ReposCustom < RMT::CLI::Base
 
     puts _('Removed custom repository by id "%{id}".') % { id: id }
   end
-  map rm: :remove
+  map 'rm' => :remove
 
   desc 'products ID', _('Shows products attached to a custom repository')
   option :csv, type: :boolean, desc: _('Output data in CSV format')

--- a/package/rmt-server.changes
+++ b/package/rmt-server.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Dec 5 14:30:00 UTC 2018 - tmuntaner@suse.com
+
+- Bugfix: Alias commands in short form no longer raise an exception
+  * remove -> rm -> r
+  * list -> ls -> l
+
+-------------------------------------------------------------------
 Mon Dec 3 17:00:00 UTC 2018 - tmuntaner@suse.com
 
 - Added ability to enable/disable multiple repositories at the


### PR DESCRIPTION
`rmt-cli p e` => `rmt-cli products enable` works
`rmt-cli p l` => `rmt-cli products list` does not

This is because thor doesn't handle the symbol well for the shortcuts.