### PR TITLE
Create rmt-client-setup-res

### DIFF
--- a/public/tools/rmt-client-setup-res
+++ b/public/tools/rmt-client-setup-res
@@ -1,0 +1,44 @@
+#! /bin/sh
+
+function usage()
+{
+    cat << EOT >&2
+
+   Usage: $0 <registration URL>
+   Usage: $0 <hostname of the RMT server>
+   
+   Example: $NAME http://rmt.example.com
+   Example: $NAME rmt.example.com
+ 
+EOT
+
+    exit 1
+}
+
+case "$1" in
+    http://*) REGURL=$1;
+              RMTNAME=${REGURL:7};;
+    https://*) RMTNAME=${REGURL:8};
+               REGURL="http://$RMTNAME";;
+    "") echo "Missing registration URL. Abort";
+        usage;;
+    -h|--help) usage;;
+    *) REGURL="http://$1"
+       RMTNAME=$1;;
+esac
+
+
+if [ `id -u` != 0 ]; then
+    echo "You must be root. Abort."
+    exit 1;
+fi
+
+rpm --import ${REGURL}/repo/SUSE/Updates/RES/8/x86_64/update/repodata/repomd.xml.key
+dnf config-manager --add-repo ${REGURL}/repo/SUSE/Updates/RES/8/x86_64/update
+dnf config-manager --add-repo ${REGURL}/repo/SUSE/Updates/RES-AS/8/x86_64/update
+dnf install SUSEConnect sles_es-release librepo-1.9.2
+dnf config-manager --set-disabled "${RMTNAME}_repo_SUSE_Updates_RES_8_x86_64_update"
+dnf config-manager --set-disabled "${RMTNAME}_repo_SUSE_Updates_RES-AS_8_x86_64_update"
+
+curl $REGURL/tools/rmt-client-setup --output rmt-client-setup
+sh rmt-client-setup https://$RMTNAME


### PR DESCRIPTION
rmt-client-setup script asssumes SUSEConnect and zypper are already installed on the system. This is not true for RHEL8, so this script installs there packages and then downloads and runs rmt-client-setup script.