### PR TITLE
convert empty release type to nil.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ package/obs/*.tar.bz2
 package/obs/.osc
 package/obs/rmt-cli.8.gz
 package/obs/_link
+package/systemsmanagement:SCC:RMT
 
 vendor/
 coverage/

--- a/PACKAGE.md
+++ b/PACKAGE.md
@@ -20,15 +20,15 @@ Note: Never push changes to the internal build service `ibs://Devel:SCC:RMT`!
       * Alternatively, if an OBS working copy is already checked out, update the working copy by running `osc up`
 2. Run `make dist` in your RMT working directory to build a tarball.
 3. Copy the files from the `package/obs` directory to the OBS working directory.
-4. Build the package with osc:
+4. Examine the changes by running `osc status` and `osc diff`.
+5. Stage the changes by running `osc addremove`.
+6. Build the package with osc:
 
     `osc build <repository> <arch> --no-verify`
 
     The list of all build targets and architectures that are configured for the project can be obtained by running `osc repos`.
 
-5. Examine the changes by running `osc status` and `osc diff`.
-6. Stage the changes by running `osc addremove`.
-7. Commit the changes into OBS by running `osc ci`.
+7. After the code is reviewed + merged in the git repository: Commit the changes into OBS by running `osc ci`.
 
 #### Tag and Release the New Version on Github
 

--- a/app/controllers/api/connect/v4/repositories/installer_controller.rb
+++ b/app/controllers/api/connect/v4/repositories/installer_controller.rb
@@ -23,6 +23,7 @@ class Api::Connect::V4::Repositories::InstallerController < Api::Connect::BaseCo
 
   def product_params
     hash = params.permit(:identifier, :version, :arch, :release_type)
+    hash[:release_type] = nil if hash[:release_type].blank?
     hash[:version] = Product.clean_up_version(hash[:version])
     hash.to_h.symbolize_keys
   end

--- a/lib/rmt.rb
+++ b/lib/rmt.rb
@@ -1,5 +1,5 @@
 module RMT
-  VERSION ||= '2.3.4'.freeze
+  VERSION ||= '2.3.5'.freeze
 
   DEFAULT_USER = '_rmt'.freeze
   DEFAULT_GROUP = 'nginx'.freeze

--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Aug  7 12:43:02 UTC 2019 - Thomas Schmidt <tschmidt@suse.com>
+
+- Version 2.3.5
+- Fix RMT installer_repo call for empty release_type parameter (bsc#1136178)
+
+-------------------------------------------------------------------
 Tue Jul 30 15:57:29 UTC 2019 - Ivan Kapelyukhin <ikapelyukhin@suse.com>
 
 - Version 2.3.4

--- a/package/obs/rmt-server.spec
+++ b/package/obs/rmt-server.spec
@@ -25,7 +25,7 @@
 %define ruby_version %{rb_default_ruby_suffix}
 
 Name:           rmt-server
-Version:        2.3.4
+Version:        2.3.5
 Release:        0
 Summary:        Repository mirroring tool and registration proxy for SCC
 License:        GPL-2.0-or-later

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -8,7 +8,7 @@ FactoryGirl.define do
     free false
     product_type :base
     sequence(:description) { FFaker::Lorem.sentence }
-    release_type ''
+    release_type nil
     version 42
     arch 'x86_64'
     release_stage 'released'

--- a/spec/lib/rmt/cli/products_spec.rb
+++ b/spec/lib/rmt/cli/products_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe RMT::CLI::Products do
         end
 
         it 'lists all products' do
-          expect { described_class.start(argv) }.to output(/.*#{expected_output}.*/).to_stdout.and output('').to_stderr
+          expect { described_class.start(argv) }.to output(/#{expected_output}/).to_stdout.and output('').to_stderr
         end
 
         it 'does not mention --all option' do

--- a/spec/requests/api/connect/v4/repositories/installer_controller_spec.rb
+++ b/spec/requests/api/connect/v4/repositories/installer_controller_spec.rb
@@ -49,6 +49,16 @@ RSpec.describe Api::Connect::V4::Repositories::InstallerController do
       its(:code) { is_expected.to eq('200') }
     end
 
+    context 'with known product and empty string as release_type' do
+      let(:product) { FactoryGirl.create(:product, :with_not_mirrored_repositories) }
+      let(:params) { { identifier: product.identifier, version: product.version, arch: product.arch, release_type: '' } }
+
+      before { get url, params: params }
+
+      its(:body) { is_expected.to eq '[]' }
+      its(:code) { is_expected.to eq('200') }
+    end
+
     describe 'response with "-" in product version' do
       let(:product) { FactoryGirl.create(:product, :with_not_mirrored_repositories, version: '24.0') }
       let(:params) { { identifier: product.identifier, version: '24.0-0', arch: product.arch } }


### PR DESCRIPTION
Some older versions of Yast in SLE12 seem to send an empty string for release_type. This
makes RMT fail with 'no product found'. This commit aligns RMT with the behavior of SCC,
and fixes the usage with SLE12 Yast.