### PR TITLE
Fix RPM dependencies packages

### DIFF
--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -1,4 +1,15 @@
 -------------------------------------------------------------------
+Tue Jun  9 07:16:15 UTC 2020 - Thorsten Kukuk <kukuk@suse.com>
+
+- Move nginx/vhosts.d directory to correct sub-package. They
+  are needed together with nginx, not rmt-server.
+- Fix dependencies especially for containerized usage:
+  - mariadb and nginx are not hard requires, could run on another host
+- Fix generic dependencies:
+  - systemd ordering was missing
+  - shadow is required for pre-install
+
+-------------------------------------------------------------------
 Tue May 19 12:31:53 UTC 2020 - Luís Caparroz <lcaparroz@suse.com>
 
 - Version 2.5.8

--- a/package/obs/rmt-server.spec
+++ b/package/obs/rmt-server.spec
@@ -47,12 +47,13 @@ BuildRequires:  libxml2-devel
 BuildRequires:  libxslt-devel
 BuildRequires:  pkgconfig(systemd)
 Requires:       gpg2
-Requires:       mariadb
-Requires:       nginx
+Recommends:     mariadb
+Recommends:     nginx
+# The config is not really required by rmt-server, but by nginx ...
 Requires:       rmt-server-configuration
 Requires(post): %{ruby_version}
 Requires(post): %{rubygem bundler}
-Requires(post): shadow
+Requires(pre):  shadow
 Requires(post): timezone
 Requires(post): util-linux
 Conflicts:      yast2-rmt < 1.0.3
@@ -60,6 +61,7 @@ Recommends:     yast2-rmt >= 1.3.0
 Recommends:     rmt-server-config
 # Does not build for i586 and s390 and is not supported on those architectures
 ExcludeArch:    %{ix86} s390
+%{systemd_ordering}
 
 %description
 This package provides a mirroring tool for RPM repositories and a registration
@@ -213,8 +215,6 @@ find %{buildroot}%{lib_dir}/vendor/bundle/ruby/*/gems/yard*/ -type f -exec chmod
 %attr(-,%{rmt_user},%{rmt_group}) /var/lib/rmt
 %dir %{_libexecdir}/supportconfig
 %dir %{_libexecdir}/supportconfig/plugins
-%dir %{_sysconfdir}/nginx
-%dir %{_sysconfdir}/nginx/vhosts.d
 %dir /var/lib/rmt
 %dir %{_sysconfdir}/slp.reg.d
 %config(noreplace) %attr(0640, %{rmt_user},root) %{_sysconfdir}/rmt.conf
@@ -244,6 +244,8 @@ find %{buildroot}%{lib_dir}/vendor/bundle/ruby/*/gems/yard*/ -type f -exec chmod
 %{_libexecdir}/supportconfig/plugins/rmt
 
 %files config
+%dir %{_sysconfdir}/nginx
+%dir %{_sysconfdir}/nginx/vhosts.d
 %config(noreplace) %{_sysconfdir}/nginx/vhosts.d/rmt-server-http.conf
 %config(noreplace) %{_sysconfdir}/nginx/vhosts.d/rmt-server-https.conf
 
@@ -253,6 +255,8 @@ find %{buildroot}%{lib_dir}/vendor/bundle/ruby/*/gems/yard*/ -type f -exec chmod
 %dir %{_sysconfdir}/nginx/rmt-auth.d/
 %dir %attr(-,%{rmt_user},%{rmt_group}) %{data_dir}/regsharing
 %exclude %{app_dir}/engines/registration_sharing/package/
+%dir %{_sysconfdir}/nginx
+%dir %{_sysconfdir}/nginx/vhosts.d
 %config(noreplace) %{_sysconfdir}/nginx/vhosts.d/rmt-server-pubcloud-http.conf
 %config(noreplace) %{_sysconfdir}/nginx/vhosts.d/rmt-server-pubcloud-https.conf
 %config(noreplace) %{_sysconfdir}/nginx/rmt-auth.d/auth-handler.conf


### PR DESCRIPTION
Some of the rmt-server RPM package's dependencies (mariadb and nginx) are marked as required, but they aren't really required to run, rmt-server, especially for containerized usage.

This PR marks these packages as recommended and makes some other package adjustments.