### PR TITLE
Add: bash-completion for 'systems' subcommand

### DIFF
--- a/package/files/rmt-cli_bash-completion.sh
+++ b/package/files/rmt-cli_bash-completion.sh
@@ -14,14 +14,14 @@ _rmt-cli()
 
 	current_word=${COMP_WORDS[COMP_CWORD]}
 	subcommand=${COMP_WORDS[1]}
-	options="sync products repos mirror import export version help"
+	options="sync products repos systems mirror import export version help"
 	depth=1
 
 	if [[ ${subcommand} =~ ^(sync|mirror|version)$ ]] ; then
 		: # these subcommands can't currently be completed further
 	elif _rmt-cli-default-completion "${options[@]}" $depth ; then
 		:
-	elif [[ ${subcommand} =~ ^(product|products|repo|repos|import|export)$ ]] ; then
+	elif [[ ${subcommand} =~ ^(product|products|repo|repos|systems|import|export)$ ]] ; then
 		((depth++))
 		_rmt-cli_$subcommand $depth
 	fi
@@ -84,6 +84,22 @@ _rmt-cli_repos()
 		_rmt-cli_repos_custom $depth
 	elif [[ ${current_word} == -* && ${COMP_WORDS[2]} =~ ^(list|ls)$ ]] ; then
 		COMPREPLY=( $(compgen -W "${flags}" -- ${current_word}) )
+	fi
+}
+
+_rmt-cli_systems()
+{
+	local current_word options flags depth
+
+	current_word=${COMP_WORDS[COMP_CWORD]}
+	options="list help scc-sync"
+	flags="--all --csv --limit="
+	depth=$1
+	if _rmt-cli-default-completion "${options[@]}" $depth ; then
+		:
+	elif [[ ${current_word} == -* && ${COMP_WORDS[2]} =~ ^(list|ls)$ ]] ; then
+		COMPREPLY=( $(compgen -W "${flags}" -- ${current_word}) )
+		[[ $COMPREPLY == "--limit=" ]] && compopt -o nospace
 	fi
 }
 

--- a/package/files/rmt-cli_bash-completion.sh
+++ b/package/files/rmt-cli_bash-completion.sh
@@ -21,7 +21,7 @@ _rmt-cli()
 		: # these subcommands can't currently be completed further
 	elif _rmt-cli-default-completion "${options[@]}" $depth ; then
 		:
-	elif [[ ${subcommand} =~ ^(product|products|repo|repos|systems|import|export)$ ]] ; then
+	elif [[ ${subcommand} =~ ^(products|repos|systems|import|export)$ ]] ; then
 		((depth++))
 		_rmt-cli_$subcommand $depth
 	fi
@@ -144,17 +144,6 @@ _rmt-cli_export()
 	elif [[ ${COMP_CWORD} == 3 ]] ; then
 		COMPREPLY=( $(compgen -f ${current_word}) )
 	fi
-}
-
-# alias functions:
-_rmt-cli_repo()
-{
-	_rmt-cli_repos
-}
-
-_rmt-cli_product()
-{
-	_rmt-cli_products
 }
 
 complete -F _rmt-cli rmt-cli


### PR DESCRIPTION
This adds the following completions:
`rmt-cli system`
`rmt-cli systems`
`rmt-cli systems help`
`rmt-cli systems list`
including flags: `--csv, --all, --limit=`
`rmt-cli systems scc-sync`

This fixes #513.

This also adds a missing parameter to the aliased function calls, which
prevented aliases to be completed correctly.

Have I missed any sub command? My installation doesn't have `scc-sync`yet, for example.
Please also test and review :)