### PR TITLE
Fix \b in help text from incorrect commands

### DIFF
--- a/lib/rmt/cli/base.rb
+++ b/lib/rmt/cli/base.rb
@@ -86,11 +86,10 @@ class RMT::CLI::Base < Thor
     # taken and adapted from https://github.com/erikhuda/thor/issues/261, as Thor does not seem to handle nested subcommands
     # the way we expect it to.
     def banner(command, _namespace = nil, _subcommand = false)
-      "#{basename} #{subcommand_prefix} #{command.usage}"
+      (name == RMT::CLI::Main.name) ? "#{basename} #{command.usage}" : "#{basename} #{subcommand_prefix} #{command.usage}"
     end
 
     def subcommand_prefix
-      return "\b" if name == RMT::CLI::Main.name
       name.gsub(/.*::/, '').gsub(/^[A-Z]/) { |match| match[0].downcase }.gsub(/[A-Z]/) { |match| " #{match[0].downcase}" }
     end
 


### PR DESCRIPTION
Usage: "rmt-cli mirror"

instead of

Usage: "rmt-cli \b mirror"

Fixes #363