### PR TITLE
Downloaded data integrity improvement

### DIFF
--- a/app/models/downloaded_file.rb
+++ b/app/models/downloaded_file.rb
@@ -19,26 +19,20 @@ class DownloadedFile < ApplicationRecord
       return false unless File.exist?(path)
 
       valid_checksum = RMT::ChecksumVerifier.match_checksum?(checksum_type, checksum_value, path)
-      file_db_entries = where(local_path: path)
-      matched_tracked_file = file_db_entries.find do |entry|
-        match_tracked_file?(entry, checksum_type, checksum_value)
-      end
-
-      duplicated_entries = file_db_entries.select { |entry| entry != matched_tracked_file }
-      duplicated_entries.each(&:destroy)
+      tracked_file = find_by(local_path: path)
+      matched_tracked_file = matches_tracked_file?(tracked_file, checksum_type, checksum_value)
 
       return true if valid_checksum && matched_tracked_file
-      return !add_file(checksum_type, checksum_value, path).nil? if valid_checksum && matched_tracked_file.nil?
+      return !add_file(checksum_type, checksum_value, path).nil? if valid_checksum && tracked_file.nil?
 
       FileUtils.remove_file(path, force: true)
-      matched_tracked_file.destroy unless matched_tracked_file.nil?
-
+      tracked_file.destroy unless tracked_file.nil?
       false
     end
 
     private
 
-    def match_tracked_file?(tracked_file, checksum_type, checksum_value)
+    def matches_tracked_file?(tracked_file, checksum_type, checksum_value)
       return false if tracked_file.nil? || tracked_file.checksum_type != checksum_type || tracked_file.checksum != checksum_value
       true
     end

--- a/app/models/downloaded_file.rb
+++ b/app/models/downloaded_file.rb
@@ -20,4 +20,8 @@ class DownloadedFile < ApplicationRecord
     end
 
   end
+
+  def size
+    file_size
+  end
 end

--- a/app/models/downloaded_file.rb
+++ b/app/models/downloaded_file.rb
@@ -1,10 +1,5 @@
 class DownloadedFile < ApplicationRecord
   class << self
-
-    def get_local_path_by_checksum(checksum_type, checksum)
-      DownloadedFile.find_by({ checksum_type: checksum_type, checksum: checksum })
-    end
-
     def track_file(checksum_type:, checksum:, local_path:, size:)
       find_or_initialize_by(local_path: local_path).tap do |record|
         record.checksum_type = checksum_type

--- a/app/models/downloaded_file.rb
+++ b/app/models/downloaded_file.rb
@@ -7,13 +7,8 @@ class DownloadedFile < ApplicationRecord
         record.file_size = size
 
         record.save if record.changed?
-      end.persisted?
+      end
     end
-
-    def untrack_file(local_path)
-      where(local_path: local_path).destroy_all
-    end
-
   end
 
   def size

--- a/app/models/downloaded_file.rb
+++ b/app/models/downloaded_file.rb
@@ -5,27 +5,6 @@ class DownloadedFile < ApplicationRecord
       DownloadedFile.find_by({ checksum_type: checksum_type, checksum: checksum })
     end
 
-    def valid_local_file?(checksum_type, checksum_value, path)
-      return false unless File.exist?(path)
-
-      valid_checksum = RMT::ChecksumVerifier.match_checksum?(checksum_type, checksum_value, path)
-      tracked_file = find_by(local_path: path)
-      matched_tracked_file = matches_tracked_file?(tracked_file, checksum_type, checksum_value)
-
-      return true if valid_checksum && matched_tracked_file
-
-      if valid_checksum && tracked_file.nil?
-        return !track_file(checksum_type: checksum_type,
-                           checksum: checksum_value,
-                           local_path: path,
-                           size: File.size(path)).nil?
-      end
-
-      FileUtils.remove_file(path, force: true)
-      tracked_file.destroy unless tracked_file.nil?
-      false
-    end
-
     def track_file(checksum_type:, checksum:, local_path:, size:)
       find_or_initialize_by(local_path: local_path).tap do |record|
         record.checksum_type = checksum_type
@@ -38,13 +17,6 @@ class DownloadedFile < ApplicationRecord
 
     def untrack_file(local_path)
       where(local_path: local_path).destroy_all
-    end
-
-    private
-
-    def matches_tracked_file?(tracked_file, checksum_type, checksum_value)
-      return false if tracked_file.nil? || tracked_file.checksum_type != checksum_type || tracked_file.checksum != checksum_value
-      true
     end
 
   end

--- a/db/migrate/20200723124836_add_uniqueness_to_downloaded_files_local_path.rb
+++ b/db/migrate/20200723124836_add_uniqueness_to_downloaded_files_local_path.rb
@@ -3,14 +3,11 @@ class AddUniquenessToDownloadedFilesLocalPath < ActiveRecord::Migration[5.2]
     # Remove duplicates before adding uniqueness to `local_path`
     ActiveRecord::Base.connection.execute(
       <<~SQL
-        DELETE FROM `downloaded_files`
-        WHERE `downloaded_files`.`id` NOT IN (
-            SELECT * FROM (
-                SELECT max(`files`.`id`) AS unique_id FROM `downloaded_files` AS `files`
-                INNER JOIN `downloaded_files` ON `downloaded_files`.`id`=`files`.`id`
-                GROUP BY `files`.`local_path`
-            ) as tmp
-        )
+        DELETE df1 FROM
+            downloaded_files AS df1,
+            downloaded_files AS df2
+            WHERE df1.id < df2.id AND
+                df1.local_path = df2.local_path
       SQL
     )
 

--- a/db/migrate/20200723124836_add_uniqueness_to_downloaded_files_local_path.rb
+++ b/db/migrate/20200723124836_add_uniqueness_to_downloaded_files_local_path.rb
@@ -1,0 +1,9 @@
+class AddUniquenessToDownloadedFilesLocalPath < ActiveRecord::Migration[5.2]
+  def change
+    # Remove duplicates before adding uniqueness to `local_path`
+    unique_ids = DownloadedFile.group(:local_path).select('max(id)')
+    DownloadedFile.where.not(id: unique_ids).delete_all
+
+    add_index :downloaded_files, :local_path, unique: true
+  end
+end

--- a/db/migrate/20200723124836_add_uniqueness_to_downloaded_files_local_path.rb
+++ b/db/migrate/20200723124836_add_uniqueness_to_downloaded_files_local_path.rb
@@ -1,8 +1,18 @@
 class AddUniquenessToDownloadedFilesLocalPath < ActiveRecord::Migration[5.2]
   def change
     # Remove duplicates before adding uniqueness to `local_path`
-    unique_ids = DownloadedFile.group(:local_path).select('max(id)')
-    DownloadedFile.where.not(id: unique_ids).delete_all
+    ActiveRecord::Base.connection.execute(
+      <<~SQL
+        DELETE FROM `downloaded_files`
+        WHERE `downloaded_files`.`id` NOT IN (
+            SELECT * FROM (
+                SELECT max(`files`.`id`) AS unique_id FROM `downloaded_files` AS `files`
+                INNER JOIN `downloaded_files` ON `downloaded_files`.`id`=`files`.`id`
+                GROUP BY `files`.`local_path`
+            ) as tmp
+        )
+      SQL
+    )
 
     add_index :downloaded_files, :local_path, unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_15_151211) do
+ActiveRecord::Schema.define(version: 2020_07_23_124836) do
 
   create_table "activations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "service_id", null: false
@@ -35,6 +35,7 @@ ActiveRecord::Schema.define(version: 2020_07_15_151211) do
     t.string "local_path"
     t.bigint "file_size", unsigned: true
     t.index ["checksum_type", "checksum"], name: "index_downloaded_files_on_checksum_type_and_checksum"
+    t.index ["local_path"], name: "index_downloaded_files_on_local_path", unique: true
   end
 
   create_table "hw_infos", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/lib/rmt/deduplicator.rb
+++ b/lib/rmt/deduplicator.rb
@@ -23,10 +23,10 @@ class RMT::Deduplicator
       end
 
       if track
-        ::DownloadedFile.track_file(checksum: target_file.checksum,
-                                    checksum_type: target_file.checksum_type,
-                                    local_path: target_file.local_path,
-                                    size: File.size(target_file.local_path))
+        DownloadedFile.track_file(checksum: target_file.checksum,
+                                  checksum_type: target_file.checksum_type,
+                                  local_path: target_file.local_path,
+                                  size: File.size(target_file.local_path))
       end
 
       true
@@ -35,13 +35,13 @@ class RMT::Deduplicator
     private
 
     def hardlink(src, dest)
-      ::FileUtils.ln(src, dest)
+      FileUtils.ln(src, dest)
     rescue StandardError
-      raise ::RMT::Deduplicator::HardlinkException.new("#{src} → #{dest}")
+      raise RMT::Deduplicator::HardlinkException.new("#{src} → #{dest}")
     end
 
     def copy(src, dest)
-      ::FileUtils.cp(src, dest)
+      FileUtils.cp(src, dest)
     end
 
     def make_file_dir(file_path)

--- a/lib/rmt/deduplicator.rb
+++ b/lib/rmt/deduplicator.rb
@@ -10,6 +10,34 @@ class RMT::Deduplicator
 
   class << self
 
+    def deduplicate(target_file, force_copy: false, track: true)
+      src = DownloadedFile.get_local_path_by_checksum(target_file.checksum_type,
+                                                      target_file.checksum)
+
+      if src.nil?
+        return false
+      elsif !File.exist?(src.local_path) || (src.file_size != File.size(src.local_path))
+        raise MismatchException.new(src.local_path)
+      end
+
+      make_file_dir(target_file.local_path)
+
+      if RMT::Config.deduplication_by_hardlink? && !force_copy
+        hardlink(src.local_path, target_file.local_path)
+      else
+        copy(src.local_path, target_file.local_path)
+      end
+
+      if track
+        ::DownloadedFile.track_file(checksum: target_file.checksum,
+                                    checksum_type: target_file.checksum_type,
+                                    local_path: target_file.local_path,
+                                    size: File.size(target_file.local_path))
+      end
+
+      true
+    end
+
     private
 
     def hardlink(src, dest)
@@ -22,31 +50,12 @@ class RMT::Deduplicator
       ::FileUtils.cp(src, dest)
     end
 
-  end
+    def make_file_dir(file_path)
+      dirname = File.dirname(file_path)
 
-  def self.deduplicate(checksum_type, checksum_value, destination, force_copy: false, track: true)
-    src = DownloadedFile.get_local_path_by_checksum(checksum_type, checksum_value)
-
-    if src.nil?
-      return false
-    elsif !File.exist?(src.local_path) || (src.file_size != File.size(src.local_path))
-      raise MismatchException.new(src.local_path)
+      FileUtils.mkdir_p(dirname)
     end
 
-    if RMT::Config.deduplication_by_hardlink? && !force_copy
-      hardlink(src.local_path, destination)
-    else
-      copy(src.local_path, destination)
-    end
-
-    if track
-      ::DownloadedFile.track_file(checksum: checksum_value,
-                                  checksum_type: checksum_type,
-                                  local_path: destination,
-                                  size: File.size(destination))
-    end
-
-    true
   end
 
 end

--- a/lib/rmt/deduplicator.rb
+++ b/lib/rmt/deduplicator.rb
@@ -8,13 +8,14 @@ class RMT::Deduplicator
   class << self
 
     def deduplicate(target_file, force_copy: false, track: true)
-      source_file_path = ::RMT::FileValidator.find_valid_file_by_checksum(
+      source_files = ::RMT::FileValidator.find_valid_files_by_checksum(
         target_file.checksum, target_file.checksum_type, deep_verify: false
       )
 
-      return false if source_file_path.nil?
+      return false if source_files.empty?
 
       make_file_dir(target_file.local_path)
+      source_file_path = source_files.first.local_path
 
       if RMT::Config.deduplication_by_hardlink? && !force_copy
         hardlink(source_file_path, target_file.local_path)

--- a/lib/rmt/deduplicator.rb
+++ b/lib/rmt/deduplicator.rb
@@ -1,56 +1,52 @@
 require 'fileutils'
 
-class RMT::Deduplicator
-
+module RMT::Deduplicator
   class HardlinkException < RuntimeError
   end
 
-  class << self
+  private
 
-    def deduplicate(target_file, force_copy: false, track: true)
-      source_files = ::RMT::FileValidator.find_valid_files_by_checksum(
-        target_file.checksum, target_file.checksum_type, deep_verify: false
-      )
+  def deduplicate(target_file)
+    source_files = find_valid_files_by_checksum(
+      target_file.checksum, target_file.checksum_type
+    )
 
-      return false if source_files.empty?
+    return false if source_files.empty?
 
-      make_file_dir(target_file.local_path)
-      source_file_path = source_files.first.local_path
+    make_file_dir(target_file.local_path)
+    source_file_path = source_files.first.local_path
 
-      if RMT::Config.deduplication_by_hardlink? && !force_copy
-        hardlink(source_file_path, target_file.local_path)
-      else
-        copy(source_file_path, target_file.local_path)
-      end
-
-      if track
-        DownloadedFile.track_file(checksum: target_file.checksum,
-                                  checksum_type: target_file.checksum_type,
-                                  local_path: target_file.local_path,
-                                  size: File.size(target_file.local_path))
-      end
-
-      true
+    if RMT::Config.deduplication_by_hardlink? && !airgap_mode
+      hardlink(source_file_path, target_file.local_path)
+    else
+      copy(source_file_path, target_file.local_path)
     end
 
-    private
-
-    def hardlink(src, dest)
-      FileUtils.ln(src, dest)
-    rescue StandardError
-      raise RMT::Deduplicator::HardlinkException.new("#{src} → #{dest}")
+    # we don't want to track airgap files in our database
+    unless airgap_mode
+      DownloadedFile.track_file(checksum: target_file.checksum,
+                                checksum_type: target_file.checksum_type,
+                                local_path: target_file.local_path,
+                                size: File.size(target_file.local_path))
     end
 
-    def copy(src, dest)
-      FileUtils.cp(src, dest)
-    end
-
-    def make_file_dir(file_path)
-      dirname = File.dirname(file_path)
-
-      FileUtils.mkdir_p(dirname)
-    end
-
+    logger.info("→ #{File.basename(target_file.local_path)}")
+    true
   end
 
+  def hardlink(src, dest)
+    FileUtils.ln(src, dest)
+  rescue StandardError
+    raise RMT::Deduplicator::HardlinkException.new("#{src} → #{dest}")
+  end
+
+  def copy(src, dest)
+    FileUtils.cp(src, dest)
+  end
+
+  def make_file_dir(file_path)
+    dirname = File.dirname(file_path)
+
+    FileUtils.mkdir_p(dirname)
+  end
 end

--- a/lib/rmt/deduplicator.rb
+++ b/lib/rmt/deduplicator.rb
@@ -39,7 +39,12 @@ class RMT::Deduplicator
       copy(src.local_path, destination)
     end
 
-    DownloadedFile.add_file(checksum_type, checksum_value, destination) if track
+    if track
+      ::DownloadedFile.track_file(checksum: checksum_value,
+                                  checksum_type: checksum_type,
+                                  local_path: destination,
+                                  size: File.size(destination))
+    end
 
     true
   end

--- a/lib/rmt/downloader.rb
+++ b/lib/rmt/downloader.rb
@@ -177,7 +177,7 @@ class RMT::Downloader
     FileUtils.mv(request.download_path.path, local_file)
     File.chmod(0o644, local_file)
 
-    if @track_files
+    if @track_files && local_file.match?(/\.(rpm|drpm)$/)
       ::DownloadedFile.track_file(checksum: checksum_value,
                                   checksum_type: checksum_type,
                                   local_path: local_file,

--- a/lib/rmt/downloader.rb
+++ b/lib/rmt/downloader.rb
@@ -55,15 +55,6 @@ class RMT::Downloader
     failed_downloads
   end
 
-  def self.make_local_path(root_path, remote_file)
-    filename = File.join(root_path, remote_file.gsub(/\.\./, '__'))
-    dirname = File.dirname(filename)
-
-    FileUtils.mkdir_p(dirname)
-
-    filename
-  end
-
   protected
 
   def get_cache_timestamp(filename)
@@ -78,7 +69,7 @@ class RMT::Downloader
   # @param [Array] failed_downloads array of remote files that have failed downloads, passed by reference, prevents from raising RMT::Downloader exceptions
   # @return [RMT::FiberRequest] a request that can be run individually or with Typhoeus::Hydra
   def create_fiber_request(local_filenames, remote_file, checksum_type: nil, checksum_value: nil, failed_downloads: nil)
-    local_filename = self.class.make_local_path(@destination_dir, remote_file)
+    local_filename = make_local_path(@destination_dir, remote_file)
 
     request_fiber = Fiber.new do
       begin
@@ -205,5 +196,14 @@ class RMT::Downloader
     unless RMT::ChecksumVerifier.match_checksum?(checksum_type, checksum_value, download_path)
       raise RMT::Downloader::Exception.new(_("Checksum doesn't match"))
     end
+  end
+
+  def make_local_path(root_path, remote_file)
+    filename = File.join(root_path, remote_file.gsub(/\.\./, '__'))
+    dirname = File.dirname(filename)
+
+    FileUtils.mkdir_p(dirname)
+
+    filename
   end
 end

--- a/lib/rmt/downloader.rb
+++ b/lib/rmt/downloader.rb
@@ -186,7 +186,12 @@ class RMT::Downloader
     FileUtils.mv(request.download_path.path, local_file)
     File.chmod(0o644, local_file)
 
-    ::DownloadedFile.add_file(checksum_type, checksum_value, local_file) if @track_files
+    if @track_files
+      ::DownloadedFile.track_file(checksum: checksum_value,
+                                  checksum_type: checksum_type,
+                                  local_path: local_file,
+                                  size: File.size(local_file))
+    end
 
     @logger.info("↓ #{File.basename(local_file)}")
   rescue StandardError => e

--- a/lib/rmt/downloader.rb
+++ b/lib/rmt/downloader.rb
@@ -178,10 +178,10 @@ class RMT::Downloader
     File.chmod(0o644, local_file)
 
     if @track_files && local_file.match?(/\.(rpm|drpm)$/)
-      ::DownloadedFile.track_file(checksum: checksum_value,
-                                  checksum_type: checksum_type,
-                                  local_path: local_file,
-                                  size: File.size(local_file))
+      DownloadedFile.track_file(checksum: checksum_value,
+                                checksum_type: checksum_type,
+                                local_path: local_file,
+                                size: File.size(local_file))
     end
 
     @logger.info("↓ #{File.basename(local_file)}")

--- a/lib/rmt/file_validator.rb
+++ b/lib/rmt/file_validator.rb
@@ -3,27 +3,37 @@ require 'fileutils'
 class RMT::FileValidator
   class << self
     def validate_local_file(file_reference, deep_verify:)
-      valid_on_disk = verify_file_on_disk(file_reference, deep_verify)
-      update_file_status_in_database(file_reference, valid_on_disk)
+      if valid_on_disk?(file_reference, deep_verify)
+        DownloadedFile.track_file(checksum: file_reference.checksum,
+                                  checksum_type: file_reference.checksum_type,
+                                  local_path: file_reference.local_path,
+                                  size: file_reference.size)
+        return true
+      end
 
-      valid_on_disk
+      # Remove invalid files/DB entries as soon as they are found
+      FileUtils.remove_file(file_reference.local_path, force: true)
+      DownloadedFile.where(local_path: file_reference.local_path).destroy_all
+      false
     end
 
-    def find_valid_file_by_checksum(checksum, checksum_type, deep_verify:)
-      valid_files = DownloadedFile
-        .where(checksum: checksum, checksum_type: checksum_type).map do |file|
-          valid_on_disk = verify_file_on_disk(file, deep_verify)
-          file.destroy unless valid_on_disk
+    def find_valid_files_by_checksum(checksum, checksum_type, deep_verify:)
+      valid_files_on_disk = DownloadedFile
+        .where(checksum: checksum, checksum_type: checksum_type)
+        .group_by { |f| valid_on_disk?(f, deep_verify) }
 
-          valid_on_disk ? file.local_path : nil
-        end
+      # Remove invalid files/DB entries as soon as they are found
+      valid_files_on_disk[false]&.each do |file|
+        FileUtils.remove_file(file.local_path, force: true)
+        file.destroy
+      end
 
-      valid_files.compact.first
+      valid_files_on_disk[true] || []
     end
 
     private
 
-    def verify_file_on_disk(file, deep_verify)
+    def valid_on_disk?(file, deep_verify)
       return false unless File.exist?(file.local_path)
 
       has_valid_metadata = (File.size(file.local_path) == file.size)
@@ -31,22 +41,8 @@ class RMT::FileValidator
         has_valid_metadata &= RMT::ChecksumVerifier
           .match_checksum?(file.checksum_type, file.checksum, file.local_path)
       end
-      return true if has_valid_metadata
 
-      FileUtils.remove_file(file.local_path, force: true)
-      false
-    end
-
-    def update_file_status_in_database(file, valid_on_disk)
-      if valid_on_disk
-        DownloadedFile.track_file(checksum: file.checksum,
-                                  checksum_type: file.checksum_type,
-                                  local_path: file.local_path,
-                                  size: file.size)
-        return
-      end
-
-      DownloadedFile.where(local_path: file.local_path).destroy_all
+      has_valid_metadata
     end
   end
 end

--- a/lib/rmt/file_validator.rb
+++ b/lib/rmt/file_validator.rb
@@ -1,48 +1,46 @@
 require 'fileutils'
 
-class RMT::FileValidator
-  class << self
-    def validate_local_file(file_reference, deep_verify:)
-      if valid_on_disk?(file_reference, deep_verify)
-        DownloadedFile.track_file(checksum: file_reference.checksum,
-                                  checksum_type: file_reference.checksum_type,
-                                  local_path: file_reference.local_path,
-                                  size: file_reference.size)
-        return true
-      end
+module RMT::FileValidator
+  private
+
+  def validate_local_file(file_reference)
+    if valid_on_disk?(file_reference)
+      DownloadedFile.track_file(checksum: file_reference.checksum,
+                                checksum_type: file_reference.checksum_type,
+                                local_path: file_reference.local_path,
+                                size: file_reference.size)
+      return true
+    end
+
+    # Remove invalid files/DB entries as soon as they are found
+    FileUtils.remove_file(file_reference.local_path, force: true)
+    DownloadedFile.where(local_path: file_reference.local_path).destroy_all
+    false
+  end
+
+  def find_valid_files_by_checksum(checksum, checksum_type)
+    files = DownloadedFile
+      .where(checksum: checksum, checksum_type: checksum_type).to_a
+
+    files.delete_if do |file|
+      next false if valid_on_disk?(file)
 
       # Remove invalid files/DB entries as soon as they are found
-      FileUtils.remove_file(file_reference.local_path, force: true)
-      DownloadedFile.where(local_path: file_reference.local_path).destroy_all
-      false
+      FileUtils.remove_file(file.local_path, force: true)
+      file.destroy
+      true
+    end
+  end
+
+  def valid_on_disk?(file)
+    return false unless File.exist?(file.local_path)
+
+    has_valid_metadata = (File.size(file.local_path) == file.size)
+    if deep_verify
+      has_valid_metadata &= RMT::ChecksumVerifier
+        .match_checksum?(file.checksum_type, file.checksum, file.local_path)
     end
 
-    def find_valid_files_by_checksum(checksum, checksum_type, deep_verify:)
-      files = DownloadedFile
-        .where(checksum: checksum, checksum_type: checksum_type).to_a
-
-      files.delete_if do |file|
-        next false if valid_on_disk?(file, deep_verify)
-
-        # Remove invalid files/DB entries as soon as they are found
-        FileUtils.remove_file(file.local_path, force: true)
-        file.destroy
-        true
-      end
-    end
-
-    private
-
-    def valid_on_disk?(file, deep_verify)
-      return false unless File.exist?(file.local_path)
-
-      has_valid_metadata = (File.size(file.local_path) == file.size)
-      if deep_verify
-        has_valid_metadata &= RMT::ChecksumVerifier
-          .match_checksum?(file.checksum_type, file.checksum, file.local_path)
-      end
-
-      has_valid_metadata
-    end
+    has_valid_metadata
   end
 end

--- a/lib/rmt/file_validator.rb
+++ b/lib/rmt/file_validator.rb
@@ -5,11 +5,25 @@ class RMT::FileValidator
   class << self
     def validate_local_file(file_reference, deep_verify:)
       verify_file_on_disk(file_reference, deep_verify).tap do |valid_on_disk|
-        verify_file_on_database(file_reference, valid_on_disk)
+        update_file_status_on_database(file_reference, valid_on_disk)
       end
     end
 
+    def find_valid_file_by_checksum(checksum, checksum_type, deep_verify:)
+      ::DownloadedFile
+        .where(checksum: checksum, checksum_type: checksum_type)
+        .map { |file| [file, validate_tracked_file_on_disk(file, deep_verify)] }
+        .find { |_, valid_on_disk| valid_on_disk }
+        &.first&.local_path
+    end
+
     private
+
+    def validate_tracked_file_on_disk(file_record, deep_verify)
+      verify_file_on_disk(file_record, deep_verify).tap do |valid_on_disk|
+        file_record.destroy unless valid_on_disk
+      end
+    end
 
     def verify_file_on_disk(file, deep_verify)
       file_exist = File.exist?(file.local_path)
@@ -22,19 +36,13 @@ class RMT::FileValidator
       false
     end
 
-    def verify_file_on_database(file, valid_on_disk)
-      if valid_on_disk
-        ::DownloadedFile.track_file(
-          checksum: file.checksum,
-          checksum_type: file.checksum_type,
-          local_path: file.local_path,
-          size: file.size
-        )
+    def update_file_status_on_database(file, valid_on_disk)
+      return ::DownloadedFile.untrack_file(file.local_path) unless valid_on_disk
 
-        return
-      end
-
-      ::DownloadedFile.untrack_file(file.local_path)
+      ::DownloadedFile.track_file(checksum: file.checksum,
+                                  checksum_type: file.checksum_type,
+                                  local_path: file.local_path,
+                                  size: file.size)
     end
 
     def file_match_metadata?(file, deep_verify)

--- a/lib/rmt/file_validator.rb
+++ b/lib/rmt/file_validator.rb
@@ -1,59 +1,52 @@
 require 'fileutils'
-require 'rmt/checksum_verifier'
 
 class RMT::FileValidator
   class << self
     def validate_local_file(file_reference, deep_verify:)
-      verify_file_on_disk(file_reference, deep_verify).tap do |valid_on_disk|
-        update_file_status_on_database(file_reference, valid_on_disk)
-      end
+      valid_on_disk = verify_file_on_disk(file_reference, deep_verify)
+      update_file_status_in_database(file_reference, valid_on_disk)
+
+      valid_on_disk
     end
 
     def find_valid_file_by_checksum(checksum, checksum_type, deep_verify:)
-      ::DownloadedFile
-        .where(checksum: checksum, checksum_type: checksum_type)
-        .map { |file| [file, validate_tracked_file_on_disk(file, deep_verify)] }
-        .find { |_, valid_on_disk| valid_on_disk }
-        &.first&.local_path
+      valid_files = DownloadedFile
+        .where(checksum: checksum, checksum_type: checksum_type).map do |file|
+          valid_on_disk = verify_file_on_disk(file, deep_verify)
+          file.destroy unless valid_on_disk
+
+          valid_on_disk ? file.local_path : nil
+        end
+
+      valid_files.compact.first
     end
 
     private
 
-    def validate_tracked_file_on_disk(file_record, deep_verify)
-      verify_file_on_disk(file_record, deep_verify).tap do |valid_on_disk|
-        file_record.destroy unless valid_on_disk
-      end
-    end
-
     def verify_file_on_disk(file, deep_verify)
-      file_exist = File.exist?(file.local_path)
-      match_metadata = file_exist ? file_match_metadata?(file, deep_verify) : false
+      return false unless File.exist?(file.local_path)
 
-      return true if match_metadata
+      has_valid_metadata = (File.size(file.local_path) == file.size)
+      if deep_verify
+        has_valid_metadata &= RMT::ChecksumVerifier
+          .match_checksum?(file.checksum_type, file.checksum, file.local_path)
+      end
+      return true if has_valid_metadata
 
-      FileUtils.remove_file(file.local_path, force: true) if file_exist
-
+      FileUtils.remove_file(file.local_path, force: true)
       false
     end
 
-    def update_file_status_on_database(file, valid_on_disk)
-      return ::DownloadedFile.untrack_file(file.local_path) unless valid_on_disk
-
-      ::DownloadedFile.track_file(checksum: file.checksum,
+    def update_file_status_in_database(file, valid_on_disk)
+      if valid_on_disk
+        DownloadedFile.track_file(checksum: file.checksum,
                                   checksum_type: file.checksum_type,
                                   local_path: file.local_path,
                                   size: file.size)
-    end
+        return
+      end
 
-    def file_match_metadata?(file, deep_verify)
-      File.size(file.local_path) == file.size && file_match_checksum?(file, deep_verify)
-    end
-
-    def file_match_checksum?(file, deep_verify)
-      return true unless deep_verify
-
-      ::RMT::ChecksumVerifier
-        .match_checksum?(file.checksum_type, file.checksum, file.local_path)
+      DownloadedFile.where(local_path: file.local_path).destroy_all
     end
   end
 end

--- a/lib/rmt/file_validator.rb
+++ b/lib/rmt/file_validator.rb
@@ -1,0 +1,56 @@
+require 'fileutils'
+require 'rmt/checksum_verifier'
+
+class RMT::FileValidator
+  class << self
+    def validate_local_file(repository_dir:, metadata:, deep_verify:)
+      verify_file_on_disk(repository_dir, metadata, deep_verify).tap do |(file_path, valid_file)|
+        verify_file_on_database(file_path, valid_file, metadata)
+      end
+    end
+
+    private
+
+    def verify_file_on_disk(repository_dir, metadata, deep_verify)
+      path = local_path(repository_dir, metadata)
+      file_exist = File.exist?(path)
+      match_metadata = file_exist ? file_match_metadata?(path, metadata, deep_verify) : false
+
+      return [path, true] if match_metadata
+
+      FileUtils.remove_file(path, force: true) if file_exist
+
+      [path, false]
+    end
+
+    def verify_file_on_database(file_path, valid_file, metadata)
+      if valid_file
+        ::DownloadedFile.track_file(
+          checksum: metadata.checksum,
+          checksum_type: metadata.checksum_type,
+          local_path: file_path,
+          size: metadata.size
+        )
+
+        return
+      end
+
+      ::DownloadedFile.untrack_file(file_path)
+    end
+
+    def local_path(repository_dir, metadata)
+      File.join(repository_dir, metadata.location.gsub(/\.\./, '__'))
+    end
+
+    def file_match_metadata?(path, metadata, deep_verify)
+      File.size(path) == metadata.size && file_match_checksum?(path, metadata, deep_verify)
+    end
+
+    def file_match_checksum?(path, metadata, deep_verify)
+      return true unless deep_verify
+
+      ::RMT::ChecksumVerifier
+        .match_checksum?(metadata.checksum_type, metadata.checksum, path)
+    end
+  end
+end

--- a/lib/rmt/mirror.rb
+++ b/lib/rmt/mirror.rb
@@ -157,16 +157,16 @@ class RMT::Mirror
     @downloader.destination_dir = @repository_dir
     @downloader.cache_dir = nil
 
-    package_references =
+    package_repomd_references =
       parse_mirror_data_files(deltainfo_files, RepomdParser::DeltainfoXmlParser) +
       parse_mirror_data_files(primary_files, RepomdParser::PrimaryXmlParser)
 
-    package_files = package_references.map do |reference|
+    package_file_references = package_repomd_references.map do |reference|
       FileReference.build_from_metadata(reference,
                                         base_dir: @repository_dir)
     end
 
-    failed_downloads = download_package_files(package_files)
+    failed_downloads = download_package_files(package_file_references)
 
     raise _('Failed to download %{failed_count} files') % { failed_count: failed_downloads.size } unless failed_downloads.empty?
   rescue StandardError => e

--- a/lib/rmt/mirror.rb
+++ b/lib/rmt/mirror.rb
@@ -6,8 +6,8 @@ require 'time'
 class RMT::Mirror
   class FileReference
     class << self
-      def build_from_metadata(metadata, base_dir:, base_url:)
-        new(base_dir: base_dir, base_url: base_url, relative_remote_path: metadata.location)
+      def build_from_metadata(metadata, base_dir:)
+        new(base_dir: base_dir, relative_remote_path: metadata.location)
           .tap do |file|
             file.arch = metadata.arch
             file.checksum = metadata.checksum
@@ -17,14 +17,13 @@ class RMT::Mirror
       end
     end
 
-    attr_reader :local_path, :relative_remote_path, :remote_path
+    attr_reader :local_path, :relative_remote_path
     attr_accessor :arch, :checksum, :checksum_type, :size
     alias location relative_remote_path
 
-    def initialize(base_dir:, base_url:, relative_remote_path:)
+    def initialize(base_dir:, relative_remote_path:)
       @local_path = File.join(base_dir, relative_remote_path.gsub(/\.\./, '__'))
       @relative_remote_path = relative_remote_path
-      @remote_path = URI.join(base_url, relative_remote_path)
     end
   end
 
@@ -165,8 +164,7 @@ class RMT::Mirror
 
     package_files = package_references.map do |reference|
       FileReference.build_from_metadata(reference,
-                                        base_dir: @repository_dir,
-                                        base_url: @repository_url)
+                                        base_dir: @repository_dir)
     end
 
     failed_downloads = download_package_files(package_files)

--- a/lib/rmt/mirror.rb
+++ b/lib/rmt/mirror.rb
@@ -211,7 +211,7 @@ class RMT::Mirror
 
   def deduplicate(file_reference)
     return false unless ::RMT::Deduplicator
-      .deduplicate(file_reference.checksum_type, file_reference.checksum, file_reference.local_path,
+      .deduplicate(file_reference,
                    force_copy: @force_dedup_by_copy,
                    track: @track_download_files)
 
@@ -225,8 +225,6 @@ class RMT::Mirror
   def filter_downloadable_files(file_references)
     file_references.reject do |file|
       valid_file = ::RMT::FileValidator.validate_local_file(file, deep_verify: false)
-
-      ::RMT::Downloader.make_local_path(@repository_dir, file.location) unless valid_file
 
       valid_file || deduplicate(file)
     end

--- a/lib/rmt/mirror.rb
+++ b/lib/rmt/mirror.rb
@@ -210,16 +210,14 @@ class RMT::Mirror
   end
 
   def deduplicate(file_reference)
-    return false unless ::RMT::Deduplicator
-      .deduplicate(file_reference,
-                   force_copy: @force_dedup_by_copy,
-                   track: @track_download_files)
+    deduplicated = ::RMT::Deduplicator.deduplicate(
+      file_reference, force_copy: @force_dedup_by_copy, track: @track_download_files
+    )
+
+    return false unless deduplicated
 
     @logger.info("→ #{File.basename(file_reference.local_path)}")
     true
-  rescue ::RMT::Deduplicator::MismatchException => e
-    @logger.debug(_('× File does not exist or has wrong filesize, deduplication ignored %{error}.') % { error: e.message })
-    false
   end
 
   def filter_downloadable_files(file_references)

--- a/lib/rmt/mirror.rb
+++ b/lib/rmt/mirror.rb
@@ -7,7 +7,7 @@ class RMT::Mirror
   class FileReference
     class << self
       def build_from_metadata(metadata, base_dir:)
-        new(base_dir: base_dir, relative_remote_path: metadata.location)
+        new(base_dir: base_dir, location: metadata.location)
           .tap do |file|
             file.arch = metadata.arch
             file.checksum = metadata.checksum
@@ -17,13 +17,12 @@ class RMT::Mirror
       end
     end
 
-    attr_reader :local_path, :relative_remote_path
+    attr_reader :local_path, :location
     attr_accessor :arch, :checksum, :checksum_type, :size
-    alias location relative_remote_path
 
-    def initialize(base_dir:, relative_remote_path:)
-      @local_path = File.join(base_dir, relative_remote_path.gsub(/\.\./, '__'))
-      @relative_remote_path = relative_remote_path
+    def initialize(base_dir:, location:)
+      @local_path = File.join(base_dir, location.gsub(/\.\./, '__'))
+      @location = location
     end
   end
 
@@ -189,7 +188,7 @@ class RMT::Mirror
 
   def need_to_download?(file)
     return false if file.arch == 'src' && !@mirror_src
-    return false if ::RMT::FileValidator.validate_local_file(file, deep_verify: false)
+    return false if RMT::FileValidator.validate_local_file(file, deep_verify: false)
     return false if deduplicate(file)
 
     true
@@ -211,7 +210,7 @@ class RMT::Mirror
   end
 
   def deduplicate(file_reference)
-    deduplicated = ::RMT::Deduplicator.deduplicate(
+    deduplicated = RMT::Deduplicator.deduplicate(
       file_reference, force_copy: @force_dedup_by_copy, track: @track_download_files
     )
 

--- a/lib/rmt/mirror.rb
+++ b/lib/rmt/mirror.rb
@@ -195,14 +195,14 @@ class RMT::Mirror
 
   def filter_downloadable_files(root_path, referenced_files)
     referenced_files.reject do |parsed_file|
-      local_file = ::RMT::Downloader.make_local_path(root_path, parsed_file.location)
+      local_file, valid_file = ::RMT::FileValidator.validate_local_file(
+        repository_dir: @repository_dir, metadata: parsed_file, deep_verify: false
+      )
 
-      valid_local_file?(parsed_file, local_file) || deduplicate(parsed_file, local_file)
+      ::RMT::Downloader.make_local_path(root_path, parsed_file.location) unless valid_file
+
+      valid_file || deduplicate(parsed_file, local_file)
     end
-  end
-
-  def valid_local_file?(parsed_file, destination)
-    ::DownloadedFile.valid_local_file?(parsed_file.checksum_type, parsed_file.checksum, destination)
   end
 
   def remove_tmp_directories

--- a/spec/lib/rmt/deduplicator_spec.rb
+++ b/spec/lib/rmt/deduplicator_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe RMT::Deduplicator do
         end
       end
 
-      context 'when file tracking is enabled' do
+      context 'when file tracking is disabled' do
         let(:track_files) { false }
 
         it 'does not track files on database' do
@@ -85,10 +85,24 @@ RSpec.describe RMT::Deduplicator do
 
         let(:checksum) { 'foo' }
 
+        it('returns false') { is_expected.to be false }
+
         it 'does not duplicate file' do
-          expect { deduplicate }.to raise_error(::RMT::Deduplicator::MismatchException)
-          expect(File.exist?(dest_path)).to be_falsey
-          expect(File.stat(source_path).nlink).to eq(1)
+          deduplicate
+
+          expect(File.exist?(dest_path)).to be false
+        end
+
+        it 'removes invalid source files' do
+          deduplicate
+
+          expect(File.exist?(source_path)).to be false
+        end
+
+        it 'untracks invalid source files' do
+          expect { deduplicate }
+            .to change { DownloadedFile.where(local_path: source_path).count }
+            .from(1).to(0)
         end
       end
     end
@@ -129,10 +143,24 @@ RSpec.describe RMT::Deduplicator do
 
         let(:checksum) { 'foo' }
 
+        it('returns false') { is_expected.to be false }
+
         it 'does not duplicate file' do
-          expect { deduplicate }.to raise_error(::RMT::Deduplicator::MismatchException)
-          expect(File.exist?(dest_path)).to be_falsey
-          expect(File.stat(source_path).nlink).to eq(1)
+          deduplicate
+
+          expect(File.exist?(dest_path)).to be false
+        end
+
+        it 'removes invalid source files' do
+          deduplicate
+
+          expect(File.exist?(source_path)).to be false
+        end
+
+        it 'untracks invalid source files' do
+          expect { deduplicate }
+            .to change { DownloadedFile.where(local_path: source_path).count }
+            .from(1).to(0)
         end
       end
     end

--- a/spec/lib/rmt/file_validator_spec.rb
+++ b/spec/lib/rmt/file_validator_spec.rb
@@ -1,0 +1,270 @@
+require 'rails_helper'
+
+RSpec.describe RMT::FileValidator do
+  around do |example|
+    example.run
+    FileUtils.remove_entry(tmp_dir, force: true)
+  end
+
+  describe '.validate_local_file' do
+    let!(:tmp_dir) { Dir.mktmpdir('rmt') }
+
+    let(:metadata) do
+      instance_double(
+        '::RepomdParser::Reference',
+        checksum: expected_metadata[:checksum],
+        checksum_type: expected_metadata[:checksum_type],
+        location: 'dummy_product/product/apples-0.1-0.x86_64.rpm',
+        size: expected_metadata[:file_size]
+      )
+    end
+
+    let(:file_local_path) { File.join(tmp_dir, metadata.location) }
+
+    # File on disk shared contexts/examples
+
+    shared_context 'file on disk' do
+      before do
+        fixture_path = file_fixture(metadata.location).to_s
+
+        File.join(tmp_dir, metadata.location).tap do |file|
+          FileUtils.mkdir_p(File.dirname(file))
+          FileUtils.cp(fixture_path, file)
+        end
+      end
+    end
+
+    shared_context 'file on disk mismatches metadata' do
+      include_context 'file on disk'
+
+      let(:expected_metadata) do
+        {
+          checksum: '2c4e3fa1624bd23221eecdda9c7fcefad042992a9eaed227d06dd8210cfe2821',
+          checksum_type: 'SHA256',
+          file_size: 2020
+        }
+      end
+    end
+
+    shared_examples 'no files on disk' do
+      it 'returns file path and invalid file status' do
+        path, valid_file = described_class.validate_local_file(
+          repository_dir: tmp_dir,
+          metadata: metadata,
+          deep_verify: deep_verify
+        )
+
+        expect(path).to eq(file_local_path)
+        expect(valid_file).to be false
+      end
+    end
+
+    shared_examples 'invalid file on disk' do
+      it 'returns file path and invalid file status' do
+        path, valid_file = described_class.validate_local_file(
+          repository_dir: tmp_dir,
+          metadata: metadata,
+          deep_verify: deep_verify
+        )
+
+        expect(path).to eq(file_local_path)
+        expect(valid_file).to be false
+      end
+
+      it 'removes the local file' do
+        expect do
+          described_class.validate_local_file(
+            repository_dir: tmp_dir,
+            metadata: metadata,
+            deep_verify: deep_verify
+          )
+        end.to change { File.exist?(file_local_path) }.from(true).to(false)
+      end
+    end
+
+    shared_examples 'valid file on disk' do
+      it 'returns file path and valid file status' do
+        path, valid_file = described_class.validate_local_file(
+          repository_dir: tmp_dir,
+          metadata: metadata,
+          deep_verify: deep_verify
+        )
+
+        expect(path).to eq(file_local_path)
+        expect(valid_file).to be true
+      end
+
+      it 'does not remove the local file from the disk' do
+        expect do
+          described_class.validate_local_file(
+            repository_dir: tmp_dir,
+            metadata: metadata,
+            deep_verify: deep_verify
+          )
+        end.not_to change { File.exist?(file_local_path) == true }
+      end
+    end
+
+    # File tracking on database shared contexts/examples
+
+    shared_context 'file record on database' do
+      before do
+        ::DownloadedFile.track_file(
+          checksum: metadata.checksum,
+          checksum_type: metadata.checksum_type,
+          local_path: file_local_path,
+          size: metadata.size
+        )
+      end
+    end
+
+    shared_examples 'invalid tracked file on database' do
+      it 'untracks the file in the database' do
+        expect do
+          described_class.validate_local_file(
+            repository_dir: tmp_dir,
+            metadata: metadata,
+            deep_verify: deep_verify
+          )
+        end.to change { ::DownloadedFile.where(local_path: file_local_path).count }
+          .from(1).to(0)
+      end
+    end
+
+    shared_examples 'valid untracked file on disk' do
+      it 'start tracking the local file in the database' do
+        expect do
+          described_class.validate_local_file(
+            repository_dir: tmp_dir,
+            metadata: metadata,
+            deep_verify: deep_verify
+          )
+        end.to change { ::DownloadedFile.where(local_path: file_local_path).count }
+          .from(0).to(1)
+
+        file_record = ::DownloadedFile.find_by(local_path: file_local_path)
+
+        expect(file_record).to have_attributes(
+          checksum: metadata.checksum,
+          checksum_type: metadata.checksum_type,
+          local_path: file_local_path,
+          file_size: metadata.size
+        )
+      end
+    end
+
+    shared_examples 'valid tracked file on disk' do
+      it 'updates the database without creating a new record' do
+        file_record_id = ::DownloadedFile.find_by(local_path: file_local_path).id
+
+        expect do
+          described_class.validate_local_file(
+            repository_dir: tmp_dir,
+            metadata: metadata,
+            deep_verify: deep_verify
+          )
+        end.not_to change { ::DownloadedFile.where(local_path: file_local_path).count }
+
+        updated_file_record = ::DownloadedFile.find_by(local_path: file_local_path)
+
+        expect(updated_file_record).to have_attributes(
+          id: file_record_id,
+          checksum: metadata.checksum,
+          checksum_type: metadata.checksum_type,
+          local_path: file_local_path,
+          file_size: metadata.size
+        )
+      end
+    end
+
+    # File and database verification
+
+    shared_examples 'file/database integrity verification' do
+      context 'no files on disk, untracked on database' do
+        include_examples 'no files on disk'
+      end
+
+      context 'no files on disk, tracked on database' do
+        include_context 'file record on database'
+
+        include_examples 'no files on disk'
+        include_examples 'invalid tracked file on database'
+      end
+
+      context 'invalid file on disk, untracked on database' do
+        include_context 'file on disk mismatches metadata'
+
+        include_examples 'invalid file on disk'
+      end
+
+      context 'invalid file on disk, tracked on database' do
+        include_context 'file on disk mismatches metadata'
+        include_context 'file record on database'
+
+        include_examples 'invalid file on disk'
+        include_examples 'invalid tracked file on database'
+      end
+
+      context 'valid file on disk, untracked on database' do
+        include_context 'file on disk'
+
+        include_examples 'valid file on disk'
+        include_examples 'valid untracked file on disk'
+      end
+
+      context 'valid file on disk, tracked on database w/ valid metadata' do
+        include_context 'file on disk'
+        include_context 'file record on database'
+
+        include_examples 'valid file on disk'
+        include_examples 'valid tracked file on disk'
+      end
+
+      context 'valid file on disk, tracked on database w/ invalid metadata' do
+        include_context 'file on disk'
+
+        before do
+          ::DownloadedFile.track_file(
+            checksum: 'invalid_checksum',
+            checksum_type: metadata.checksum_type,
+            local_path: file_local_path,
+            size: 2020
+          )
+        end
+
+        include_examples 'valid file on disk'
+        include_examples 'valid tracked file on disk'
+      end
+    end
+
+    context 'with deep verification disabled' do
+      let(:deep_verify) { false }
+
+      # Valid file path and size, invalid checksum
+      let(:expected_metadata) do
+        {
+          checksum: '2c4e3fa1624bd23221eecdda9c7fcefad042992a9eaed227d06dd8210cfe2821',
+          checksum_type: 'SHA256',
+          file_size: 1934
+        }
+      end
+
+      include_examples 'file/database integrity verification'
+    end
+
+    context 'with deep verification enabled' do
+      let(:deep_verify) { true }
+
+      # Valid file path, size and checksum
+      let(:expected_metadata) do
+        {
+          checksum: '5c4e3fa1624bd23251eecdda9c7fcefad045995a9eaed527d06dd8510cfe2851',
+          checksum_type: 'SHA256',
+          file_size: 1934
+        }
+      end
+
+      include_examples 'file/database integrity verification'
+    end
+  end
+end

--- a/spec/lib/rmt/file_validator_spec.rb
+++ b/spec/lib/rmt/file_validator_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe RMT::FileValidator do
 
     shared_context 'file record on database' do
       before do
-        ::DownloadedFile.track_file(
+        DownloadedFile.track_file(
           checksum: file.checksum,
           checksum_type: file.checksum_type,
           local_path: file.local_path,
@@ -91,7 +91,7 @@ RSpec.describe RMT::FileValidator do
     shared_examples 'invalid tracked file on database' do
       it 'untracks the file in the database' do
         expect { validate_local_file }
-          .to change { ::DownloadedFile.where(local_path: file.local_path).count }
+          .to change { DownloadedFile.where(local_path: file.local_path).count }
           .from(1).to(0)
       end
     end
@@ -99,10 +99,10 @@ RSpec.describe RMT::FileValidator do
     shared_examples 'valid untracked file on disk' do
       it 'start tracking the local file in the database' do
         expect { validate_local_file }
-          .to change { ::DownloadedFile.where(local_path: file.local_path).count }
+          .to change { DownloadedFile.where(local_path: file.local_path).count }
           .from(0).to(1)
 
-        file_record = ::DownloadedFile.find_by(local_path: file.local_path)
+        file_record = DownloadedFile.find_by(local_path: file.local_path)
 
         expect(file_record).to have_attributes(
           checksum: file.checksum,
@@ -115,12 +115,12 @@ RSpec.describe RMT::FileValidator do
 
     shared_examples 'valid tracked file on disk' do
       it 'updates the database without creating a new record' do
-        file_record_id = ::DownloadedFile.find_by(local_path: file.local_path).id
+        file_record_id = DownloadedFile.find_by(local_path: file.local_path).id
 
         expect { validate_local_file }
-          .not_to change { ::DownloadedFile.where(local_path: file.local_path).count }
+          .not_to change { DownloadedFile.where(local_path: file.local_path).count }
 
-        updated_file_record = ::DownloadedFile.find_by(local_path: file.local_path)
+        updated_file_record = DownloadedFile.find_by(local_path: file.local_path)
 
         expect(updated_file_record).to have_attributes(
           id: file_record_id,
@@ -183,7 +183,7 @@ RSpec.describe RMT::FileValidator do
         include_context 'file on disk'
 
         before do
-          ::DownloadedFile.track_file(
+          DownloadedFile.track_file(
             checksum: 'invalid_checksum',
             checksum_type: file.checksum_type,
             local_path: file.local_path,

--- a/spec/lib/rmt/file_validator_spec.rb
+++ b/spec/lib/rmt/file_validator_spec.rb
@@ -7,8 +7,19 @@ RSpec.describe RMT::FileValidator do
   end
 
   let!(:tmp_dir) { Dir.mktmpdir('rmt') }
+  let(:dummy_class) do
+    Class.new do
+      include RMT::FileValidator
 
-  describe '.validate_local_file' do
+      attr_reader :deep_verify
+
+      def initialize(deep_verify)
+        @deep_verify = deep_verify
+      end
+    end
+  end
+
+  describe '#validate_local_file' do
     let(:file_relative_remote_path) { 'dummy_product/product/apples-0.1-0.x86_64.rpm' }
     let(:file_local_path) { File.join(tmp_dir, file_relative_remote_path) }
 
@@ -136,7 +147,7 @@ RSpec.describe RMT::FileValidator do
 
     shared_examples 'file/database integrity verification' do
       subject(:validate_local_file) do
-        described_class.validate_local_file(file, deep_verify: deep_verify)
+        dummy_class.new(deep_verify).send(:validate_local_file, file)
       end
 
       context 'no files on disk, untracked on database' do
@@ -251,7 +262,7 @@ RSpec.describe RMT::FileValidator do
     diffable
   end
 
-  describe '.find_valid_files_by_checksum' do
+  describe '#find_valid_files_by_checksum' do
     let(:valid_file) do
       fixture_path = file_fixture('dummy_product/product/apples-0.1-0.x86_64.rpm').to_s
       file = instance_double(
@@ -380,9 +391,8 @@ RSpec.describe RMT::FileValidator do
 
     shared_examples 'finding valid files by checksum' do
       subject(:find_valid_files_by_checksum) do
-        described_class.find_valid_files_by_checksum(checksum,
-                                                    checksum_type,
-                                                    deep_verify: deep_verify)
+        dummy_class.new(deep_verify)
+          .send(:find_valid_files_by_checksum, checksum, checksum_type)
       end
 
       context 'when no records on database match the given checksum' do

--- a/spec/models/downloaded_file_spec.rb
+++ b/spec/models/downloaded_file_spec.rb
@@ -25,7 +25,7 @@ describe DownloadedFile, type: :model do
     end
 
     it 'handles missing files' do
-      add_downloaded_file(checksum_type, checksum, '/foo/bar')
+      DownloadedFile.destroy_all
       expect(DownloadedFile.get_local_path_by_checksum(checksum_type, checksum)).to be_nil
     end
   end

--- a/spec/models/downloaded_file_spec.rb
+++ b/spec/models/downloaded_file_spec.rb
@@ -43,10 +43,8 @@ describe DownloadedFile, type: :model do
           response = nil
           expect { response = described_class.track_file(file_attributes) }
             .not_to change { described_class.count }
-          expect(response).to be true
 
-          expect(described_class.find_by(local_path: file_attributes[:local_path]))
-            .to eq(existent_record)
+          expect(response).to eq(existent_record)
         end
       end
 
@@ -58,14 +56,14 @@ describe DownloadedFile, type: :model do
           response = nil
           expect { response = described_class.track_file(updated_file_attributes) }
             .not_to change { described_class.count }
-          expect(response).to be true
 
-          expect(described_class.find_by(local_path: file_attributes[:local_path]))
-            .to have_attributes(id: existent_record.id,
-                                checksum_type: updated_file_attributes[:checksum_type],
-                                checksum: updated_file_attributes[:checksum],
-                                local_path: file_attributes[:local_path],
-                                file_size: updated_file_attributes[:size])
+          expect(response).to have_attributes(
+            id: existent_record.id,
+            checksum_type: updated_file_attributes[:checksum_type],
+            checksum: updated_file_attributes[:checksum],
+            local_path: file_attributes[:local_path],
+            file_size: updated_file_attributes[:size]
+          )
         end
       end
 
@@ -82,35 +80,6 @@ describe DownloadedFile, type: :model do
         )
 
         expect(files_with_duplicated_checksum.count).to eq(2)
-      end
-    end
-  end
-
-  describe '.untrack_file' do
-    let(:test_file) { file_fixture('dummy_product/product/apples-0.1-0.x86_64.rpm').to_s }
-
-    context 'when there are no records with the specified local path' do
-      it 'does not raise any errors' do
-        described_class.where(local_path: test_file).destroy_all
-
-        expect { described_class.untrack_file(test_file) }.not_to raise_error
-      end
-    end
-
-    context 'when there are records with the specified local path' do
-      before do
-        described_class.create(
-          checksum_type: 'SHA256',
-          checksum: '5c4e3fa1624bd23251eecdda9c7fcefad045995a9eaed527d06dd8510cfe2851',
-          local_path: test_file,
-          file_size: 1934
-        )
-      end
-
-      it 'deletes the database records' do
-        described_class.untrack_file(test_file)
-
-        expect(described_class.where(local_path: test_file).count).to eq(0)
       end
     end
   end

--- a/spec/models/downloaded_file_spec.rb
+++ b/spec/models/downloaded_file_spec.rb
@@ -7,29 +7,34 @@ describe DownloadedFile, type: :model do
     let(:test_file_1_path) { file_fixture('dummy_product/product/apples-0.1-0.x86_64.rpm').to_s }
     let(:test_file_2_path) { file_fixture('dummy_product/product/apples-0.2-0.x86_64.rpm').to_s }
 
-    before do
-      add_downloaded_file('foo', 'bar', test_file_1_path)
-      add_downloaded_file('foobar', 'barfoo', test_file_2_path)
-    end
-
     it 'has file1' do
+      add_downloaded_file('foo', 'bar', test_file_1_path)
+
       expect(DownloadedFile.find_by(checksum_type: 'foo', checksum: 'bar').local_path).to eq(test_file_1_path)
     end
 
     it 'has the file size of file1' do
+      add_downloaded_file('foo', 'bar', test_file_1_path)
+
       expect(DownloadedFile.find_by(checksum_type: 'foo', checksum: 'bar').file_size).to eq(File.size(test_file_1_path))
     end
 
     it 'has file2' do
+      add_downloaded_file('foobar', 'barfoo', test_file_2_path)
+
       expect(DownloadedFile.find_by(checksum_type: 'foobar', checksum: 'barfoo').local_path).to eq(test_file_2_path)
     end
 
     it 'has the file size of file2' do
+      add_downloaded_file('foobar', 'barfoo', test_file_2_path)
+
       expect(DownloadedFile.find_by(checksum_type: 'foobar', checksum: 'barfoo').file_size).to eq(File.size(test_file_2_path))
     end
 
     it 'allows checksum duplicates' do
+      add_downloaded_file('foo', 'bar', test_file_1_path)
       add_downloaded_file('foo', 'bar', test_file_2_path)
+
       expect(DownloadedFile.where(checksum_type: 'foo', checksum: 'bar').count).to eq(2)
     end
   end
@@ -87,56 +92,6 @@ describe DownloadedFile, type: :model do
 
         expect(DownloadedFile.where(local_path: test_file_path).count).to eq(0)
         expect(File.exist?(test_file_path)).to be(false)
-      end
-    end
-
-    context 'when there are duplicated entries (same local path) on db' do
-      context 'and at least one entry matches a valid local file and the checksum metadata' do
-        it 'removes other duplicated entries' do
-          add_downloaded_file(checksum_type, checksum, test_file_path)
-          add_downloaded_file(checksum_type, checksum.sub('5', '2'), test_file_path)
-          add_downloaded_file(checksum_type, checksum.sub('5', '3'), test_file_path)
-
-          expect(DownloadedFile.where(local_path: test_file_path).count).to eq(3)
-          expect(File.exist?(test_file_path)).to be(true)
-
-          expect(DownloadedFile.valid_local_file?(checksum_type, checksum, test_file_path)).to be(true)
-
-          expect(DownloadedFile.where(local_path: test_file_path).count).to eq(1)
-          expect(File.exist?(test_file_path)).to be(true)
-        end
-      end
-
-      context 'and at least one entry matches the checksum metadata but not the local file' do
-        it 'removes all duplicated entries and mismatched file' do
-          add_downloaded_file(checksum_type, checksum.sub('5', '1'), test_file_path)
-          add_downloaded_file(checksum_type, checksum.sub('5', '2'), test_file_path)
-          add_downloaded_file(checksum_type, checksum.sub('5', '3'), test_file_path)
-
-          expect(DownloadedFile.where(local_path: test_file_path).count).to eq(3)
-          expect(File.exist?(test_file_path)).to be(true)
-
-          expect(DownloadedFile.valid_local_file?(checksum_type, checksum.sub('5', '1'), test_file_path)).to be(false)
-
-          expect(DownloadedFile.where(local_path: test_file_path).count).to eq(0)
-          expect(File.exist?(test_file_path)).to be(false)
-        end
-      end
-
-      context 'and no entries match a local file neither the checksum metadata' do
-        it 'removes all duplicated entries and mismatched file' do
-          add_downloaded_file(checksum_type, checksum.sub('5', '1'), test_file_path)
-          add_downloaded_file(checksum_type, checksum.sub('5', '2'), test_file_path)
-          add_downloaded_file(checksum_type, checksum.sub('5', '3'), test_file_path)
-
-          expect(DownloadedFile.where(local_path: test_file_path).count).to eq(3)
-          expect(File.exist?(test_file_path)).to be(true)
-
-          expect(DownloadedFile.valid_local_file?(checksum_type, checksum.sub('5', '4'), test_file_path)).to be(false)
-
-          expect(DownloadedFile.where(local_path: test_file_path).count).to eq(0)
-          expect(File.exist?(test_file_path)).to be(false)
-        end
       end
     end
   end

--- a/spec/models/downloaded_file_spec.rb
+++ b/spec/models/downloaded_file_spec.rb
@@ -1,35 +1,7 @@
 require 'spec_helper'
 require 'rails_helper'
 
-
 describe DownloadedFile, type: :model do
-  describe '#get_local_path_by_checksum' do
-    let(:checksum_type) { 'SHA256' }
-    let(:checksum) { '5c4e3fa1624bd23251eecdda9c7fcefad045995a9eaed527d06dd8510cfe2851' }
-    let(:test_file_path) { file_fixture('dummy_product/product/apples-0.1-0.x86_64.rpm').to_s }
-    let(:test_file_2_path) { file_fixture('dummy_product/product/apples-0.2-0.x86_64.rpm').to_s }
-
-    it 'gets the correct path with proper checksum' do
-      add_downloaded_file(checksum_type, checksum, test_file_path)
-
-      file = DownloadedFile.get_local_path_by_checksum(checksum_type, checksum)
-
-      expect(file.local_path).to eq(test_file_path)
-    end
-
-    it 'returns nil if files has been changed' do
-      add_downloaded_file(checksum_type, checksum, test_file_path)
-      file = DownloadedFile.find_by(checksum_type: checksum_type, checksum: checksum)
-      file.update(local_path: test_file_2_path)
-      expect(DownloadedFile.get_local_path_by_checksum(checksum_type, 'foo')).to be_nil
-    end
-
-    it 'handles missing files' do
-      DownloadedFile.destroy_all
-      expect(DownloadedFile.get_local_path_by_checksum(checksum_type, checksum)).to be_nil
-    end
-  end
-
   describe '.track_file' do
     let(:test_file) { file_fixture('dummy_product/product/apples-0.1-0.x86_64.rpm').to_s }
     let(:file_attributes) do
@@ -97,7 +69,7 @@ describe DownloadedFile, type: :model do
         end
       end
 
-      it 'allows checksum duplicated records' do
+      it 'allows checksum duplicated checksum records' do
         duplicated_file_attributes = file_attributes
           .merge(local_path: test_file.sub('apples', 'oranges'))
 

--- a/spec/models/downloaded_file_spec.rb
+++ b/spec/models/downloaded_file_spec.rb
@@ -30,7 +30,7 @@ describe DownloadedFile, type: :model do
     end
   end
 
-  describe '#track_file' do
+  describe '.track_file' do
     let(:test_file) { file_fixture('dummy_product/product/apples-0.1-0.x86_64.rpm').to_s }
     let(:file_attributes) do
       {
@@ -114,7 +114,7 @@ describe DownloadedFile, type: :model do
     end
   end
 
-  describe '#untrack_file' do
+  describe '.untrack_file' do
     let(:test_file) { file_fixture('dummy_product/product/apples-0.1-0.x86_64.rpm').to_s }
 
     context 'when there are no records with the specified local path' do
@@ -140,6 +140,21 @@ describe DownloadedFile, type: :model do
 
         expect(described_class.where(local_path: test_file).count).to eq(0)
       end
+    end
+  end
+
+  describe '#size' do
+    let(:test_file) { file_fixture('dummy_product/product/apples-0.1-0.x86_64.rpm').to_s }
+
+    it 'returns the same value as #file_size (alias)' do
+      downloaded_file = described_class.create(
+        checksum_type: 'SHA256',
+        checksum: '5c4e3fa1624bd23251eecdda9c7fcefad045995a9eaed527d06dd8510cfe2851',
+        local_path: test_file,
+        file_size: 1934
+      )
+
+      expect(downloaded_file.size).to eq(downloaded_file.file_size)
     end
   end
 end

--- a/spec/models/downloaded_file_spec.rb
+++ b/spec/models/downloaded_file_spec.rb
@@ -3,42 +3,6 @@ require 'rails_helper'
 
 
 describe DownloadedFile, type: :model do
-  describe '#add_file!' do
-    let(:test_file_1_path) { file_fixture('dummy_product/product/apples-0.1-0.x86_64.rpm').to_s }
-    let(:test_file_2_path) { file_fixture('dummy_product/product/apples-0.2-0.x86_64.rpm').to_s }
-
-    it 'has file1' do
-      add_downloaded_file('foo', 'bar', test_file_1_path)
-
-      expect(DownloadedFile.find_by(checksum_type: 'foo', checksum: 'bar').local_path).to eq(test_file_1_path)
-    end
-
-    it 'has the file size of file1' do
-      add_downloaded_file('foo', 'bar', test_file_1_path)
-
-      expect(DownloadedFile.find_by(checksum_type: 'foo', checksum: 'bar').file_size).to eq(File.size(test_file_1_path))
-    end
-
-    it 'has file2' do
-      add_downloaded_file('foobar', 'barfoo', test_file_2_path)
-
-      expect(DownloadedFile.find_by(checksum_type: 'foobar', checksum: 'barfoo').local_path).to eq(test_file_2_path)
-    end
-
-    it 'has the file size of file2' do
-      add_downloaded_file('foobar', 'barfoo', test_file_2_path)
-
-      expect(DownloadedFile.find_by(checksum_type: 'foobar', checksum: 'barfoo').file_size).to eq(File.size(test_file_2_path))
-    end
-
-    it 'allows checksum duplicates' do
-      add_downloaded_file('foo', 'bar', test_file_1_path)
-      add_downloaded_file('foo', 'bar', test_file_2_path)
-
-      expect(DownloadedFile.where(checksum_type: 'foo', checksum: 'bar').count).to eq(2)
-    end
-  end
-
   describe '#valid_local_file?' do
     around do |example|
       @tmp_dir = Dir.mktmpdir('rmt')
@@ -73,12 +37,12 @@ describe DownloadedFile, type: :model do
     end
 
     it 'tracks the file again if not yet tracked' do
-      file = add_downloaded_file(checksum_type, checksum, test_file_path)
-      file.destroy
+      response = nil
+      expect { response = DownloadedFile.valid_local_file?(checksum_type, checksum, test_file_path) }
+        .to change { DownloadedFile.where(local_path: test_file_path).count }
+        .from(0).to(1)
 
-      expect(DownloadedFile.where(local_path: test_file_path).count).to eq(0)
-      expect(DownloadedFile.valid_local_file?(checksum_type, checksum, test_file_path)).to be(true)
-      expect(DownloadedFile.where(local_path: test_file_path).count).to eq(1)
+      expect(response).to be true
     end
 
     context 'when a file matches a DB entry but not the checksum metadata' do
@@ -103,8 +67,11 @@ describe DownloadedFile, type: :model do
     let(:test_file_2_path) { file_fixture('dummy_product/product/apples-0.2-0.x86_64.rpm').to_s }
 
     it 'gets the correct path with proper checksum' do
-      file = add_downloaded_file(checksum_type, checksum, test_file_path)
-      expect(DownloadedFile.get_local_path_by_checksum(checksum_type, checksum)).to eq(file)
+      add_downloaded_file(checksum_type, checksum, test_file_path)
+
+      file = DownloadedFile.get_local_path_by_checksum(checksum_type, checksum)
+
+      expect(file.local_path).to eq(test_file_path)
     end
 
     it 'returns nil if files has been changed' do
@@ -117,6 +84,119 @@ describe DownloadedFile, type: :model do
     it 'handles missing files' do
       add_downloaded_file(checksum_type, checksum, '/foo/bar')
       expect(DownloadedFile.get_local_path_by_checksum(checksum_type, checksum)).to be_nil
+    end
+  end
+
+  describe '#track_file' do
+    let(:test_file) { file_fixture('dummy_product/product/apples-0.1-0.x86_64.rpm').to_s }
+    let(:file_attributes) do
+      {
+        checksum_type: 'SHA256',
+        checksum: '5c4e3fa1624bd23251eecdda9c7fcefad045995a9eaed527d06dd8510cfe2851',
+        local_path: test_file,
+        size: 1934
+      }
+    end
+
+    context 'when there are no records with the specified local path' do
+      it 'creates a new record' do
+        expect { described_class.track_file(file_attributes) }
+          .to change { described_class.count }.by(1)
+
+        expect(described_class.find_by(local_path: file_attributes[:local_path]))
+          .to have_attributes(checksum_type: file_attributes[:checksum_type],
+                              checksum: file_attributes[:checksum],
+                              local_path: file_attributes[:local_path],
+                              file_size: file_attributes[:size])
+      end
+    end
+
+    context 'when there is a record with the specified local path' do
+      before do
+        described_class.create(
+          checksum_type: file_attributes[:checksum_type],
+          checksum: file_attributes[:checksum],
+          local_path: file_attributes[:local_path],
+          file_size: file_attributes[:size]
+        )
+      end
+
+      context 'and the file attributes match the existent record' do
+        it 'returns the existent record' do
+          existent_record = described_class.find_by(local_path: file_attributes[:local_path])
+
+          response = nil
+          expect { response = described_class.track_file(file_attributes) }
+            .not_to change { described_class.count }
+          expect(response).to be true
+
+          expect(described_class.find_by(local_path: file_attributes[:local_path]))
+            .to eq(existent_record)
+        end
+      end
+
+      context 'and the file attributes do not match the existent record' do
+        it 'updates and then returns the existent record' do
+          existent_record = described_class.find_by(local_path: file_attributes[:local_path])
+          updated_file_attributes = file_attributes.merge(size: 2020)
+
+          response = nil
+          expect { response = described_class.track_file(updated_file_attributes) }
+            .not_to change { described_class.count }
+          expect(response).to be true
+
+          expect(described_class.find_by(local_path: file_attributes[:local_path]))
+            .to have_attributes(id: existent_record.id,
+                                checksum_type: updated_file_attributes[:checksum_type],
+                                checksum: updated_file_attributes[:checksum],
+                                local_path: file_attributes[:local_path],
+                                file_size: updated_file_attributes[:size])
+        end
+      end
+
+      it 'allows checksum duplicated records' do
+        duplicated_file_attributes = file_attributes
+          .merge(local_path: test_file.sub('apples', 'oranges'))
+
+        described_class.track_file(file_attributes)
+        described_class.track_file(duplicated_file_attributes)
+
+        files_with_duplicated_checksum = described_class.where(
+          checksum: file_attributes[:checksum],
+          checksum_type: file_attributes[:checksum_type]
+        )
+
+        expect(files_with_duplicated_checksum.count).to eq(2)
+      end
+    end
+  end
+
+  describe '#untrack_file' do
+    let(:test_file) { file_fixture('dummy_product/product/apples-0.1-0.x86_64.rpm').to_s }
+
+    context 'when there are no records with the specified local path' do
+      it 'does not raise any errors' do
+        described_class.where(local_path: test_file).destroy_all
+
+        expect { described_class.untrack_file(test_file) }.not_to raise_error
+      end
+    end
+
+    context 'when there are records with the specified local path' do
+      before do
+        described_class.create(
+          checksum_type: 'SHA256',
+          checksum: '5c4e3fa1624bd23251eecdda9c7fcefad045995a9eaed527d06dd8510cfe2851',
+          local_path: test_file,
+          file_size: 1934
+        )
+      end
+
+      it 'deletes the database records' do
+        described_class.untrack_file(test_file)
+
+        expect(described_class.where(local_path: test_file).count).to eq(0)
+      end
     end
   end
 end

--- a/spec/support/deduplication_helpers.rb
+++ b/spec/support/deduplication_helpers.rb
@@ -3,7 +3,12 @@ def deduplication_method(method)
 end
 
 def add_downloaded_file(checksum_type, checksum, path)
-  DownloadedFile.add_file(checksum_type, checksum, path)
+  size = File.size(path)
+
+  DownloadedFile.track_file(checksum: checksum,
+                            checksum_type: checksum_type,
+                            local_path: path,
+                            size: size)
 rescue StandardError
   nil
 end

--- a/spec/support/deduplication_helpers.rb
+++ b/spec/support/deduplication_helpers.rb
@@ -9,8 +9,6 @@ def add_downloaded_file(checksum_type, checksum, path)
                             checksum_type: checksum_type,
                             local_path: path,
                             size: size)
-rescue StandardError
-  nil
 end
 
 def deduplicate(checksum_type, checksum, path, track: true)

--- a/spec/support/deduplication_helpers.rb
+++ b/spec/support/deduplication_helpers.rb
@@ -11,6 +11,18 @@ def add_downloaded_file(checksum_type, checksum, path)
                             size: size)
 end
 
+def create_and_track_file(file_reference, fixture_path)
+  if fixture_path
+    FileUtils.mkdir_p(File.dirname(file_reference.local_path))
+    FileUtils.cp(fixture_path, file_reference.local_path)
+  end
+
+  DownloadedFile.track_file(checksum: file_reference.checksum,
+                            checksum_type: file_reference.checksum_type,
+                            local_path: file_reference.local_path,
+                            size: file_reference.size)
+end
+
 def deduplicate(checksum_type, checksum, path, track: true)
   ::RMT::Deduplicator.deduplicate(checksum_type, checksum, path, track: track)
 rescue ::RMT::Deduplicator::MismatchException


### PR DESCRIPTION
## Why

@ikapelyukhin pointed out some issues on PR #585, which should be addressed in order to assure data integrity on the customer database without affecting the mirroring process performance.

## What

* `DownloadedFile#local_path` uniqueness: I created a new migration which will remove possible duplicated `local_path` entries, if any, prior to adding an index with an uniqueness constraint to the field.
* I removed all local file validation logic from `DownloadedFile` and `RMT::Deduplicator`: now, all validation and data integrity logic is on `RMT::FileValidator`, which also fix invalid DB entries when searching for a  candidate source file for deduplication.
* Right now, file validation before deduplicating/downloading works without changes: `RMT::FileValidator` has an option for "deep verifying," which will be implemented as command flag in another PR;
* I tried to separate concerns for each of the classes I touched.

## Open to Discussion

* The `downloaded_file` table does not enforce any validation on blank fields: right now we can have entries with blank checksums, size or local paths. Should we think about it?
* I removed the exception `RMT::Deduplicator::MismatchException`, since it was only used to log to the `STDOUT` when a `downloaded_file` entry had no file matched on disk or the file had wrong data (invalid size or checksum) but RMT would take no action on top of this error, just ignore. There is the possibility of enhancing the class `RMT::FileValiator` to log its actions, like when tracking/untracking a file on DB, validating a file (invalid checksum or file does not exist) or removing invalid files. I'm not sure how much of this information would have some value to the customer.
* I'm planning to add the flag `--deep-verify` to the command `rmt-cli mirror`, in another PR. Should we consider it for other commands too?