### PR TITLE
Remove refactoring leftover

### DIFF
--- a/lib/rmt/cli/main.rb
+++ b/lib/rmt/cli/main.rb
@@ -68,6 +68,5 @@ class RMT::CLI::Main < RMT::CLI::Base
   end
 
   map %w[--version -v] => :version
-  map %w[registration] => :registrations
 
 end


### PR DESCRIPTION
There's a forgotten alias left over from refactoring in #423, which shows up as an alternative for `rmt-cli r`.