### PR TITLE
Escape path in regex

### DIFF
--- a/engines/strict_authentication/app/controllers/strict_authentication/authentication_controller.rb
+++ b/engines/strict_authentication/app/controllers/strict_authentication/authentication_controller.rb
@@ -25,7 +25,7 @@ module StrictAuthentication
       return true if (has_sles11 && (path =~ %r{/12/} || path =~ %r{/12-SP1/}))
 
       @system.repositories.pluck(:local_path).each do |allowed_path|
-        return true if path =~ /^#{allowed_path}/
+        return true if path =~ /^#{Regexp.escape(allowed_path)}/
       end
 
       false

--- a/engines/strict_authentication/spec/requests/strict_authentication/authentication_controller_spec.rb
+++ b/engines/strict_authentication/spec/requests/strict_authentication/authentication_controller_spec.rb
@@ -46,6 +46,26 @@ module StrictAuthentication
           its(:code) { is_expected.to eq '200' }
         end
 
+        context 'when accessing product with repos with special characters' do
+          let(:product) do
+            product = FactoryGirl.create(:product, :with_service)
+            product.service.repositories << repository
+            product
+          end
+
+          let(:repository) do
+            FactoryGirl.create(
+              :repository,
+              external_url: 'https://updates.suse.com/$path/*with/.funky/(characters)/'
+            )
+          end
+
+          let(:system) { FactoryGirl.create(:system, :with_activated_product, product: product) }
+          let(:requested_uri) { '/repo/$path/*with/.funky/(characters)/repodata/repomd.xml' }
+
+          its(:code) { is_expected.to eq '200' }
+        end
+
         context 'when accessing SLES12SP1 repos and SLES 11 is activated' do
           let(:system) { FactoryGirl.create(:system, :with_activated_product, product: product) }
           let(:product) do

--- a/lib/rmt.rb
+++ b/lib/rmt.rb
@@ -1,5 +1,5 @@
 module RMT
-  VERSION ||= '2.4.4'.freeze
+  VERSION ||= '2.4.5'.freeze
 
   DEFAULT_USER = '_rmt'.freeze
   DEFAULT_GROUP = 'nginx'.freeze

--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Dec 10 11:39:24 UTC 2019 - Ivan Kapelyukhin <ikapelyukhin@suse.com>
+
+- Version 2.4.5
+- rmt-server-pubcloud: escape paths in regex
+
+-------------------------------------------------------------------
 Mon Dec  9 15:37:43 UTC 2019 - Ivan Kapelyukhin <ikapelyukhin@suse.com>
 
 - Version 2.4.4

--- a/package/obs/rmt-server.spec
+++ b/package/obs/rmt-server.spec
@@ -25,7 +25,7 @@
 %define ruby_version %{rb_default_ruby_suffix}
 
 Name:           rmt-server
-Version:        2.4.4
+Version:        2.4.5
 Release:        0
 Summary:        Repository mirroring tool and registration proxy for SCC
 License:        GPL-2.0-or-later


### PR DESCRIPTION
`/repo/$RCE/SLES11-SP4-Pool/sle-11-x86_64/` -- SLES 9 strikes back (dollar sign breaks the regex) :man_facepalming: 