### PR TITLE
Improve nginx PubCloud configs

### DIFF
--- a/lib/rmt.rb
+++ b/lib/rmt.rb
@@ -1,5 +1,5 @@
 module RMT
-  VERSION ||= '2.3.1'.freeze
+  VERSION ||= '2.3.2'.freeze
 
   DEFAULT_USER = '_rmt'.freeze
   DEFAULT_GROUP = 'nginx'.freeze

--- a/package/files/nginx-pubcloud/nginx-https.conf
+++ b/package/files/nginx-pubcloud/nginx-https.conf
@@ -19,16 +19,29 @@ server {
     include /etc/nginx/rmt-auth*.d/auth-location*.conf;
 
     location / {
-        try_files $uri/index.html $uri.html $uri @rmt_app;
+        try_files $uri/index.html $uri.html $uri;
         autoindex off;
     }
 
     location /repo {
         autoindex on;
+        log_not_found off;
         include /etc/nginx/rmt-auth*.d/auth-handler*.conf;
     }
 
     location = /repo/repoindex.xml {
+        try_files $uri @rmt_app;
+    }
+
+    location /connect {
+        try_files $uri @rmt_app;
+    }
+
+    location /services {
+        try_files $uri @rmt_app;
+    }
+
+    location /api {
         try_files $uri @rmt_app;
     }
 
@@ -46,6 +59,11 @@ server {
 
     # An alias to RMT CA certificate, so that it can be downloaded to client machines.
     location /rmt.crt {
+        alias /etc/rmt/ssl/rmt-ca.crt;
+    }
+
+    # smt.crt is used by cloud-regionsrv-client < 8.1.1
+    location /smt.crt {
         alias /etc/rmt/ssl/rmt-ca.crt;
     }
 }

--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Thu Jul 18 08:13:11 UTC 2019 - Ivan Kapelyukhin <ikapelyukhin@suse.com>
+
+- Version 2.3.2
+- PubCloud nginx config improvements:
+  * Proxy only the known routes to the backend
+  * Disable error logging for /repo
+  * Serve smt.crt over HTTPS
+
+-------------------------------------------------------------------
 Fri Jul  5 10:36:48 UTC 2019 - Ivan Kapelyukhin <ikapelyukhin@suse.com>
 
 - Version 2.3.1

--- a/package/obs/rmt-server.spec
+++ b/package/obs/rmt-server.spec
@@ -25,7 +25,7 @@
 %define ruby_version %{rb_default_ruby_suffix}
 
 Name:           rmt-server
-Version:        2.3.1
+Version:        2.3.2
 Release:        0
 Summary:        Repository mirroring tool and registration proxy for SCC
 License:        GPL-2.0-or-later


### PR DESCRIPTION
* Proxy only the known routes (`/connect`, `/service`, `/api` and `/repo/repoindex.xml`) to the backend. Currently everything gets proxied, so there's a lot of clutter in `journald` when a scanner hits a bunch of non-existent URLs, e.g.:

```
Jul 16 01:33:30 rmt-xxxxxxxxxxxxxx rails[1241]: FATAL: ActionController::RoutingError (No route matches [GET] "/moin_static182/modern/css/print.css"):
Jul 16 01:33:30 rmt-xxxxxxxxxxxxxx rails[1241]: FATAL:
Jul 16 01:33:30 rmt-xxxxxxxxxxxxxx rails[1241]: FATAL: actionpack (5.1.6.2) lib/action_dispatch/middleware/debug_exceptions.rb:63:in `call'
```

* Disable logging of not found errors for `/repo` with `log_not_found off`. Zypper doesn't know the format of the repo, so it always tries to get `media.1/media`, which creates a lot of clutter in nginx's error log, e.g.:

```
2019/07/17 13:38:44 [error] 10305#10305: *468649 open() "/usr/share/rmt/public/repo/SUSE/Products/SLE-SDK/12-SP3/x86_64/product/media.1/media" failed (2: No such file or directory) while sending to client, client: xxx.xxx.xxx.xxx, server: rmt, request: "GET /repo/SUSE/Products/SLE-SDK/12-SP3/x86_64/product/media.1/media HTTP/1.1"
2019/07/17 13:38:46 [error] 10305#10305: *468681 open() "/usr/share/rmt/public/repo/SUSE/Products/SLE-SERVER/12-SP3/x86_64/product/media.1/media" failed (2: No such file or directory) while sending to client, client: xxx.xxx.xxx.xxx, server: rmt, request: "GET /repo/SUSE/Products/SLE-SERVER/12-SP3/x86_64/product/media.1/media HTTP/1.1"
2019/07/17 13:38:47 [error] 10305#10305: *468704 open() "/usr/share/rmt/public/repo/SUSE/Updates/SLE-SERVER/12-SP3/x86_64/update/media.1/media" failed (2: No such file or directory) while sending to client, client: xxx.xxx.xxx.xxx, server: rmt, request: "GET /repo/SUSE/Updates/SLE-SERVER/12-SP3/x86_64/update/media.1/media HTTP/1.1"
```

* Serve `smt.crt` over HTTPS -- I've seen something requesting it in the logs, probably older versions of `cloud-regionsrv-client`.