### PR TITLE
Mention ruby-2.5 patches removal in changelog

### DIFF
--- a/package/rmt-server.changes
+++ b/package/rmt-server.changes
@@ -3,6 +3,8 @@ Thu Feb 21 13:48:54 UTC 2019 - ikapelyukhin@suse.com
 
 - Version 1.2.2
 - Set CURLOPT_LOW_SPEED_LIMIT to prevent downloads from getting stuck (bsc#1107806)
+- Removed use-ruby-2.5-in-rails.patch, use-ruby-2.5-in-rmt-data-import.patch and
+   use-ruby-2.5-in-rmt-cli.patch as they are no longer needed.
 
 -------------------------------------------------------------------
 Mon Feb 18 11:30:19 UTC 2019 - skotov@suse.com

--- a/package/rmt-server.spec
+++ b/package/rmt-server.spec
@@ -54,6 +54,7 @@ Source15:       auth-handler.conf
 Source16:       auth-location.conf
 Source17:       rmt-cli_bash-completion.sh
 Source18:       rmt-server.reg
+Source19:       http-certs.conf
 BuildRequires:  fdupes
 BuildRequires:  gcc
 BuildRequires:  libcurl-devel


### PR DESCRIPTION
Fixes following warnings from OBS which makes SR to be declined:
* Attention, http-certs.conf is not mentioned in spec files as source or patch.
* A Patch (use-ruby-2.5-in-rmt-data-import.patch) is being deleted without this removal being referenced in the changelog.
 * A Patch (use-ruby-2.5-in-rmt-cli.patch) is being deleted without this removal being referenced in the changelog.
 * A Patch (use-ruby-2.5-in-rails.patch) is being deleted without this removal being referenced in the changelog.