### PR TITLE
Fix license mirroring issue

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,1 @@
+package/rmt-server.changes

--- a/lib/rmt.rb
+++ b/lib/rmt.rb
@@ -1,5 +1,5 @@
 module RMT
-  VERSION ||= '1.2.2'.freeze
+  VERSION ||= '1.2.3'.freeze
 
   DEFAULT_USER = '_rmt'.freeze
   DEFAULT_GROUP = 'nginx'.freeze

--- a/lib/rmt/mirror.rb
+++ b/lib/rmt/mirror.rb
@@ -33,7 +33,7 @@ class RMT::Mirror
     primary_files, deltainfo_files = mirror_metadata
     mirror_data(primary_files, deltainfo_files)
 
-    replace_directory(@temp_licenses_dir, File.join(@repository_dir, '../product.license/')) if Dir.exist?(@temp_licenses_dir)
+    replace_directory(@temp_licenses_dir, @repository_dir.chomp('/') + '.license/') if Dir.exist?(@temp_licenses_dir)
     replace_directory(File.join(@temp_metadata_dir, 'repodata'), File.join(@repository_dir, 'repodata'))
   ensure
     remove_tmp_directories
@@ -92,9 +92,9 @@ class RMT::Mirror
   end
 
   def mirror_license
-    @downloader.repository_url = URI.join(@repository_url, '../product.license/')
+    @downloader.repository_url = @repository_url.chomp('/') + '.license/'
     @downloader.destination_dir = @temp_licenses_dir
-    @downloader.cache_dir = File.join(@repository_dir, '../product.license/')
+    @downloader.cache_dir = @repository_dir.chomp('/') + '.license/'
 
     begin
       directory_yast = @downloader.download('directory.yast')

--- a/package/rmt-server.changes
+++ b/package/rmt-server.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Mar 12 17:21:47 UTC 2019 - Hernan Schmidt <hschmidt@suse.com>
+
+- Fix license mirroring issue in some non-SUSE repositories (bsc#1128858)
+
+-------------------------------------------------------------------
 Thu Feb 21 13:48:54 UTC 2019 - ikapelyukhin@suse.com
 
 - Version 1.2.2

--- a/package/rmt-server.changes
+++ b/package/rmt-server.changes
@@ -1,6 +1,7 @@
 -------------------------------------------------------------------
 Tue Mar 12 17:21:47 UTC 2019 - Hernan Schmidt <hschmidt@suse.com>
 
+- Version 1.2.3
 - Fix license mirroring issue in some non-SUSE repositories (bsc#1128858)
 
 -------------------------------------------------------------------

--- a/package/rmt-server.spec
+++ b/package/rmt-server.spec
@@ -29,7 +29,7 @@
 %define ruby_version %{rb_default_ruby_suffix}
 %endif
 Name:           rmt-server
-Version:        1.2.2
+Version:        1.2.3
 Release:        0
 Summary:        Repository mirroring tool and registration proxy for SCC
 License:        GPL-2.0-or-later

--- a/spec/fixtures/vcr_cassettes/mirroring.yml
+++ b/spec/fixtures/vcr_cassettes/mirroring.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost/product.license/directory.yast
+    uri: http://localhost/dummy_repo.license/directory.yast
     body:
       encoding: US-ASCII
       string: ''
@@ -32,7 +32,7 @@ http_interactions:
         Not Found</h1></center>\r\n<hr><center>nginx/1.8.1</center>\r\n</body>\r\n</html>\r\n"
     http_version: '1.1'
     adapter_metadata:
-      effective_url: http://localhost/product.license/directory.yast
+      effective_url: http://localhost/dummy_repo.license/directory.yast
   recorded_at: Mon, 04 Sep 2017 11:58:19 GMT
 - request:
     method: get

--- a/spec/fixtures/vcr_cassettes/mirroring_with_auth_token.yml
+++ b/spec/fixtures/vcr_cassettes/mirroring_with_auth_token.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost/product.license/directory.yast
+    uri: http://localhost/dummy_repo.license/directory.yast
     body:
       encoding: US-ASCII
       string: ''
@@ -32,7 +32,7 @@ http_interactions:
         Not Found</h1></center>\r\n<hr><center>nginx/1.8.1</center>\r\n</body>\r\n</html>\r\n"
     http_version: '1.1'
     adapter_metadata:
-      effective_url: http://localhost/product.license/directory.yast
+      effective_url: http://localhost/dummy_repo.license/directory.yast
   recorded_at: Mon, 04 Sep 2017 11:58:19 GMT
 - request:
     method: get


### PR DESCRIPTION
Before, we used to always look for a "product.license" directory in the
repo's parent directory (i.e. "../product.license").
While most, if not all, SUSE-built repositories follow that convention,
it's not followed by all products.
The difference is that the directory is not always called
"product.license". In fact, the licenses are stored in repo_url +
".license", and it happens that the repo_urls built by SUSE end in
"product", so the licenses are in "product.license".
In the case of the IBM DLPAR Utils and IBM DLPAR SDK modules, the repos
end in "ppc64le", so the licenses are stored in directory named
"ppc64le.license".