### PR TITLE
fix missing metadata signature for custom repos

### DIFF
--- a/lib/rmt/mirror.rb
+++ b/lib/rmt/mirror.rb
@@ -86,8 +86,8 @@ class RMT::Mirror
     local_filename = @downloader.download('repodata/repomd.xml')
 
     begin
-      key_file       = @downloader.download('repodata/repomd.xml.key')
       signature_file = @downloader.download('repodata/repomd.xml.asc')
+      key_file       = @downloader.download('repodata/repomd.xml.key')
 
       RMT::GPG.new(
         metadata_file: local_filename, key_file: key_file, signature_file: signature_file, logger: @logger


### PR DESCRIPTION
Change download order for repo metadata files (start with signature, then key) to prevent breaking of custom repostories which don't provide a repomd.xml.key .  Example repository: packages.icinga.com

the existing code tries to download repomd.xml.key from the repository ; if no such file is found, the signature file repomd.xml.asc is not mirrored, thus the whole repo mirror is useless: package management tools can't verify the metadata, even if they have the signing key in their keyring.