### PR TITLE
PubCloud: allow access to SLES 12 SP1 repos when SLES 11 was activated

### DIFF
--- a/engines/strict_authentication/app/controllers/strict_authentication/authentication_controller.rb
+++ b/engines/strict_authentication/app/controllers/strict_authentication/authentication_controller.rb
@@ -20,6 +20,10 @@ module StrictAuthentication
 
       path = '/' + path.gsub(/^#{RMT::DEFAULT_MIRROR_URL_PREFIX}/, '')
 
+      # Allow access to SLES 12 and 12-SP1 repos for systems migrating from SLES 11
+      has_sles11 = @system.products.where(identifier: 'SUSE_SLES').first
+      return true if (has_sles11 && (path =~ %r{/12/} || path =~ %r{/12-SP1/}))
+
       @system.repositories.pluck(:local_path).each do |allowed_path|
         return true if path =~ /^#{allowed_path}/
       end

--- a/engines/strict_authentication/spec/requests/strict_authentication/authentication_controller_spec.rb
+++ b/engines/strict_authentication/spec/requests/strict_authentication/authentication_controller_spec.rb
@@ -45,6 +45,56 @@ module StrictAuthentication
 
           its(:code) { is_expected.to eq '200' }
         end
+
+        context 'when accessing SLES12SP1 repos and SLES 11 is activated' do
+          let(:system) { FactoryGirl.create(:system, :with_activated_product, product: product) }
+          let(:product) do
+            FactoryGirl.create(
+              :product, :with_mirrored_repositories,
+              identifier: 'SUSE_SLES', version: '11.4', arch: 'x86_64'
+            )
+          end
+
+          context 'when requested path is not activated' do
+            let(:requested_uri) { '/repo/SUSE/Products/SLE-Product-SLES/15/x86_64/product' }
+
+            its(:code) { is_expected.to eq '403' }
+          end
+
+          context 'when requested path is version 12' do
+            let(:requested_uri) { '/repo/SUSE/Updates/SLE-Module-Adv-Systems-Management/12/x86_64/update' }
+
+            its(:code) { is_expected.to eq '200' }
+          end
+
+          context 'when requested path is version 12.1' do
+            let(:requested_uri) { '/repo/SUSE/Products/SLE-SERVER/12-SP1/x86_64/product' }
+
+            its(:code) { is_expected.to eq '200' }
+          end
+        end
+
+        context 'when accessing SLES12SP1 repos and SLES 11 is not activated' do
+          let(:system) { FactoryGirl.create(:system, :with_activated_product, product: product) }
+          let(:product) do
+            FactoryGirl.create(
+              :product, :with_mirrored_repositories,
+              identifier: 'SLES', version: '15', arch: 'x86_64'
+            )
+          end
+
+          context 'when requested path is version 12' do
+            let(:requested_uri) { '/repo/SUSE/Updates/SLE-Module-Adv-Systems-Management/12/x86_64/update' }
+
+            its(:code) { is_expected.to eq '403' }
+          end
+
+          context 'when requested path is version 12.1' do
+            let(:requested_uri) { '/repo/SUSE/Products/SLE-SERVER/12-SP1/x86_64/product' }
+
+            its(:code) { is_expected.to eq '403' }
+          end
+        end
       end
     end
   end

--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -1,8 +1,9 @@
 -------------------------------------------------------------------
-Wed Oct 23 07:17:56 UTC 2019 - Ivan Kapelyukhin <ikapelyukhin@suse.com>
+Wed Nov 13 13:39:20 UTC 2019 - Ivan Kapelyukhin <ikapelyukhin@suse.com>
 
 - Version 2.4.3
-- Relax zypper auth plugin checks; produce detailed logs
+- rmt-server-pubcloud: Relax zypper auth plugin checks; produce detailed logs
+- rmt-server-pubcloud: Allow access to SLES 12 SP1 repos when SLES 11 was activated
 
 -------------------------------------------------------------------
 Mon Sep 16 11:00:45 UTC 2019 - José D. Gómez R. <jgomez@suse.com>


### PR DESCRIPTION
Allows access to repos that were not yet activated in order to allow for SLES11 systems to be migrated.