### PR TITLE
Add checksums for rmt-client-setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,9 @@ dist: clean man
 	@mkdir $(NAME)-$(VERSION)/vendor
 	@mkdir -p $(NAME)-$(VERSION)/public/repo/
 	@cp -r public/tools $(NAME)-$(VERSION)/public/
+	cd public/tools && md5sum * > ../../$(NAME)-$(VERSION)/public/tools/MD5SUMS
+	cd public/tools && sha1sum * > ../../$(NAME)-$(VERSION)/public/tools/SHA1SUMS
+	cd public/tools && sha256sum * > ../../$(NAME)-$(VERSION)/public/tools/SHA256SUMS
 
 	# i18n
 	@cp -r locale $(NAME)-$(VERSION)/

--- a/package/nginx-http.conf
+++ b/package/nginx-http.conf
@@ -20,5 +20,9 @@ server {
         return 301 https://$host$request_uri;
     }
 
+    location /tools {
+        autoindex on;
+    }
+
     include /etc/nginx/rmt-pubcloud*.d/http-certs*.conf;
 }

--- a/package/nginx-https.conf
+++ b/package/nginx-https.conf
@@ -30,6 +30,10 @@ server {
         try_files $uri @rmt_app;
     }
 
+    location /tools {
+        autoindex on;
+    }
+
     location @rmt_app {
         proxy_pass          http://rmt;
         proxy_redirect      off;

--- a/package/rmt-server.changes
+++ b/package/rmt-server.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon Mar 11 15:48:59 UTC 2019 - Thomas Muntaner <tmuntaner@suse.com>
+
+- Added MD5SUMS, SHA1SUMS, and SHA256SUMS for rmt-client-setup.
+
+-------------------------------------------------------------------
 Thu Feb 21 13:48:54 UTC 2019 - ikapelyukhin@suse.com
 
 - Version 1.2.2


### PR DESCRIPTION
Currently, we don't have a way to verify that the downloaded
rmt-client-setup was safely downloaded.

If we provide the checksums, we can give the user a way to verify
downloaded files.