### PR TITLE
Fix plain HTTP PubCloud config

### DIFF
--- a/package/files/nginx-pubcloud/nginx-http.conf
+++ b/package/files/nginx-pubcloud/nginx-http.conf
@@ -23,11 +23,36 @@ server {
 
     location /repo {
         autoindex on;
+        log_not_found off;
         include /etc/nginx/rmt-auth*.d/auth-handler*.conf;
     }
 
     location = /repo/repoindex.xml {
         try_files $uri @rmt_app;
+    }
+
+    location /connect {
+        try_files $uri @rmt_app;
+    }
+
+    location /services {
+        try_files $uri @rmt_app;
+    }
+
+    location /api {
+        try_files $uri @rmt_app;
+    }
+
+    location @rmt_app {
+        proxy_pass          http://rmt;
+        proxy_redirect      off;
+        proxy_read_timeout  600;
+
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Ssl on;
+        proxy_set_header X-Real-IP $remote_addr;
     }
 
     # Aliases to RMT CA certificate

--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -1,8 +1,9 @@
 -------------------------------------------------------------------
-Wed Jul 24 11:16:47 UTC 2019 - Ivan Kapelyukhin <ikapelyukhin@suse.com>
+Tue Jul 30 15:57:29 UTC 2019 - Ivan Kapelyukhin <ikapelyukhin@suse.com>
 
 - Version 2.3.4
 - Clean up download queue on metadata download errors (bsc#1142641)
+- Fix plain HTTP PubCloud config
 
 -------------------------------------------------------------------
 Wed Jul 24 08:19:18 UTC 2019 - Leon Schroeder <lschroeder@suse.com>


### PR DESCRIPTION
Redirect to HTTPS is off and `@rmt_app` location is missing.