### PR TITLE
include preinstalled modules in MigrationEngine#online_migrations

### DIFF
--- a/app/models/migration_engine.rb
+++ b/app/models/migration_engine.rb
@@ -17,7 +17,8 @@ class MigrationEngine
   end
 
   def online_migrations
-    generate(migration_kind: :online)
+    migrations = generate(migration_kind: :online)
+    add_preinstalled_modules(migrations)
   end
 
   def offline_migrations(target_base_product)
@@ -102,6 +103,14 @@ class MigrationEngine
     migrations.map do |migration|
       base = migration.first
       migration.concat Product.modules_for_migration(base.id)
+      migration
+    end
+  end
+
+  def add_preinstalled_modules(migrations)
+    migrations.map do |migration|
+      base = migration.first
+      migration.concat(Product.preinstalled_modules(base.id))
       migration
     end
   end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -52,6 +52,10 @@ class Product < ApplicationRecord
     joins(:product_extensions_associations)
     .where(products_extensions: { root_product_id: root_product_ids, recommended: true })
   }
+  scope :preinstalled, lambda { |root_product_ids|
+    joins(:product_extensions_associations)
+    .where(products_extensions: { root_product_id: root_product_ids, preinstalled: true })
+  }
 
   scope :with_release_stage, lambda { |release_stage|
     if release_stage
@@ -113,6 +117,10 @@ class Product < ApplicationRecord
 
   def self.modules_for_migration(root_product_ids)
     migration_extra(root_product_ids).or(recommended(root_product_ids)).distinct
+  end
+
+  def self.preinstalled_modules(root_product_ids)
+    preinstalled(root_product_ids).distinct
   end
 
   def self.free_and_recommended_modules(root_product_ids)

--- a/db/migrate/20190312110206_add_preinstalled_to_products_extensions.rb
+++ b/db/migrate/20190312110206_add_preinstalled_to_products_extensions.rb
@@ -1,0 +1,5 @@
+class AddPreinstalledToProductsExtensions < ActiveRecord::Migration[5.1]
+  def change
+    add_column :products_extensions, :preinstalled, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190118125927) do
+ActiveRecord::Schema.define(version: 20190312110206) do
 
   create_table "activations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.bigint "service_id", null: false
@@ -78,6 +78,7 @@ ActiveRecord::Schema.define(version: 20190118125927) do
     t.boolean "recommended"
     t.bigint "root_product_id", null: false
     t.boolean "migration_extra", default: false
+    t.boolean "preinstalled", default: false
     t.index ["extension_id"], name: "index_products_extensions_on_extension_id"
     t.index ["product_id", "extension_id", "root_product_id"], name: "index_products_extensions_on_product_extension_root", unique: true
     t.index ["product_id"], name: "index_products_extensions_on_product_id"

--- a/lib/rmt/scc.rb
+++ b/lib/rmt/scc.rb
@@ -106,7 +106,7 @@ class RMT::SCC
     Product.find_or_create_by(id: id)
   end
 
-  def create_product(item, root_product_id = nil, base_product = nil, recommended = false, migration_extra = false)
+  def create_product(item, root_product_id = nil, base_product = nil)
     @logger.debug _('Adding product %{product}') % { product: "#{item[:identifier]}/#{item[:version]}#{(item[:arch]) ? '/' + item[:arch] : ''}" }
 
     product = get_product(item[:id])
@@ -120,8 +120,9 @@ class RMT::SCC
         product_id: base_product,
         extension_id: product.id,
         root_product_id: root_product_id,
-        recommended: recommended,
-        migration_extra: migration_extra
+        recommended: item[:recommended] || false,
+        migration_extra: item[:migration_extra] || false,
+        preinstalled: item[:preinstalled] || false
       )
     else
       root_product_id = product.id
@@ -129,7 +130,7 @@ class RMT::SCC
     end
 
     item[:extensions].each do |ext_item|
-      create_product(ext_item, root_product_id, product.id, ext_item[:recommended], ext_item[:migration_extra])
+      create_product(ext_item, root_product_id, product.id)
     end
   end
 

--- a/package/rmt-server.changes
+++ b/package/rmt-server.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Mar 18 14:11:04 UTC 2019 - serhii@suse.de
+
+- Online migrations will automatically add additional modules
+  to the client systems depending on the base product 
+
+-------------------------------------------------------------------
 Mon Mar 18 11:41:47 UTC 2019 - tmuntaner@suse.com
 
 - Updated rails to version 5.1.6.2 (CVE-2019-5419)

--- a/spec/models/migration_engine_spec.rb
+++ b/spec/models/migration_engine_spec.rb
@@ -349,6 +349,21 @@ describe MigrationEngine do
           it 'does not contain offline migrations' do
             is_expected.to contain_exactly([product_b])
           end
+
+          context "modules with a 'preinstalled' flag are added automatically to the migration target" do
+            let!(:target_product_preinstalled_module) do
+              create(:product, :module, :with_mirrored_repositories).tap do |mod|
+                ProductsExtensionsAssociation.create(
+                  product: product_b,
+                  extension: mod,
+                  root_product: product_b,
+                  preinstalled: true
+                )
+              end
+            end
+
+            it { is_expected.to contain_exactly([product_b, target_product_preinstalled_module]) }
+          end
         end
 
         describe '#offline_migrations' do

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -179,6 +179,24 @@ RSpec.describe Product, type: :model do
     it { is_expected.to contain_exactly(recommended_module, autoselected_module, recommended_extension, autoselected_extension) }
   end
 
+  describe '.preinstalled_modules' do
+    subject { described_class.preinstalled_modules([root_product]) }
+
+    let(:root_product) { create :product }
+    let(:preinstalled_module) { create(:product, :module) }
+
+    before do
+      ProductsExtensionsAssociation.create(
+        product: root_product,
+        extension: preinstalled_module,
+        root_product: root_product,
+        preinstalled: true
+      )
+    end
+
+    it { is_expected.to contain_exactly(preinstalled_module) }
+  end
+
   describe '#recommended_for?' do
     subject { extension.recommended_for?(queried_base) }
 


### PR DESCRIPTION
Depends on https://github.com/SUSE/rmt/pull/346

Review only https://github.com/SUSE/rmt/pull/348/commits/b9a0bd571939977aa40b49eec5f2f52822d6cefd

Verification:

1. You must have `preinstalled` modules in your database
2. 

```
curl -u '<SYSTEM_LOGIN>:<SYSTEM_PASSWORD>' -H "Content-type: application/json" -d '{ "installed_products": [ { "identifier": "SLES", "version": "15", "arch": "x86_64" } ] }' -X POST <YOUR_RMT_HOST>/connect/systems/products/migrations
```