### PR TITLE
Fix offline migration

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -16,6 +16,9 @@ class Product < ApplicationRecord
            class_name: 'ProductsExtensionsAssociation',
            foreign_key: :product_id
 
+  has_many :root_products, -> { distinct },
+           through: :product_extensions_associations
+
   has_many :extensions, -> { distinct },
     through: :extension_products_associations,
     source: :extension do
@@ -111,8 +114,8 @@ class Product < ApplicationRecord
     product_extensions_associations.where(recommended: true).where(root_product: root_product).present?
   end
 
-  def available_for
-    product_extensions_associations.includes(:root_product).map(&:root_product).uniq
+  def available_for?(product)
+    root_products.include?(product) || product == self
   end
 
   def self.modules_for_migration(root_product_ids)

--- a/lib/rmt.rb
+++ b/lib/rmt.rb
@@ -1,5 +1,5 @@
 module RMT
-  VERSION ||= '2.5.2'.freeze
+  VERSION ||= '2.5.3'.freeze
 
   DEFAULT_USER = '_rmt'.freeze
   DEFAULT_GROUP = 'nginx'.freeze

--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -1,8 +1,15 @@
 -------------------------------------------------------------------
 Tue Jan 28 14:00:37 UTC 2020 - Felix Schnizlein <fschnizlein@suse.com>
 
-- Version 2.5.2
+- Version 2.5.3
 - low_speed_time and low_speed_limit can be configured
+
+-------------------------------------------------------------------
+Tue Jan 21 13:05:15 UTC 2020 - Jens Mammen <jmammen@suse.com>
+
+- Version 2.5.2
+- Fix offline migration (CVE-2019-18904: bsc#1160922) 
+- Ensure download of signature file from custom repositories
 
 -------------------------------------------------------------------
 Fri Jan 10 13:47:22 UTC 2020 - Ivan Kapelyukhin <ikapelyukhin@suse.com>

--- a/package/obs/rmt-server.spec
+++ b/package/obs/rmt-server.spec
@@ -25,7 +25,7 @@
 %define ruby_version %{rb_default_ruby_suffix}
 
 Name:           rmt-server
-Version:        2.5.2
+Version:        2.5.3
 Release:        0
 Summary:        Repository mirroring tool and registration proxy for SCC
 License:        GPL-2.0-or-later


### PR DESCRIPTION
- fix offline migration
- Add changelog for signature file download for custom repositories

Resolving version bump conflict. Increased version of https://github.com/SUSE/rmt/pull/519 to 2.5.3 instead of 2.5.2.

Included changes from rmt_embargo.