### PR TITLE
replaced string "rmt-migration" with "rmt-server-migration.service"

### DIFF
--- a/lib/rmt/cli/base.rb
+++ b/lib/rmt/cli/base.rb
@@ -64,7 +64,8 @@ class RMT::CLI::Base < Thor
       end
     rescue ActiveRecord::NoDatabaseError
       raise RMT::CLI::Error.new(
-        _("The RMT database has not yet been initialized. Run '%{command}' to setup the database.") % { command: 'systemctl start rmt-migration' },
+        _("The RMT database has not yet been initialized. Run '%{command}' to setup the database.") \
+        % { command: 'systemctl start rmt-server-migration.service' },
         RMT::CLI::Error::ERROR_DB
       )
     rescue RMT::SCC::CredentialsError, ::SUSE::Connect::Api::InvalidCredentialsError

--- a/spec/lib/rmt/cli/main_spec.rb
+++ b/spec/lib/rmt/cli/main_spec.rb
@@ -215,7 +215,7 @@ RSpec.describe RMT::CLI::Main, :with_fakefs do
 
           it 'outputs custom error message' do
             expect { command }.to output(
-              "The RMT database has not yet been initialized. Run 'systemctl start rmt-migration' to setup the database.\n"
+              "The RMT database has not yet been initialized. Run 'systemctl start rmt-server-migration.service' to setup the database.\n"
             ).to_stderr
           end
         end


### PR DESCRIPTION
- replaced "systemctl start rmt-migration" with "systemctl start rmt-server-migration.service" (see [bug](https://bugzilla.suse.com/show_bug.cgi?id=1136165))