### PR TITLE
Create UUID when system_uuid file empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Supported Ruby versions are 2.5.0 and newer.
 ## Development setup
 
 * Install the dependencies:
-  * `sudo zypper in libxml2-devel libxslt-devel`
+  * `sudo zypper in libxml2-devel libxslt-devel libmariadb-devel`
   * `bundle install`
 * Copy the file `config/rmt.yml` to `config/rmt.local.yml` to override the default settings:
     * Add your organization credentials to `scc` section

--- a/lib/suse/connect/api.rb
+++ b/lib/suse/connect/api.rb
@@ -85,7 +85,7 @@ module SUSE
       private
 
       def system_uuid
-        @system_uuid ||= if File.exist?(UUID_FILE_LOCATION)
+        @system_uuid ||= if File.exist?(UUID_FILE_LOCATION) && !File.empty?(UUID_FILE_LOCATION)
                            File.read(UUID_FILE_LOCATION)
                          else
                            uuid = SecureRandom.uuid

--- a/spec/suse/connect/api_spec.rb
+++ b/spec/suse/connect/api_spec.rb
@@ -32,27 +32,17 @@ RSpec.describe SUSE::Connect::Api do
     end
 
     context 'when system_uuid file is empty' do
-       before do
+      before do
           allow(File).to receive(:exist?).with(described_class::UUID_FILE_LOCATION).and_return(true)
           allow(File).to receive(:empty?).with(described_class::UUID_FILE_LOCATION).and_return(true)
           allow(SecureRandom).to receive(:uuid).and_return(uuid)
-        end
-
-        it 'overwrites a file' do
-          expect(File).to receive(:write).with(described_class::UUID_FILE_LOCATION, uuid).exactly(1).times
-          expect(method_call).to be(uuid)
-        end
-     end   
-      it 'overwrites a file' do
-        FakeFS.with_fresh do
-          FileUtils.mkdir_p '/var/lib/rmt/'
-          FileUtils.touch '/var/lib/rmt/system_uuid'
-          allow(SecureRandom).to receive(:uuid).and_return(uuid)
-          expect(File).to receive(:write).with(described_class::UUID_FILE_LOCATION, uuid).exactly(1).times
-          expect(method_call).to be(uuid)
-        end
       end
-    end
+
+      it 'overwrites a file' do
+        expect(File).to receive(:write).with(described_class::UUID_FILE_LOCATION, uuid).exactly(1).times
+        expect(method_call).to be(uuid)
+      end
+    end   
   end
 
   context 'api requests' do

--- a/spec/suse/connect/api_spec.rb
+++ b/spec/suse/connect/api_spec.rb
@@ -32,6 +32,17 @@ RSpec.describe SUSE::Connect::Api do
     end
 
     context 'when system_uuid file is empty' do
+       before do
+          allow(File).to receive(:exist?).with(described_class::UUID_FILE_LOCATION).and_return(true)
+          allow(File).to receive(:empty?).with(described_class::UUID_FILE_LOCATION).and_return(true)
+          allow(SecureRandom).to receive(:uuid).and_return(uuid)
+        end
+
+        it 'overwrites a file' do
+          expect(File).to receive(:write).with(described_class::UUID_FILE_LOCATION, uuid).exactly(1).times
+          expect(method_call).to be(uuid)
+        end
+     end   
       it 'overwrites a file' do
         FakeFS.with_fresh do
           FileUtils.mkdir_p '/var/lib/rmt/'

--- a/spec/suse/connect/api_spec.rb
+++ b/spec/suse/connect/api_spec.rb
@@ -33,16 +33,16 @@ RSpec.describe SUSE::Connect::Api do
 
     context 'when system_uuid file is empty' do
       before do
-          allow(File).to receive(:exist?).with(described_class::UUID_FILE_LOCATION).and_return(true)
-          allow(File).to receive(:empty?).with(described_class::UUID_FILE_LOCATION).and_return(true)
-          allow(SecureRandom).to receive(:uuid).and_return(uuid)
+        allow(File).to receive(:exist?).with(described_class::UUID_FILE_LOCATION).and_return(true)
+        allow(File).to receive(:empty?).with(described_class::UUID_FILE_LOCATION).and_return(true)
+        allow(SecureRandom).to receive(:uuid).and_return(uuid)
       end
 
       it 'overwrites a file' do
         expect(File).to receive(:write).with(described_class::UUID_FILE_LOCATION, uuid).exactly(1).times
         expect(method_call).to be(uuid)
       end
-    end   
+    end
   end
 
   context 'api requests' do

--- a/spec/suse/connect/api_spec.rb
+++ b/spec/suse/connect/api_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
 require 'webmock/rspec'
+require 'fakefs/spec_helpers'
 
 RSpec.describe SUSE::Connect::Api do
   let(:username) { 'scc_user' }
@@ -27,6 +28,18 @@ RSpec.describe SUSE::Connect::Api do
         expect(File).to receive(:write).with(described_class::UUID_FILE_LOCATION, uuid).exactly(1).times
         expect(File).not_to receive(:read).with(described_class::UUID_FILE_LOCATION)
         expect(method_call).to be(uuid)
+      end
+    end
+
+    context 'when system_uuid file is empty' do
+      it 'overwrites a file' do
+        FakeFS.with_fresh do
+          FileUtils.mkdir_p '/var/lib/rmt/'
+          FileUtils.touch '/var/lib/rmt/system_uuid'
+          allow(SecureRandom).to receive(:uuid).and_return(uuid)
+          expect(File).to receive(:write).with(described_class::UUID_FILE_LOCATION, uuid).exactly(1).times
+          expect(method_call).to be(uuid)
+        end
       end
     end
   end


### PR DESCRIPTION
Added a check to only read the uuid-file if it is not empty, otherwise it creates a new uuid.
(... and added a dependency to readme)