### PR TITLE
Move reloading of nginx to correct sub-packages

### DIFF
--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jun 29 08:20:37 UTC 2020 - Thorsten Kukuk <kukuk@suse.com>
+
+- Move the nginx reload to the configuration package which contain
+  nginx config files, don't reload nginx unconditionally from main
+  package.
+
+-------------------------------------------------------------------
 Tue Jun 16 13:05:49 UTC 2020 - Luís Caparroz <luis.caparroz@suse.com>
 
 - Version 2.5.10

--- a/package/obs/rmt-server.spec
+++ b/package/obs/rmt-server.spec
@@ -306,7 +306,7 @@ fi
 %postun
 %service_del_postun rmt-server.target rmt-server.service rmt-server-migration.service rmt-server-mirror.service rmt-server-sync.service rmt-server-systems-scc-sync.service
 
-%posttrans
+%posttrans config
 /usr/bin/systemctl reload nginx.service
 
 %pre pubcloud
@@ -323,5 +323,6 @@ fi
 
 %posttrans pubcloud
 /usr/bin/systemctl try-restart rmt-server.service
+/usr/bin/systemctl reload nginx.service
 
 %changelog


### PR DESCRIPTION
The posttrans in the spec file reloads nginx for the main package, but the nginx configuration is in sub-packages. So if a configuration sub-package without nginx config is installed, this leads to a systemctl/RPM error.