### PR TITLE
Lockfile overhaul

### DIFF
--- a/features/lockfile_spec.rb
+++ b/features/lockfile_spec.rb
@@ -7,13 +7,16 @@ describe 'rmt-cli' do
     `/usr/bin/rmt-cli sync > /dev/null &`
   end
   # kill running process to let further specs pass
-  after { `kill -9 $(cat /tmp/rmt.lock)` }
+  after { `pkill -9 -f rmt-cli` }
 
   describe 'lockfile' do
     command '/usr/bin/rmt-cli sync', allow_error: true
-    its(:stderr) { is_expected.to eq("Process is locked by the application with \
-pid #{`pgrep rmt-cli`.strip}. Close this application or wait for it \
-to finish before trying again.\n") }
+    its(:stderr) do
+      is_expected.to eq(
+        "Another instance of this command is already running. Terminate" \
+        " the other instance or wait for it to finish.\n"
+      )
+    end
 
     its(:exitstatus) { is_expected.to eq 1 }
   end

--- a/lib/rmt.rb
+++ b/lib/rmt.rb
@@ -1,5 +1,5 @@
 module RMT
-  VERSION ||= '2.5.6'.freeze
+  VERSION ||= '2.5.7'.freeze
 
   DEFAULT_USER = '_rmt'.freeze
   DEFAULT_GROUP = 'nginx'.freeze

--- a/lib/rmt/cli/mirror.rb
+++ b/lib/rmt/cli/mirror.rb
@@ -1,7 +1,7 @@
 class RMT::CLI::Mirror < RMT::CLI::Base
   desc 'all', _('Mirror all enabled repositories')
   def all
-    RMT::Lockfile.lock do
+    RMT::Lockfile.lock('mirror') do
       logger = RMT::Logger.new(STDOUT)
       mirror = RMT::Mirror.new(logger: logger, mirror_src: RMT::Config.mirror_src_files?)
 
@@ -32,7 +32,7 @@ class RMT::CLI::Mirror < RMT::CLI::Base
 
   desc 'repository IDS', _('Mirror enabled repositories with given repository IDs')
   def repository(*ids)
-    RMT::Lockfile.lock do
+    RMT::Lockfile.lock('mirror') do
       logger = RMT::Logger.new(STDOUT)
       mirror = RMT::Mirror.new(logger: logger, mirror_src: RMT::Config.mirror_src_files?)
 
@@ -58,7 +58,7 @@ class RMT::CLI::Mirror < RMT::CLI::Base
 
   desc 'product IDS', _('Mirror enabled repositories for a product with given product IDs')
   def product(*targets)
-    RMT::Lockfile.lock do
+    RMT::Lockfile.lock('mirror') do
       logger = RMT::Logger.new(STDOUT)
       mirror = RMT::Mirror.new(logger: logger, mirror_src: RMT::Config.mirror_src_files?)
 

--- a/lib/rmt/http_request.rb
+++ b/lib/rmt/http_request.rb
@@ -16,7 +16,7 @@ class RMT::HttpRequest < Typhoeus::Request
       options[:proxyuserpwd] = "#{Settings.http_client.proxy_user}:#{Settings.http_client.proxy_password}"
     end
 
-    # Abort download if speed is below the configured bytes/sec (default 512) for the amount of time configured in seconds 
+    # Abort download if speed is below the configured bytes/sec (default 512) for the amount of time configured in seconds
     # (default 120), to prevent downloads from getting stuck
     options[:low_speed_limit] = Settings.try(:http_client).try(:low_speed_limit) || 512
     options[:low_speed_time] = Settings.try(:http_client).try(:low_speed_time) || 120

--- a/lib/rmt/lockfile.rb
+++ b/lib/rmt/lockfile.rb
@@ -1,25 +1,34 @@
 class RMT::Lockfile
-  LOCKFILE_LOCATION = '/tmp/rmt.lock'.freeze
   ExecutionLockedError = Class.new(StandardError)
 
   class << self
-    def lock
-      # https://ruby-doc.org/core-2.5.0/File.html#method-i-flock
-      File.open(RMT::Lockfile::LOCKFILE_LOCATION, File::RDWR | File::CREAT) do |f|
-        if f.flock(File::LOCK_EX | File::LOCK_NB)
-          f.write(Process.pid.to_s)
-          f.flush
-          f.truncate(f.pos)
-        else
-          pid = File.read(RMT::Lockfile::LOCKFILE_LOCATION)
-          raise ExecutionLockedError.new(
-            _('Process is locked by the application with pid %{pid}. Close this application or wait for it to finish before trying again.') \
-                % { pid: pid } + "\n"
-          )
-        end
+    def lock(lock_name = nil)
+      lock_name = ['rmt-cli', lock_name].compact.join('-')
 
-        yield
+      is_lock_obtained = obtain_lock(lock_name)
+      unless is_lock_obtained
+        raise ExecutionLockedError.new(
+          _('Another instance of this command is already running. Terminate the other instance or wait for it to finish.')
+        )
       end
+
+      yield
+
+      release_lock(lock_name)
+    end
+
+    protected
+
+    def obtain_lock(lock_name)
+      quoted_lock_name = ActiveRecord::Base.connection.quote(lock_name)
+      # get_lock returns 1 if lock was obtained, 0 otherwise
+      result = ActiveRecord::Base.connection.execute("SELECT GET_LOCK(#{quoted_lock_name}, 1)")
+      result.first.first == 1
+    end
+
+    def release_lock(lock_name)
+      quoted_lock_name = ActiveRecord::Base.connection.quote(lock_name)
+      ActiveRecord::Base.connection.execute("SELECT RELEASE_LOCK(#{quoted_lock_name})")
     end
   end
 end

--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Apr 17 03:25:20 UTC 2020 - Ivan Kapelyukhin <ikapelyukhin@suse.com>
+
+- Version 2.5.7
+- Use DB locks intead of lockfiles (bsc#1165548)
+
+-------------------------------------------------------------------
 Fri Apr  3 09:29:07 UTC 2020 - Thomas Schmidt <tschmidt@suse.com>
 
 - Version 2.5.6

--- a/package/obs/rmt-server.spec
+++ b/package/obs/rmt-server.spec
@@ -25,7 +25,7 @@
 %define ruby_version %{rb_default_ruby_suffix}
 
 Name:           rmt-server
-Version:        2.5.6
+Version:        2.5.7
 Release:        0
 Summary:        Repository mirroring tool and registration proxy for SCC
 License:        GPL-2.0-or-later

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -97,7 +97,6 @@ RSpec.configure do |config|
 
   config.around(:each, :with_fakefs) do |example|
     FakeFS.with_fresh do
-      FileUtils.mkdir_p(File.dirname(RMT::Lockfile::LOCKFILE_LOCATION))
       example.run
     end
   end

--- a/spec/support/shared_examples/cli.rb
+++ b/spec/support/shared_examples/cli.rb
@@ -18,17 +18,14 @@ end
 
 shared_examples 'handles lockfile exception' do
   context 'with existing lockfile' do
-    let(:pid) { 42 }
-
     before do
-      allow_any_instance_of(FakeFS::File).to receive(:flock).and_return(false)
-      allow(FakeFS::File).to receive(:read).with(::RMT::Lockfile::LOCKFILE_LOCATION).and_return(pid)
+      allow(RMT::Lockfile).to receive(:obtain_lock).and_return(false)
     end
 
     it 'handles lockfile exception' do
       expect(described_class).to receive(:exit)
       expect { command }.to output(
-        "Process is locked by the application with pid #{pid}. Close this application or wait for it to finish before trying again.\n"
+        "Another instance of this command is already running. Terminate the other instance or wait for it to finish.\n"
       ).to_stderr
     end
   end


### PR DESCRIPTION
Does 3 things:

 * Fixes the lockfile bug (bsc#1165548) -- creates locks in the DB instead of /tmp;
 * Addresses concerns that were raised with regards to containerization of RMT -- having locks in the DB prevents different containers from running the same task;
 * Creates separate locks for sync/import and mirror jobs -- mirror job doesn't really conflict with a sync/import job (as it only reads from the DB); this should fix an issue we often have -- mirror jobs run over 24 hours in some regions, sync jobs break due to lockfiles being held by those long-running mirror jobs.
