### PR TITLE
Enable comments for i18n strings

### DIFF
--- a/config/initializers/fast_gettext.rb
+++ b/config/initializers/fast_gettext.rb
@@ -4,3 +4,6 @@ FastGettext.add_text_domain('rmt', path: File.join(rmt_path, 'locale'), type: :p
 FastGettext.default_locale = :en
 FastGettext.available_locales = FastGettext.default_available_locales = %w[en de fr ja es pt_BR zh_CN]
 FastGettext.text_domain = FastGettext.default_text_domain = 'rmt'
+
+# enable comments in .po/.pot files prefixed with i18n tag (see rxgettext -h)
+Rails.application.config.gettext_i18n_rails.xgettext = %w[--add-comments=i18n]

--- a/lib/rmt/cli/decorators/product_decorator.rb
+++ b/lib/rmt/cli/decorators/product_decorator.rb
@@ -35,6 +35,7 @@ class RMT::CLI::Decorators::ProductDecorator < RMT::CLI::Decorators::Base
       _('ID'),
       _('Product'),
       _('Version'),
+      # i18n: architecture
       _('Arch'),
       _('Mirror?'),
       _('Last mirrored')


### PR DESCRIPTION
This should enable adding hints for the translators for strings in the code. Only comments with a tag will show in `.po`/`.pot` files, I've set the tag to `i18n`.

Before:

```
msgid "Arch"
msgstr ""
```

After:

```
#. i18n: architecture
#: ../lib/rmt/cli/decorators/product_decorator.rb:39
msgid "Arch"
msgstr ""
```

The comments should show in Weblate.