### PR TITLE
Migration target display with RMT contains release stage

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -95,6 +95,10 @@ class Product < ApplicationRecord
     [identifier, version, arch].join('/')
   end
 
+  def friendly_name
+    [name, friendly_version, release_type, (arch if arch != 'unknown')].compact.join(' ')
+  end
+
   def change_repositories_mirroring!(conditions, mirroring_enabled)
     repos = repositories.where(conditions)
     repo_names = repos.pluck(:name)

--- a/db/migrate/20190717114051_remove_friendly_name_from_products.rb
+++ b/db/migrate/20190717114051_remove_friendly_name_from_products.rb
@@ -1,0 +1,5 @@
+class RemoveFriendlyNameFromProducts < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :products, :friendly_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190320120959) do
+ActiveRecord::Schema.define(version: 20190717114051) do
 
   create_table "activations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.bigint "service_id", null: false
@@ -56,7 +56,6 @@ ActiveRecord::Schema.define(version: 20190320120959) do
   create_table "products", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "name"
     t.text "description"
-    t.string "friendly_name"
     t.string "shortname"
     t.string "former_identifier"
     t.string "product_type"

--- a/lib/rmt.rb
+++ b/lib/rmt.rb
@@ -1,5 +1,5 @@
 module RMT
-  VERSION ||= '2.3.2'.freeze
+  VERSION ||= '2.3.3'.freeze
 
   DEFAULT_USER = '_rmt'.freeze
   DEFAULT_GROUP = 'nginx'.freeze

--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Jul 24 08:19:18 UTC 2019 - Leon Schroeder <lschroeder@suse.com>
+
+- Version 2.3.3
+- Removed release stage from names to be consistent with SCC (bsc#1136168)
+  * Generate friendly_name as needed
+  * Drops friendly_name column from database
+
+-------------------------------------------------------------------
 Thu Jul 18 08:13:11 UTC 2019 - Ivan Kapelyukhin <ikapelyukhin@suse.com>
 
 - Version 2.3.2

--- a/package/obs/rmt-server.spec
+++ b/package/obs/rmt-server.spec
@@ -25,7 +25,7 @@
 %define ruby_version %{rb_default_ruby_suffix}
 
 Name:           rmt-server
-Version:        2.3.2
+Version:        2.3.3
 Release:        0
 Summary:        Repository mirroring tool and registration proxy for SCC
 License:        GPL-2.0-or-later

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -4,7 +4,6 @@ FactoryGirl.define do
     sequence(:identifier) { |n| "product-#{n}" }
     sequence(:cpe) { |n| "cpe:/o:product:#{n}" }
     sequence(:shortname) { |n| "Product #{n}" }
-    sequence(:friendly_name) { |n| "Product #{n}" }
     sequence(:product_class) { |n| n.to_s.ljust(5, 'A') }
     free false
     product_type :base

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -128,6 +128,17 @@ RSpec.describe Product, type: :model do
     end
   end
 
+  describe '#friendly_name' do
+    subject { create(:product, product_attrs).friendly_name }
+
+    let(:product_attrs) { { name: 'Dummy Product', friendly_version: '99', release_type: 'Bar', arch: 'x86_64', release_stage: 'bazinga!' } }
+
+    it {
+      is_expected.to eq 'Dummy Product 99 Bar x86_64'
+      is_expected.not_to include 'bazinga!'
+    }
+  end
+
   describe '.modules_for_migration' do
     subject { described_class.modules_for_migration([root_product]) }
 

--- a/spec/serializers/v3/product_serializer_spec.rb
+++ b/spec/serializers/v3/product_serializer_spec.rb
@@ -35,6 +35,15 @@ describe V3::ProductSerializer do
     end
   end
 
+  describe '#friendly_name' do
+    subject { described_class.new(product).as_json[:friendly_name] }
+
+    let(:release_stage) { 'foo' }
+    let(:product) { create :product, release_stage: release_stage }
+
+    it { is_expected.not_to include(release_stage) }
+  end
+
   describe 'SLES extension tree' do
     subject(:serializer) { described_class.new(sles15, root_product: sles15, base_url: base_url) }
 


### PR DESCRIPTION
glue adds the release_stage to the friendly_name. This will now be removed while importing to rmt.