### PR TITLE
Remove top-level link to changes file

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,1 +1,0 @@
-package/rmt-server.changes


### PR DESCRIPTION
Unfortunately, GitHub doesn't redirect to the linked file, so it defeats
the purpose.