### PR TITLE
Faster mirroring / fix mirroring logic

### DIFF
--- a/lib/rmt.rb
+++ b/lib/rmt.rb
@@ -1,5 +1,5 @@
 module RMT
-  VERSION ||= '2.3.0'.freeze
+  VERSION ||= '2.3.1'.freeze
 
   DEFAULT_USER = '_rmt'.freeze
   DEFAULT_GROUP = 'nginx'.freeze

--- a/lib/rmt/downloader.rb
+++ b/lib/rmt/downloader.rb
@@ -28,43 +28,31 @@ class RMT::Downloader
     @logger = logger
     @cache_dir = cache_dir
     @save_for_dedup = save_for_dedup
+    @queue = []
   end
 
   def download(remote_file, checksum_type: nil, checksum_value: nil)
-    local_filename = self.class.make_local_path(@destination_dir, remote_file)
-
-    cache_timestamp = nil
-    if @cache_dir
-      cache_filename = File.join(@cache_dir, remote_file)
-      cache_timestamp = get_cache_timestamp(cache_filename)
-    end
-
-    request_fiber = Fiber.new do
-      response = make_request(remote_file, request_fiber, cache_timestamp)
-
-      if (response.code == 304)
-        copy_from_cache(cache_filename, local_filename)
-      else
-        finalize_download(response.request, local_filename, checksum_type, checksum_value)
-      end
-    end
-
-    request_fiber.resume.run
-
-    local_filename
-  end
-
-  def get_cache_timestamp(filename)
-    File.mtime(filename).utc.httpdate if File.exist?(filename)
+    local_filenames = []
+    fiber_request = create_fiber_request(
+      local_filenames,
+      remote_file,
+      checksum_type: checksum_type,
+      checksum_value: checksum_value
+    )
+    fiber_request.run
+    local_filenames.first
   end
 
   def download_multi(files)
     @queue = files
     @hydra = Typhoeus::Hydra.new(max_concurrency: @concurrency)
 
-    @concurrency.times { process_queue }
+    local_filenames = []
+    failed_downloads = []
+    @concurrency.times { process_queue(local_filenames, failed_downloads) }
 
     @hydra.run
+    local_filenames
   end
 
   def self.make_local_path(root_path, remote_file)
@@ -78,25 +66,63 @@ class RMT::Downloader
 
   protected
 
-  def process_queue
-    queue_item = @queue.shift
-    return unless queue_item
-    remote_file = queue_item.location
-    local_file = self.class.make_local_path(@destination_dir, remote_file)
+  def get_cache_timestamp(filename)
+    File.mtime(filename).utc.httpdate if File.exist?(filename)
+  end
 
-    # The request is wrapped into a fiber for exception handling
+  # Creates a fiber that wraps RMT::FiberRequest and runs it
+  # @param [Array] local_filenames array of paths to downloaded files, passed by reference
+  # @param [String] remote_file path of the remote file relative to @repository_url
+  # @param [String] checksum_type expected remote file checksum type
+  # @param [String] checksum_value expected remote file checksum value
+  # @param [Array] failed_downloads array of remote files that have failed downloads, passed by reference, prevents from raising RMT::Downloader exceptions
+  # @return [RMT::FiberRequest] a request that can be run individually or with Typhoeus::Hydra
+  def create_fiber_request(local_filenames, remote_file, checksum_type: nil, checksum_value: nil, failed_downloads: nil)
+    local_filename = self.class.make_local_path(@destination_dir, remote_file)
+
     request_fiber = Fiber.new do
       begin
-        response = make_request(remote_file, request_fiber)
-        finalize_download(response.request, local_file, queue_item[:checksum_type], queue_item[:checksum])
+        cache_timestamp = nil
+        if @cache_dir
+          cache_filename = File.join(@cache_dir, remote_file)
+          cache_timestamp = get_cache_timestamp(cache_filename)
+        end
+
+        response = make_request(remote_file, request_fiber, cache_timestamp)
+
+        if (response.code == 304)
+          copy_from_cache(cache_filename, local_filename)
+        else
+          finalize_download(response.request, local_filename, checksum_type, checksum_value)
+        end
+
+        local_filenames << local_filename
       rescue RMT::Downloader::Exception => e
-        @logger.warn("× #{File.basename(local_file)} - #{e}")
+        raise(e) unless failed_downloads
+
+        @logger.warn("× #{File.basename(local_filename)} - #{e}")
+        failed_downloads << remote_file
       ensure
-        process_queue
+        process_queue(local_filenames, failed_downloads)
       end
     end
 
-    @hydra.queue(request_fiber.resume)
+    request_fiber.resume
+  end
+
+  def process_queue(local_filenames, failed_downloads = nil)
+    queue_item = @queue.shift
+    return unless queue_item
+
+    @hydra.queue(
+      create_fiber_request(
+        local_filenames,
+        queue_item.location,
+        checksum_type: queue_item.checksum_type,
+        checksum_value: queue_item.checksum,
+        failed_downloads: failed_downloads
+      )
+    )
   end
 
   def make_request(remote_file, request_fiber, cache_timestamp = nil)

--- a/lib/rmt/downloader.rb
+++ b/lib/rmt/downloader.rb
@@ -52,7 +52,7 @@ class RMT::Downloader
     @concurrency.times { process_queue(local_filenames, failed_downloads) }
 
     @hydra.run
-    local_filenames
+    failed_downloads
   end
 
   def self.make_local_path(root_path, remote_file)
@@ -99,7 +99,7 @@ class RMT::Downloader
         end
 
         local_filenames << local_filename
-      rescue RMT::Downloader::Exception => e
+      rescue RMT::Downloader::Exception, RMT::ChecksumVerifier::Exception => e
         raise(e) unless failed_downloads
 
         @logger.warn("× #{File.basename(local_filename)} - #{e}")

--- a/lib/rmt/http_request.rb
+++ b/lib/rmt/http_request.rb
@@ -19,6 +19,7 @@ class RMT::HttpRequest < Typhoeus::Request
     # Abort download if speed is below 512 bytes/sec for 120 sec, to prevent downloads from getting stuck
     options[:low_speed_limit] = 512
     options[:low_speed_time] = 120
+    options[:accept_encoding] = 'gzip'
   end
 
 end

--- a/lib/rmt/mirror.rb
+++ b/lib/rmt/mirror.rb
@@ -34,6 +34,7 @@ class RMT::Mirror
     @repository_dir = File.join(base_dir, '/suma/')
     @downloader.repository_url = URI.join(repository_url)
     @downloader.destination_dir = @repository_dir
+    @downloader.cache_dir = @repository_dir
 
     @logger.info _('Mirroring SUSE Manager product tree to %{dir}') % { dir: @repository_dir }
     @downloader.download('product_tree.json')

--- a/lib/rmt/mirror.rb
+++ b/lib/rmt/mirror.rb
@@ -134,11 +134,8 @@ class RMT::Mirror
       return
     end
 
-    File.open(directory_yast).each_line do |filename|
-      filename.strip!
-      next if filename == 'directory.yast'
-      @downloader.download(filename)
-    end
+    license_files = File.readlines(directory_yast).map(&:strip).reject { |item| item == 'directory.yast' }
+    @downloader.download_multi(license_files)
   rescue StandardError => e
     raise RMT::Mirror::Exception.new(_('Error while mirroring license: %{error}') % { error: e.message })
   end

--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jul  5 10:36:48 UTC 2019 - Ivan Kapelyukhin <ikapelyukhin@suse.com>
+
+- Version 2.3.1
+- Fix mirroring logic when errors are encountered (bsc#1140492)
+- Refactor RMT::Mirror to download metadata/licenses in parallel
+
+-------------------------------------------------------------------
 Mon Jul  1 11:36:11 UTC 2019 - Ivan Kapelyukhin <ikapelyukhin@suse.com>
 
 - Version 2.3.0

--- a/package/obs/rmt-server.spec
+++ b/package/obs/rmt-server.spec
@@ -25,7 +25,7 @@
 %define ruby_version %{rb_default_ruby_suffix}
 
 Name:           rmt-server
-Version:        2.3.0
+Version:        2.3.1
 Release:        0
 Summary:        Repository mirroring tool and registration proxy for SCC
 License:        GPL-2.0-or-later

--- a/spec/fixtures/vcr_cassettes/mirroring.yml
+++ b/spec/fixtures/vcr_cassettes/mirroring.yml
@@ -145,6 +145,40 @@ http_interactions:
   recorded_at: Mon, 04 Sep 2017 11:58:19 GMT
 - request:
     method: get
+    uri: http://localhost/dummy_repo/repodata/repomd.xml.asc
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RMT/0.1
+      Expect:
+      - ''
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - nginx/1.8.1
+      Date:
+      - Mon, 04 Sep 2017 11:58:19 GMT
+      Content-Type:
+      - text/html
+      Content-Length:
+      - '168'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: "<html>\r\n<head><title>404 Not Found</title></head>\r\n<body bgcolor=\"white\">\r\n<center><h1>404
+        Not Found</h1></center>\r\n<hr><center>nginx/1.8.1</center>\r\n</body>\r\n</html>\r\n"
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: http://localhost/dummy_repo/repodata/repomd.xml.asc
+  recorded_at: Mon, 04 Sep 2017 11:58:19 GMT
+- request:
+    method: get
     uri: http://localhost/dummy_repo/repodata/837fb50abc9680b1e11e050901a56721855a5e854e85e46ceaad2c6816297e69-filelists.xml.gz
     body:
       encoding: US-ASCII

--- a/spec/fixtures/vcr_cassettes/mirroring_with_auth_token.yml
+++ b/spec/fixtures/vcr_cassettes/mirroring_with_auth_token.yml
@@ -145,6 +145,40 @@ http_interactions:
   recorded_at: Mon, 04 Sep 2017 11:58:19 GMT
 - request:
     method: get
+    uri: http://localhost/dummy_repo/repodata/repomd.xml.asc?repo_auth_token
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RMT/0.1
+      Expect:
+      - ''
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - nginx/1.8.1
+      Date:
+      - Mon, 04 Sep 2017 11:58:19 GMT
+      Content-Type:
+      - text/html
+      Content-Length:
+      - '168'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: "<html>\r\n<head><title>404 Not Found</title></head>\r\n<body bgcolor=\"white\">\r\n<center><h1>404
+        Not Found</h1></center>\r\n<hr><center>nginx/1.8.1</center>\r\n</body>\r\n</html>\r\n"
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: http://localhost/dummy_repo/repodata/repomd.xml.asc?repo_auth_token
+  recorded_at: Mon, 04 Sep 2017 11:58:19 GMT
+- request:
+    method: get
     uri: http://localhost/dummy_repo/repodata/837fb50abc9680b1e11e050901a56721855a5e854e85e46ceaad2c6816297e69-filelists.xml.gz?repo_auth_token
     body:
       encoding: US-ASCII

--- a/spec/lib/rmt/downloader_spec.rb
+++ b/spec/lib/rmt/downloader_spec.rb
@@ -227,7 +227,7 @@ RSpec.describe RMT::Downloader do
         stub_request(:get, "http://example.com/#{file}").with(headers: headers)
           .to_return(status: 404, body: file, headers: {})
       end
-      downloader.download_multi(queue)
+      downloader.download_multi(queue, ignore_errors: true)
     end
 
     it 'requested all files' do

--- a/spec/lib/rmt/mirror_spec.rb
+++ b/spec/lib/rmt/mirror_spec.rb
@@ -272,12 +272,20 @@ RSpec.describe RMT::Mirror do
 
       context "when can't download data", vcr: { cassette_name: 'mirroring_product' } do
         it 'handles RMT::Downloader::Exception' do
-          expect_any_instance_of(RMT::Downloader).to receive(:download_multi).and_raise(RMT::Downloader::Exception, "418 - I'm a teapot")
+          allow_any_instance_of(RMT::Downloader).to receive(:download_multi).and_wrap_original do |klass, *args|
+            # raise the exception only for the RPMs
+            raise(RMT::Downloader::Exception, "418 - I'm a teapot") if args[0][0].location =~ /rpm$/
+            klass.call(*args)
+          end
           expect { rmt_mirror.mirror(mirror_params) }.to raise_error(RMT::Mirror::Exception, "Error while mirroring data: 418 - I'm a teapot")
         end
 
         it 'handles RMT::ChecksumVerifier::Exception' do
-          expect_any_instance_of(RMT::Downloader).to receive(:download_multi).and_raise(RMT::ChecksumVerifier::Exception, "Checksum doesn't match")
+          allow_any_instance_of(RMT::Downloader).to receive(:download_multi).and_wrap_original do |klass, *args|
+            # raise the exception only for the RPMs
+            raise(RMT::ChecksumVerifier::Exception, "Checksum doesn't match") if args[0][0].location =~ /rpm$/
+            klass.call(*args)
+          end
           expect { rmt_mirror.mirror(mirror_params) }.to raise_error(RMT::Mirror::Exception, "Error while mirroring data: Checksum doesn't match")
         end
       end

--- a/spec/lib/rmt/mirror_spec.rb
+++ b/spec/lib/rmt/mirror_spec.rb
@@ -272,21 +272,21 @@ RSpec.describe RMT::Mirror do
 
       context "when can't download data", vcr: { cassette_name: 'mirroring_product' } do
         it 'handles RMT::Downloader::Exception' do
-          allow_any_instance_of(RMT::Downloader).to receive(:download_multi).and_wrap_original do |klass, *args|
+          allow_any_instance_of(RMT::Downloader).to receive(:finalize_download).and_wrap_original do |klass, *args|
             # raise the exception only for the RPMs/DRPMs
-            raise(RMT::Downloader::Exception, "418 - I'm a teapot") if !args[0][0].is_a?(String) && args[0][0].location =~ /rpm$/
+            raise(RMT::Downloader::Exception, "418 - I'm a teapot") if args[1] =~ /rpm$/
             klass.call(*args)
           end
-          expect { rmt_mirror.mirror(mirror_params) }.to raise_error(RMT::Mirror::Exception, "Error while mirroring data: 418 - I'm a teapot")
+          expect { rmt_mirror.mirror(mirror_params) }.to raise_error(RMT::Mirror::Exception, 'Error while mirroring data: Failed to download 6 files')
         end
 
         it 'handles RMT::ChecksumVerifier::Exception' do
-          allow_any_instance_of(RMT::Downloader).to receive(:download_multi).and_wrap_original do |klass, *args|
+          allow_any_instance_of(RMT::Downloader).to receive(:finalize_download).and_wrap_original do |klass, *args|
             # raise the exception only for the RPMs/DRPMs
-            raise(RMT::ChecksumVerifier::Exception, "Checksum doesn't match") if !args[0][0].is_a?(String) && args[0][0].location =~ /rpm$/
+            raise(RMT::ChecksumVerifier::Exception, "Checksum doesn't match") if args[1] =~ /rpm$/
             klass.call(*args)
           end
-          expect { rmt_mirror.mirror(mirror_params) }.to raise_error(RMT::Mirror::Exception, "Error while mirroring data: Checksum doesn't match")
+          expect { rmt_mirror.mirror(mirror_params) }.to raise_error(RMT::Mirror::Exception, 'Error while mirroring data: Failed to download 6 files')
         end
       end
     end

--- a/spec/lib/rmt/mirror_spec.rb
+++ b/spec/lib/rmt/mirror_spec.rb
@@ -244,8 +244,8 @@ RSpec.describe RMT::Mirror do
 
       context "when can't download some of the license files" do
         before do
-          allow_any_instance_of(RMT::Downloader).to receive(:download).and_wrap_original do |klass, *args|
-            raise RMT::Downloader::Exception.new unless args[0] == 'directory.yast'
+          allow_any_instance_of(RMT::Downloader).to receive(:download_multi).and_wrap_original do |klass, *args|
+            raise RMT::Downloader::Exception.new if args[0][0] =~ /license/
             klass.call(*args)
           end
         end


### PR DESCRIPTION
Makes mirroring faster by downloading everything in parallel, especially when there are no pending .rpm/.drpm updates. On an RMT that didn't have any pending updates in 8 repos:

Before:
```
> time rmt-cli mirror
real	0m38.995s
```

After:
```
> time rmt-cli mirror
real	0m20.302s
```

### Changes

1. License files: there's a lot of license files which were downloaded sequentially, e.g.:
```
license.de.txt
license.es.txt
license.fr.txt
license.it.txt
license.ja.txt
license.ko.txt
license.pt_BR.txt
license.ru.txt
license.txt
license.zh_CN.txt
license.zh_TW.txt
```
2. Metadata files: there's also a lot of them, also downloaded sequentially, e.g.:
```
a5b9125090f4487980e3bf94d469ae3a3c5c6e47016b18a0ddf26e9a7106bce7-susedata.cs.xml.gz
a5b9125090f4487980e3bf94d469ae3a3c5c6e47016b18a0ddf26e9a7106bce7-susedata.de.xml.gz
a5b9125090f4487980e3bf94d469ae3a3c5c6e47016b18a0ddf26e9a7106bce7-susedata.es.xml.gz
a5b9125090f4487980e3bf94d469ae3a3c5c6e47016b18a0ddf26e9a7106bce7-susedata.fr.xml.gz
a5b9125090f4487980e3bf94d469ae3a3c5c6e47016b18a0ddf26e9a7106bce7-susedata.hu.xml.gz
a5b9125090f4487980e3bf94d469ae3a3c5c6e47016b18a0ddf26e9a7106bce7-susedata.it.xml.gz
a5b9125090f4487980e3bf94d469ae3a3c5c6e47016b18a0ddf26e9a7106bce7-susedata.ja.xml.gz
a5b9125090f4487980e3bf94d469ae3a3c5c6e47016b18a0ddf26e9a7106bce7-susedata.lt.xml.gz
a5b9125090f4487980e3bf94d469ae3a3c5c6e47016b18a0ddf26e9a7106bce7-susedata.nl.xml.gz
a5b9125090f4487980e3bf94d469ae3a3c5c6e47016b18a0ddf26e9a7106bce7-susedata.nn.xml.gz
a5b9125090f4487980e3bf94d469ae3a3c5c6e47016b18a0ddf26e9a7106bce7-susedata.ru.xml.gz
a5b9125090f4487980e3bf94d469ae3a3c5c6e47016b18a0ddf26e9a7106bce7-susedata.uk.xml.gz
```
3. Add `cache_dir` for SUMA product tree mirroring so that `If-Modified-Since` is added to the request (although currently that doesn't work on server side).
4. Enable `gzip` compression.
5. Refactor `RMT::Downloader` to use unified request creation method for both `download` and `download_multi`, documented how it works in the code.
6. Change mirroring logic to prevent swapping metadata if there were errors when downloading files (bsc#1140492).

