### PR TITLE
Include Python2 module into SLE15 online migrations

### DIFF
--- a/lib/rmt.rb
+++ b/lib/rmt.rb
@@ -1,5 +1,5 @@
 module RMT
-  VERSION ||= '1.2.6'.freeze
+  VERSION ||= '1.2.7'.freeze
 
   DEFAULT_USER = '_rmt'.freeze
   DEFAULT_GROUP = 'nginx'.freeze

--- a/package/rmt-server.changes
+++ b/package/rmt-server.changes
@@ -1,6 +1,7 @@
 -------------------------------------------------------------------
 Thu Mar 21 11:55:02 UTC 2019 - skotov@suse.com
 
+- Version 1.2.7
 - Online migrations will automatically add additional modules
   to the client systems depending on the base product
 

--- a/package/rmt-server.changes
+++ b/package/rmt-server.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Mar 21 11:55:02 UTC 2019 - skotov@suse.com
+
+- Online migrations will automatically add additional modules
+  to the client systems depending on the base product
+
+-------------------------------------------------------------------
 Wed Mar 20 16:14:09 UTC 2019 - Ivan Kapelyukhin <ikapelyukhin@suse.com>
 
 - Version 1.2.6

--- a/package/rmt-server.spec
+++ b/package/rmt-server.spec
@@ -29,7 +29,7 @@
 %define ruby_version %{rb_default_ruby_suffix}
 %endif
 Name:           rmt-server
-Version:        1.2.6
+Version:        1.2.7
 Release:        0
 Summary:        Repository mirroring tool and registration proxy for SCC
 License:        GPL-2.0-or-later

--- a/spec/models/migration_engine_spec.rb
+++ b/spec/models/migration_engine_spec.rb
@@ -349,6 +349,30 @@ describe MigrationEngine do
           it 'does not contain offline migrations' do
             is_expected.to contain_exactly([product_b])
           end
+
+          context 'python2 module gets added to SLE 15 online migrations' do
+            let(:installed_products) { [sle15] }
+            let(:system) { create :system, :with_activated_product, product: sle15 }
+
+            let!(:sle15) do
+              create :product, :with_mirrored_repositories,
+                name: 'sle15', version: '15'
+            end
+            let!(:sle15_sp1) do
+              create :product, :with_mirrored_repositories,
+                :cloned, from: sle15,
+                name: 'sle15-sp1', version: '15.1', predecessors: [sle15]
+            end
+            let!(:python2_module) do
+              create :product, :module, :with_mirrored_repositories,
+                identifier: 'sle-module-python2', version: '15.1', base_products: [sle15_sp1],
+                arch: sle15.arch
+            end
+
+            it 'contains python2 module' do
+              is_expected.to contain_exactly([sle15_sp1, python2_module])
+            end
+          end
         end
 
         describe '#offline_migrations' do


### PR DESCRIPTION
Verification: 

`curl -u '<SYSTEM_LOGIN>:<SYSTEM_PASSWORD>' -H "Content-type: application/json" -d '{ "installed_products": [ { "identifier": "SLES", "version": "15", "arch": "x86_64" } ] }' -X POST <YOUR_SCC_HOST>/connect/systems/products/migrations`