### PR TITLE
Include online migration paths into offline migration

### DIFF
--- a/package/rmt-server.changes
+++ b/package/rmt-server.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Dec 11 14:48:27 UTC 2018 - skotov@suse.com
+
+ Include online migration paths into offline migration (bsc#1117106)
+
+-------------------------------------------------------------------
 Tue Dec 11 10:42:33 UTC 2018 - skotov@suse.com
 
 - Sync products that do not have base product (bsc#1109307) 


### PR DESCRIPTION
Sample `curl` request for verifying
```
curl -u '<SYSTEM_LOGIN>:<SYSTEM_PASSWORD>' -H "Content-type: application/json" -d '{ "installed_products": [ { "identifier": "SLES", "version": "15", "arch": "x86_64" } ], "target_base_product": { "identifier": "SLES", "version": "15.1", "arch": "x86_64" }}' -X POST http://rmt.or.scc.host:4224/connect/systems/products/offline_migrations | jq '.[] | map(.friendly_name)'
```