### PR TITLE
Improve handling of Settings

### DIFF
--- a/config/default_rmt.yml
+++ b/config/default_rmt.yml
@@ -1,0 +1,25 @@
+database:
+  host: localhost
+  database: rmt
+  username: rmt
+  password:
+  adapter: mysql2
+  encoding: utf8
+  timeout: 5000
+  pool: 5
+
+scc:
+  username:
+  password:
+
+mirroring:
+  mirror_src: false
+  verify_rpm_checksums: false
+  dedup_method: hardlink
+
+http_client:
+  verbose: false
+  proxy:
+  proxy_auth:
+  proxy_user:
+  proxy_password:

--- a/lib/rmt/config.rb
+++ b/lib/rmt/config.rb
@@ -4,10 +4,12 @@ require_relative '../rmt'
 Config.setup do |config|
   config.merge_nil_values = false
 
-  config.schema do
-    required(:scc).schema do
-      required(:username).filled
-      required(:password).filled
+  unless ENV['RAILS_ENV'] == 'test'
+    config.schema do
+      required(:scc).schema do
+        required(:username).filled
+        required(:password).filled
+      end
     end
   end
 end

--- a/lib/rmt/config.rb
+++ b/lib/rmt/config.rb
@@ -25,7 +25,7 @@ module RMT::Config
     end
   end
 
-  def self.respond_to_missing?
+  def self.respond_to_missing?(method, _)
     super
   end
 

--- a/lib/rmt/config.rb
+++ b/lib/rmt/config.rb
@@ -12,6 +12,15 @@ Config.load_and_set_settings(
 )
 
 module RMT::Config
+  def self.method_missing(key)
+    raise NoMethodError if Settings[key].nil?
+    Settings[key]
+  end
+
+  def self.respond_to_missing?(method, *args)
+    method == :scc or super
+  end
+
   def self.db_config(key = 'database')
     {
       'username' => Settings[key].username,
@@ -31,5 +40,4 @@ module RMT::Config
   def self.deduplication_by_hardlink?
     Settings.try(:mirroring).try(:dedup_method).to_s.to_sym != :copy
   end
-
 end

--- a/lib/rmt/config.rb
+++ b/lib/rmt/config.rb
@@ -3,9 +3,17 @@ require_relative '../rmt'
 
 Config.setup do |config|
   config.merge_nil_values = false
+
+  config.schema do
+    required(:scc).schema do
+      required(:username).filled
+      required(:password).filled
+    end
+  end
 end
 
 Config.load_and_set_settings(
+  File.join(__dir__, '../../config/default_rmt.yml'),
   '/etc/rmt.conf',
   File.join(__dir__, '../../config/rmt.yml'),
   File.join(__dir__, '../../config/rmt.local.yml')

--- a/lib/rmt/config.rb
+++ b/lib/rmt/config.rb
@@ -4,13 +4,8 @@ require_relative '../rmt'
 Config.setup do |config|
   config.merge_nil_values = false
 
-  unless ENV['RAILS_ENV'] == 'test'
-    config.schema do
-      required(:scc).schema do
-        required(:username).filled
-        required(:password).filled
-      end
-    end
+  config.schema do
+    required(:scc).schema
   end
 end
 
@@ -23,12 +18,15 @@ Config.load_and_set_settings(
 
 module RMT::Config
   def self.method_missing(key)
-    raise NoMethodError if Settings[key].nil?
-    Settings[key]
+    if Settings[key]
+      Settings[key]
+    else
+      super
+    end
   end
 
-  def self.respond_to_missing?(method, *args)
-    method == :scc or super
+  def self.respond_to_missing?
+    super
   end
 
   def self.db_config(key = 'database')

--- a/lib/rmt/http_request.rb
+++ b/lib/rmt/http_request.rb
@@ -9,11 +9,12 @@ class RMT::HttpRequest < Typhoeus::Request
 
     super
 
-    options[:proxy] = Settings.try(:http_client).try(:proxy)
-    options[:proxyauth] = Settings.try(:http_client).try(:proxy_auth) ? Settings.try(:http_client).try(:proxy_auth).to_sym : :any
+    options[:proxy] = RMT::Config.http_client.proxy
 
-    if Settings.try(:http_client).try(:proxy_user) && Settings.try(:http_client).try(:proxy_password)
-      options[:proxyuserpwd] = "#{Settings.http_client.proxy_user}:#{Settings.http_client.proxy_password}"
+    options[:proxyauth] = RMT::Config.http_client.proxy_auth ? RMT::Config.http_client.proxy_auth.to_sym : :any
+
+    if RMT::Config.http_client.proxy_user && RMT::Config.http_client.proxy_password
+      options[:proxyuserpwd] = "#{RMT::Config.http_client.proxy_user}:#{RMT::Config.http_client.proxy_password}"
     end
   end
 

--- a/lib/rmt/http_request.rb
+++ b/lib/rmt/http_request.rb
@@ -5,7 +5,7 @@ class RMT::HttpRequest < Typhoeus::Request
 
   def set_defaults
     Typhoeus::Config.user_agent = "RMT/#{RMT::VERSION}"
-    Typhoeus::Config.verbose = Settings.try(:http_client).try(:verbose)
+    Typhoeus::Config.verbose = RMT::Config.http_client.verbose
 
     super
 

--- a/lib/rmt/scc.rb
+++ b/lib/rmt/scc.rb
@@ -17,7 +17,7 @@ class RMT::SCC
     cleanup_database
 
     @logger.info(_('Downloading data from SCC'))
-    scc_api_client = SUSE::Connect::Api.new(Settings.scc.username, Settings.scc.password)
+    scc_api_client = SUSE::Connect::Api.new(RMT::Config.scc.username, RMT::Config.scc.password)
 
     @logger.info(_('Updating products'))
     data = scc_api_client.list_products
@@ -36,7 +36,7 @@ class RMT::SCC
 
     @logger.info _('Exporting data from SCC to %{path}') % { path: path }
 
-    scc_api_client = SUSE::Connect::Api.new(Settings.scc.username, Settings.scc.password)
+    scc_api_client = SUSE::Connect::Api.new(RMT::Config.scc.username, RMT::Config.scc.password)
 
     @logger.info(_('Exporting products'))
     File.write(File.join(path, 'organizations_products.json'), scc_api_client.list_products.to_json)
@@ -80,7 +80,7 @@ class RMT::SCC
   protected
 
   def credentials_set?
-    Settings.try(:scc).try(:username) && Settings.try(:scc).try(:password)
+    RMT::Config.scc.username && RMT::Config.scc.password
   end
 
   def cleanup_database

--- a/spec/lib/rmt/config_spec.rb
+++ b/spec/lib/rmt/config_spec.rb
@@ -27,4 +27,20 @@ RSpec.describe RMT::Config do
       end
     end
   end
+
+  describe '#respond_to_missing?' do
+    context 'when called with a unsupported parameter' do
+      it 'returns false' do
+        expect(described_class.respond_to?(:foo)).to eq(false)
+      end
+    end
+  end
+
+  describe '#method_missing' do
+    context 'when called with a unsupported parameter' do
+      it 'returns an error' do
+        expect{ described_class.foo }.to raise_error(NoMethodError)
+      end
+    end
+  end
 end

--- a/spec/lib/rmt/scc_spec.rb
+++ b/spec/lib/rmt/scc_spec.rb
@@ -97,8 +97,8 @@ describe RMT::SCC do
   describe '#sync' do
     context 'without SCC credentials' do
       before do
-        allow(RMT::Config).to receive_message_chain(:scc, :username).and_return nil
-        allow(RMT::Config).to receive_message_chain(:scc, :password).and_return nil
+        options = { username: nil, password: nil }
+        options.each { |key, value| Settings.scc.send("#{key}=", value) }
       end
 
       it 'raises an error' do
@@ -108,8 +108,8 @@ describe RMT::SCC do
 
     context 'with SCC credentials' do
       before do
-        allow(RMT::Config).to receive_message_chain(:scc, :username).and_return 'foo'
-        allow(RMT::Config).to receive_message_chain(:scc, :password).and_return 'bar'
+        options = { username: 'foo', password: 'bar' }
+        options.each { |key, value| Settings.scc.send("#{key}=", value) }
         described_class.new.sync
       end
 
@@ -125,8 +125,8 @@ describe RMT::SCC do
       let(:sled) { Product.find_by(identifier: 'SLED') }
 
       before do
-        allow(RMT::Config).to receive_message_chain(:scc, :username).and_return 'foo'
-        allow(RMT::Config).to receive_message_chain(:scc, :password).and_return 'bar'
+        options = { username: 'foo', password: 'bar' }
+        options.each { |key, value| Settings.scc.send("#{key}=", value) }
         described_class.new.sync
       end
 
@@ -179,8 +179,8 @@ describe RMT::SCC do
       let(:products_with_extra_extension) { products + [extra_product] }
 
       before do
-        allow(RMT::Config).to receive_message_chain(:scc, :username).and_return 'foo'
-        allow(RMT::Config).to receive_message_chain(:scc, :password).and_return 'bar'
+        options = { username: 'foo', password: 'bar' }
+        options.each { |key, value| Settings.scc.send("#{key}=", value) }
         allow(api_double).to receive(:list_products).and_return products_with_extra_extension
         allow(api_double).to receive(:list_repositories).and_return repositories_with_extra_repos
         described_class.new.sync
@@ -203,8 +203,8 @@ describe RMT::SCC do
       end
 
       before do
-        allow(RMT::Config).to receive_message_chain(:scc, :username).and_return 'foo'
-        allow(RMT::Config).to receive_message_chain(:scc, :password).and_return 'bar'
+        options = { username: 'foo', password: 'bar' }
+        options.each { |key, value| Settings.scc.send("#{key}=", value) }
         described_class.new.sync
       end
 
@@ -236,8 +236,8 @@ describe RMT::SCC do
     end
 
     before do
-      allow(RMT::Config).to receive_message_chain(:scc, :username).and_return 'foo'
-      allow(RMT::Config).to receive_message_chain(:scc, :password).and_return 'bar'
+      options = { username: 'foo', password: 'bar' }
+      options.each { |key, value| Settings.scc.send("#{key}=", value) }
 
       expect(SUSE::Connect::Api).to receive(:new) { api_double }
       expect(api_double).to receive(:list_products) { [] }
@@ -269,8 +269,8 @@ describe RMT::SCC do
 
     context 'without SCC credentials' do
       before do
-        allow(RMT::Config).to receive_message_chain(:scc, :username).and_return nil
-        allow(RMT::Config).to receive_message_chain(:scc, :password).and_return nil
+        options = { username: nil, password: nil }
+        options.each { |key, value| Settings.scc.send("#{key}=", value) }
       end
 
       it 'raises an error' do
@@ -280,8 +280,8 @@ describe RMT::SCC do
 
     context 'with SCC credentials' do
       before do
-        allow(RMT::Config).to receive_message_chain(:scc, :username).and_return 'me'
-        allow(RMT::Config).to receive_message_chain(:scc, :password).and_return 'groot'
+        options = { username: 'me', password: 'groot' }
+        options.each { |key, value| Settings.scc.send("#{key}=", value) }
       end
 
       %w[orders products_unscoped products repositories subscriptions].each do |data|

--- a/spec/lib/rmt/scc_spec.rb
+++ b/spec/lib/rmt/scc_spec.rb
@@ -97,7 +97,8 @@ describe RMT::SCC do
   describe '#sync' do
     context 'without SCC credentials' do
       before do
-        allow(Settings).to receive(:scc).and_return OpenStruct.new
+        allow(RMT::Config).to receive_message_chain(:scc, :username).and_return nil
+        allow(RMT::Config).to receive_message_chain(:scc, :password).and_return nil
       end
 
       it 'raises an error' do
@@ -107,7 +108,8 @@ describe RMT::SCC do
 
     context 'with SCC credentials' do
       before do
-        allow(Settings).to receive(:scc).and_return OpenStruct.new(username: 'foo', password: 'bar')
+        allow(RMT::Config).to receive_message_chain(:scc, :username).and_return 'foo'
+        allow(RMT::Config).to receive_message_chain(:scc, :password).and_return 'bar'
         described_class.new.sync
       end
 
@@ -123,7 +125,8 @@ describe RMT::SCC do
       let(:sled) { Product.find_by(identifier: 'SLED') }
 
       before do
-        allow(Settings).to receive(:scc).and_return OpenStruct.new(username: 'foo', password: 'bar')
+        allow(RMT::Config).to receive_message_chain(:scc, :username).and_return 'foo'
+        allow(RMT::Config).to receive_message_chain(:scc, :password).and_return 'bar'
         described_class.new.sync
       end
 
@@ -176,7 +179,8 @@ describe RMT::SCC do
       let(:products_with_extra_extension) { products + [extra_product] }
 
       before do
-        allow(Settings).to receive(:scc).and_return OpenStruct.new(username: 'foo', password: 'bar')
+        allow(RMT::Config).to receive_message_chain(:scc, :username).and_return 'foo'
+        allow(RMT::Config).to receive_message_chain(:scc, :password).and_return 'bar'
         allow(api_double).to receive(:list_products).and_return products_with_extra_extension
         allow(api_double).to receive(:list_repositories).and_return repositories_with_extra_repos
         described_class.new.sync
@@ -199,7 +203,8 @@ describe RMT::SCC do
       end
 
       before do
-        allow(Settings).to receive(:scc).and_return OpenStruct.new(username: 'foo', password: 'bar')
+        allow(RMT::Config).to receive_message_chain(:scc, :username).and_return 'foo'
+        allow(RMT::Config).to receive_message_chain(:scc, :password).and_return 'bar'
         described_class.new.sync
       end
 
@@ -231,13 +236,8 @@ describe RMT::SCC do
     end
 
     before do
-      # to prevent 'does not implement' verifying doubles error
-      Settings.class_eval do
-        def scc
-        end
-      end
-
-      allow(Settings).to receive(:scc).and_return OpenStruct.new(username: 'foo', password: 'bar')
+      allow(RMT::Config).to receive_message_chain(:scc, :username).and_return 'foo'
+      allow(RMT::Config).to receive_message_chain(:scc, :password).and_return 'bar'
 
       expect(SUSE::Connect::Api).to receive(:new) { api_double }
       expect(api_double).to receive(:list_products) { [] }
@@ -269,7 +269,8 @@ describe RMT::SCC do
 
     context 'without SCC credentials' do
       before do
-        allow(Settings).to receive(:scc).and_return OpenStruct.new
+        allow(RMT::Config).to receive_message_chain(:scc, :username).and_return nil
+        allow(RMT::Config).to receive_message_chain(:scc, :password).and_return nil
       end
 
       it 'raises an error' do
@@ -279,7 +280,8 @@ describe RMT::SCC do
 
     context 'with SCC credentials' do
       before do
-        allow(Settings).to receive(:scc).and_return(OpenStruct.new(username: 'me', password: 'groot'))
+        allow(RMT::Config).to receive_message_chain(:scc, :username).and_return 'me'
+        allow(RMT::Config).to receive_message_chain(:scc, :password).and_return 'groot'
       end
 
       %w[orders products_unscoped products repositories subscriptions].each do |data|

--- a/spec/models/product_predecessor_association_spec.rb
+++ b/spec/models/product_predecessor_association_spec.rb
@@ -7,6 +7,6 @@ RSpec.describe ProductPredecessorAssociation, type: :model do
   end
 
   describe 'attributes' do
-    it { is_expected.to define_enum_for(:kind).with(%i[online offline]) }
+    it { is_expected.to define_enum_for(:kind).with_values(%i[online offline]) }
   end
 end


### PR DESCRIPTION
Fixes #178, using `RMT::Config` instead of `Settings`, encapsulating the error in `RMT::Config` and using `dry-validation`'s schema.

I also tried to change how the settings are being handled in `engines`, but as the tests were already breaking and I don't know if this is expected, I didn't touch the files and tests in this folder.