### PR TITLE
Use proper product name of SUSE Manager

### DIFF
--- a/lib/rmt/mirror.rb
+++ b/lib/rmt/mirror.rb
@@ -37,7 +37,7 @@ class RMT::Mirror
     @logger.info _('Mirroring SUSE Manager product tree to %{dir}') % { dir: @repository_dir }
     @downloader.download('product_tree.json')
   rescue RMT::Downloader::Exception => e
-    raise RMT::Mirror::Exception.new(_('Could not mirror suma product tree with error: %{error}') % { error: e.message })
+    raise RMT::Mirror::Exception.new(_('Could not mirror SUSE Manager product tree with error: %{error}') % { error: e.message })
   end
 
   def mirror(repository_url:, local_path:, auth_token: nil, repo_name: nil)

--- a/spec/lib/rmt/mirror_spec.rb
+++ b/spec/lib/rmt/mirror_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe RMT::Mirror do
       end
 
       it 'raises mirroring exception' do
-        expect { command }.to raise_error(RMT::Mirror::Exception, "Could not mirror suma product tree with error: 418 - I'm a teapot")
+        expect { command }.to raise_error(RMT::Mirror::Exception, "Could not mirror SUSE Manager product tree with error: 418 - I'm a teapot")
       end
     end
   end


### PR DESCRIPTION
To [un-confuse the translators](https://l10n.opensuse.org/translate/rmt/i18n/ru/?type=comments#comments), also `suma` is not a proper way to reference SUSE Manager.