### PR TITLE
Truncate PID in lockfile

### DIFF
--- a/features/lockfile_spec.rb
+++ b/features/lockfile_spec.rb
@@ -1,15 +1,18 @@
 require File.expand_path('../support/command_rspec_helper', __FILE__)
 
 describe 'rmt-cli' do
-  before { `/usr/bin/rmt-cli sync > /dev/null &` }
+  before do
+    `echo long_text_but_not_the_process_id > /tmp/rmt.lock`
+    `chown _rmt /tmp/rmt.lock`
+    `/usr/bin/rmt-cli sync > /dev/null &`
+  end
   # kill running process to let further specs pass
   after { `kill -9 $(cat /tmp/rmt.lock)` }
 
   describe 'lockfile' do
     command '/usr/bin/rmt-cli sync', allow_error: true
-
     its(:stderr) { is_expected.to eq("Process is locked by the application with \
-pid #{File.read('/tmp/rmt.lock')}. Close this application or wait for it \
+pid #{`pgrep rmt-cli`.strip}. Close this application or wait for it \
 to finish before trying again\n") }
 
     its(:exitstatus) { is_expected.to eq 1 }

--- a/lib/rmt/lockfile.rb
+++ b/lib/rmt/lockfile.rb
@@ -8,7 +8,8 @@ class RMT::Lockfile
       File.open(RMT::Lockfile::LOCKFILE_LOCATION, File::RDWR | File::CREAT) do |f|
         if f.flock(File::LOCK_EX | File::LOCK_NB)
           f.write(Process.pid.to_s)
-          f.fsync
+          f.flush
+          f.truncate(f.pos)
         else
           pid = File.read(RMT::Lockfile::LOCKFILE_LOCATION)
           raise ExecutionLockedError.new(

--- a/package/rmt-server.changes
+++ b/package/rmt-server.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon Feb 11 12:00:06 UTC 2019 - skotov@suse.com
+
+- Truncate the RMT lockfile when writing a new PID
+
+-------------------------------------------------------------------
 Wed Jan 30 10:40:38 UTC 2019 - ikapelyukhin@suse.com
 
 - Version 1.2.0


### PR DESCRIPTION
If the old PID has more digits than the current one user would see the wrong PID because the file is not truncated but only first digits are rewritten. This PR fixes that.

See also https://apidock.com/ruby/File/flock for an example.

The fix can be verified by writing some content into `/tmp/rmt.lock` which should be longer that the PID and then running 2 RMT CLI processes in 2 console tabs. You should see correct PID in the error message.