### PR TITLE
Fix subscription kinds

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Supported Ruby versions are 2.5.0 and newer.
 * Grant the just configured database user access to your database. The following command will grant access to the default user `rmt` with password `rmt` (run it as root):
 
 ```
-mysql -u root <<EOFF
+mysql -u root -p <<EOFF
 GRANT ALL PRIVILEGES ON \`rmt%\`.* TO rmt@localhost IDENTIFIED BY 'rmt';
 FLUSH PRIVILEGES;
 EOFF

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ After installation configure your RMT instance:
     * Create a MySQL/MariaDB user with the following command:
     ```
     mysql -u root -p <<EOFF
-    GRANT ALL PRIVILEGES ON \`rmt\`.* TO rmt@localhost IDENTIFIED BY 'rmt';
+    GRANT ALL PRIVILEGES ON \`rmt%\`.* TO rmt@localhost IDENTIFIED BY 'rmt';
     FLUSH PRIVILEGES;
     EOFF
     ```

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -1,7 +1,13 @@
 class Subscription < ApplicationRecord
 
   # we avoid to name enum key 'test' because it will override existing private method
-  enum kind: { is_test: 'test', full: 'full', evaluation: 'evaluation', oem: 'oem', provisional: 'provisional', internal: 'internal' }
+  # The different subscription types are documented in:
+  # https://github.com/SUSE/scc-docs/blob/master/projects/scc/architecture/business-logic/subscription-types.md
+  # we avoid to name enum key 'test' because it will override existing private method
+  enum kind: {
+    is_test: 'test', full: 'full', evaluation: 'evaluation', oem: 'oem', internal: 'internal', partner: 'partner'
+  }
+
   enum status: { expired: 'EXPIRED', active: 'ACTIVE', notactivated: 'NOTACTIVATED' }
 
   validates :regcode, presence: true

--- a/db/migrate/20200403075822_migrate_provisional_to_evaluation.rb
+++ b/db/migrate/20200403075822_migrate_provisional_to_evaluation.rb
@@ -1,0 +1,5 @@
+class MigrateProvisionalToEvaluation < ActiveRecord::Migration[5.1]
+  def change
+    Subscription.where(kind: 'provisional').update_all(kind: 'evaluation')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200205123840) do
+ActiveRecord::Schema.define(version: 20200403075822) do
 
   create_table "activations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.bigint "service_id", null: false

--- a/lib/rmt.rb
+++ b/lib/rmt.rb
@@ -1,5 +1,5 @@
 module RMT
-  VERSION ||= '2.5.5'.freeze
+  VERSION ||= '2.5.6'.freeze
 
   DEFAULT_USER = '_rmt'.freeze
   DEFAULT_GROUP = 'nginx'.freeze

--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Apr  3 09:29:07 UTC 2020 - Thomas Schmidt <tschmidt@suse.com>
+
+- Version 2.5.6
+- Align supported subscription types with SCC:
+  'test', 'full', 'evaluation', 'oem', 'internal', 'partner'
+  (bsc#1168554)
+
+-------------------------------------------------------------------
 Wed Feb  5 12:55:32 UTC 2020 - Felix Schnizlein <fschnizlein@suse.com>
 
 - Version 2.5.5

--- a/package/obs/rmt-server.spec
+++ b/package/obs/rmt-server.spec
@@ -25,7 +25,7 @@
 %define ruby_version %{rb_default_ruby_suffix}
 
 Name:           rmt-server
-Version:        2.5.5
+Version:        2.5.6
 Release:        0
 Summary:        Repository mirroring tool and registration proxy for SCC
 License:        GPL-2.0-or-later

--- a/package/obs/rmt-server.spec
+++ b/package/obs/rmt-server.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package rmt-server
 #
-# Copyright (c) 2019 SUSE LINUX GmbH, Nuernberg, Germany.
+# Copyright (c) 2020 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -12,7 +12,7 @@
 # license that conforms to the Open Source Definition (Version 1.9)
 # published by the Open Source Initiative.
 
-# Please submit bugfixes or comments via http://bugs.opensuse.org/
+# Please submit bugfixes or comments via https://bugs.opensuse.org/
 #
 
 
@@ -35,6 +35,9 @@ Source0:        %{name}-%{version}.tar.bz2
 Source1:        rmt-server-rpmlintrc
 Source2:        rmt.conf
 Source3:        rmt-cli.8.gz
+BuildRequires:  %{ruby_version}
+BuildRequires:  %{ruby_version}-devel
+BuildRequires:  %{rubygem bundler}
 BuildRequires:  fdupes
 BuildRequires:  gcc
 BuildRequires:  libcurl-devel
@@ -42,13 +45,10 @@ BuildRequires:  libffi-devel
 BuildRequires:  libmysqlclient-devel
 BuildRequires:  libxml2-devel
 BuildRequires:  libxslt-devel
-BuildRequires:  %{ruby_version}
-BuildRequires:  %{ruby_version}-devel
-BuildRequires:  %{rubygem bundler}
 BuildRequires:  systemd
+Requires:       gpg2
 Requires:       mariadb
 Requires:       nginx
-Requires:       gpg2
 Requires:       rmt-server-configuration
 Requires(post): %{ruby_version}
 Requires(post): %{rubygem bundler}
@@ -82,7 +82,7 @@ Provides:       rmt-server-configuration
 Conflicts:      rmt-server-configuration
 
 %description config
-Summary:        Default nginx configuration for RMT.
+Default nginx configuration for RMT.
 
 %package pubcloud
 Summary:        RMT pubcloud extensions
@@ -100,6 +100,7 @@ cp -p %{SOURCE2} .
 
 %setup -q
 sed -i '1 s|/usr/bin/env\ ruby|/usr/bin/ruby.%{ruby_version}|' bin/*
+
 %build
 bundle.%{ruby_version} install %{?jobs:--jobs %{jobs}} --without test development --deployment --standalone
 


### PR DESCRIPTION
This pull request  aligns the subscriptions kinds with scc.suse.com. SCC has removed the `provisional` type and added a new `partner` type for partner subscriptions.

belongs to:  https://trello.com/c/t9Hb2nLE/1291-sh-align-subscription-types-kinds-with-scc