### PR TITLE
Update fuubar and yard gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,7 +126,7 @@ GEM
     ffaker (2.11.0)
     ffi (1.9.25)
     formatador (0.2.5)
-    fuubar (2.4.0)
+    fuubar (2.4.1)
       rspec-core (~> 3.0)
       ruby-progressbar (~> 1.4)
     gettext (3.2.9)
@@ -310,7 +310,7 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.19)
+    yard (0.9.20)
 
 PLATFORMS
   ruby
@@ -366,4 +366,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.16.2
+   1.17.3


### PR DESCRIPTION
* update fuubar, to 2.4.1 because 2.4.0 was removed from Rubygems
* update yard to 0.9.20 because of security alert GHSA-xfhh-rx56-rxcr

Because we don't use yard server (yard is a dependency of versionist) we do not need to create a changelog here.