### PR TITLE
Rake test should fail on error

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,14 +1,24 @@
 unless ENV['NO_COVERAGE']
   SimpleCov.minimum_coverage 100
-  SimpleCov.start do
-    SimpleCov.command_name ENV['SIMPLECOV_CMD']
-    add_filter '/spec/'
-    add_filter '/tasks/'
+  if ENV['SIMPLECOV_CMD'] == 'test:core'
+    SimpleCov.start do
+      SimpleCov.command_name ENV['SIMPLECOV_CMD']
+      add_filter '/spec/'
+      add_filter '/tasks/'
 
-    track_files('app/**/*.rb')
-    track_files('lib/**/*.rb')
-    track_files('engines/**/app/**/*.rb')
-    track_files('engines/**/lib/**/*.rb')
-    track_files('engines/**/*.rb')
+      track_files('app/**/*.rb')
+      track_files('lib/**/*.rb')
+    end
+  end
+  if ENV['SIMPLECOV_CMD'] == 'test:engines'
+    SimpleCov.start do
+      SimpleCov.command_name ENV['SIMPLECOV_CMD']
+      add_filter '/spec/'
+      add_filter '/tasks/'
+
+      track_files('engines/**/app/**/*.rb')
+      track_files('engines/**/lib/**/*.rb')
+      track_files('engines/**/*.rb')
+    end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,6 +14,7 @@ Bundler.require(*Rails.groups)
 
 
 # Engine loading mechanism
+# :nocov:
 if (Rails.env.production? || ENV['RMT_LOAD_ENGINES'])
   Dir.glob("#{__dir__}/../engines/*").select { |i| File.directory?(i) }.each do |dir|
     engine_name = File.basename(dir)
@@ -21,6 +22,7 @@ if (Rails.env.production? || ENV['RMT_LOAD_ENGINES'])
     require_relative(filename) if File.exist?(filename)
   end
 end
+# :nocov:
 
 module RMT
   class CustomConfiguration < Rails::Application::Configuration

--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -10,7 +10,7 @@ RSpec::Core::RakeTask.new('test:core') do |t|
   ENV['SIMPLECOV_CMD'] = 'test:core'
   t.pattern = 'spec'
   t.verbose = false
-  t.fail_on_error = false
+  t.fail_on_error = true
   t.rspec_opts = '--format Fuubar --color'
 end
 
@@ -19,6 +19,6 @@ RSpec::Core::RakeTask.new('test:engines') do |t|
   ENV['SIMPLECOV_CMD'] = 'test:engines'
   t.pattern = 'engines/*/spec/**/**{,/*/**}/*_spec.rb'
   t.verbose = false
-  t.fail_on_error = false
+  t.fail_on_error = true
   t.rspec_opts = '--format Fuubar --color'
 end


### PR DESCRIPTION
Currently, if rspec fails, we continue on and give an exit code of 0, that shouldn't happen.

I split the code coverage into their respective code suites: core and engine. Core will fail if we're missing 100% code coverage in normal RMT and engine will fail if the engine files are not 100% tested.
