### PR TITLE
Adapt integration tests to new RPM specfile

### DIFF
--- a/integration/run.sh
+++ b/integration/run.sh
@@ -4,7 +4,7 @@ mkdir ~/obs
 cd ~/obs
 osc co systemsmanagement:SCC:RMT rmt-server
 cd /tmp/rmt-server/package
-cp * ~/obs/systemsmanagement:SCC:RMT/rmt-server
+cp obs/* ~/obs/systemsmanagement:SCC:RMT/rmt-server
 cd ~/obs/systemsmanagement:SCC:RMT/rmt-server && osc build SLE_15 x86_64 --no-verify --trust-all-projects && cd .. &&
 zypper --non-interactive --no-gpg-checks in --no-recommends /oscbuild/SLE_15-x86_64/home/abuild/rpmbuild/RPMS/x86_64/*
 cd /usr/share/rmt


### PR DESCRIPTION
Some files have been moved from `package` to `package/obs/` directory and that requires a small updated in integration tests script.