### PR TITLE
rmt-server-pubcloud: SLE11 EOL

### DIFF
--- a/package/files/nginx-pubcloud/nginx-http.conf
+++ b/package/files/nginx-pubcloud/nginx-http.conf
@@ -11,48 +11,16 @@ server {
         autoindex off;
     }
 
-    # redirection to HTTPS is temporarily disabled for SLES11 clients
-    #
-    # location /repo {
-    #     return 301 https://$host$request_uri;
-    # }
-    #
-    # location = /repo/repoindex.xml {
-    #     return 301 https://$host$request_uri;
-    # }
-
     location /repo {
-        autoindex on;
-        log_not_found off;
-        include /etc/nginx/rmt-auth*.d/auth-handler*.conf;
+        return 301 https://$host$request_uri;
     }
 
     location = /repo/repoindex.xml {
-        try_files $uri @rmt_app;
+        return 301 https://$host$request_uri;
     }
 
-    location /connect {
-        try_files $uri @rmt_app;
-    }
-
-    location /services {
-        try_files $uri @rmt_app;
-    }
-
-    location /api {
-        try_files $uri @rmt_app;
-    }
-
-    location @rmt_app {
-        proxy_pass          http://rmt;
-        proxy_redirect      off;
-        proxy_read_timeout  600;
-
-        proxy_set_header Host $http_host;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Ssl on;
-        proxy_set_header X-Real-IP $remote_addr;
+    location /suma {
+        return 301 https://$host$request_uri;
     }
 
     # Aliases to RMT CA certificate

--- a/package/files/nginx-pubcloud/nginx-https.conf
+++ b/package/files/nginx-pubcloud/nginx-https.conf
@@ -13,8 +13,7 @@ server {
     ssl_certificate     /etc/rmt/ssl/rmt-server.crt;
     ssl_certificate_key /etc/rmt/ssl/rmt-server.key;
 
-    # TLSv1 and TLSv1.1 for compatibility with older SLES11 clients
-    ssl_protocols       TLSv1 TLSv1.1 TLSv1.2 TLSv1.3;
+    ssl_protocols       TLSv1.2 TLSv1.3;
 
     include /etc/nginx/rmt-auth*.d/auth-location*.conf;
 


### PR DESCRIPTION
We've had some changes made to the configs to support old SLE11 clients, now that SLE11 is out of support we can revert those changes.