### PR TITLE
Add the ability to remove un-mirrored repositories

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -66,6 +66,9 @@ You can install and run this wizard like this:
   	
   	`rmt-cli products show SLES/15/x86_64`
 
+  * `rmt-cli repos clean`:
+    Remove un-mirrored repositories from the local disk.
+
   * `rmt-cli repos list [--all] [--csv]`:
     Lists the repositories that are enabled for mirroring.
 

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -67,7 +67,7 @@ You can install and run this wizard like this:
   	`rmt-cli products show SLES/15/x86_64`
 
   * `rmt-cli repos clean`:
-    Remove un-mirrored repositories from the local disk.
+    Removes locally mirrored files of repositories which are not marked to be mirrored.
 
   * `rmt-cli repos list [--all] [--csv]`:
     Lists the repositories that are enabled for mirroring.

--- a/lib/rmt/cli/repos.rb
+++ b/lib/rmt/cli/repos.rb
@@ -16,6 +16,49 @@ class RMT::CLI::Repos < RMT::CLI::Base
   end
   map 'ls' => :list
 
+  desc 'clean', _('Remove un-mirrored repositories from the local disk.')
+  def clean
+    base_directory = RMT::DEFAULT_MIRROR_DIR
+
+    repos_to_delete = Repository.where(mirroring_enabled: false).map do |repo|
+      repository_dir = File.join(base_directory, repo.local_path)
+      Dir.exist?(repository_dir) ? repo : nil
+    end.compact
+
+    if repos_to_delete.empty?
+      puts _('No un-mirrored repositories found on local disk.')
+      return
+    end
+
+    puts _('RMT found the following un-mirrored repositories:')
+    print "\n\e[31m"
+    repos_to_delete.each do |repo|
+      puts repo.description
+    end
+    print "\n\e[0m\e[1m"
+    print _('Would you like to continue and remove these directories from your local disk?')
+    print "\n\e[22m\s\s"
+    print _("Only '%{input}' will be accepted.") % { input: 'yes' }
+    print "\n\n\s\s\e[1m"
+    print _('Enter a value:')
+    print "\e[22m\s\s"
+
+    input = $stdin.gets.to_s.strip
+    if input != 'yes'
+      puts "\n" + _('Clean cancelled.')
+      return
+    end
+
+    repos_to_delete.each do |repo|
+      path = File.join(base_directory, repo.local_path)
+      FileUtils.rm_r(path, secure: true)
+    end
+
+    print "\n\e[32m"
+    print _('Clean finished.')
+    print "\e[0m\n"
+  end
+
   desc 'enable IDS', _('Enable mirroring of repositories by a list of repository IDs')
   long_desc <<-REPOS
 #{_('Enable mirroring of repositories by a list of repository IDs')}
@@ -42,6 +85,8 @@ $ rmt-cli repos disable 2526 3263
 REPOS
   def disable(*ids)
     change_repos(ids, false)
+
+    puts "\n\e[1m" + _("To clean up downloaded files, please run '%{command}'") % { command: 'rmt-cli repos clean' } + "\e[22m"
   end
 
   protected

--- a/lib/rmt/cli/repos.rb
+++ b/lib/rmt/cli/repos.rb
@@ -16,7 +16,7 @@ class RMT::CLI::Repos < RMT::CLI::Base
   end
   map 'ls' => :list
 
-  desc 'clean', _('Remove un-mirrored repositories from the local disk.')
+  desc 'clean', _('Removes un-mirrored repositories from the local disk.')
   def clean
     base_directory = RMT::DEFAULT_MIRROR_DIR
 

--- a/lib/rmt/cli/repos.rb
+++ b/lib/rmt/cli/repos.rb
@@ -16,7 +16,7 @@ class RMT::CLI::Repos < RMT::CLI::Base
   end
   map 'ls' => :list
 
-  desc 'clean', _('Removes un-mirrored repositories from the local disk.')
+  desc 'clean', _('Removes locally mirrored files of repositories which are not marked to be mirrored')
   def clean
     base_directory = RMT::DEFAULT_MIRROR_DIR
 
@@ -26,17 +26,17 @@ class RMT::CLI::Repos < RMT::CLI::Base
     end.compact
 
     if repos_to_delete.empty?
-      puts _('No un-mirrored repositories found on local disk.')
+      puts _('RMT only found locally mirrored files of repositories that are marked to be mirrored.')
       return
     end
 
-    puts _('RMT found the following un-mirrored repositories:')
+    puts _('RMT found locally mirrored files from the following repositories which are not marked to be mirrored:')
     print "\n\e[31m"
     repos_to_delete.each do |repo|
       puts repo.description
     end
     print "\n\e[0m\e[1m"
-    print _('Would you like to continue and remove these directories from your local disk?')
+    print _('Would you like to continue and remove the locally mirrored files of these repositories?')
     print "\n\e[22m\s\s"
     print _("Only '%{input}' will be accepted.") % { input: 'yes' }
     print "\n\n\s\s\e[1m"
@@ -54,7 +54,7 @@ class RMT::CLI::Repos < RMT::CLI::Base
       path = File.join(base_directory, repo.local_path)
       FileUtils.rm_r(path, secure: true)
       DownloadedFile.where('local_path LIKE ?', "#{path}%").destroy_all
-      puts _("Deleted repository '%{repo}'.") % { repo: repo.description }
+      puts _("Deleted locally mirrored files from repository '%{repo}'.") % { repo: repo.description }
     end
 
     print "\n\e[32m"

--- a/lib/rmt/cli/repos.rb
+++ b/lib/rmt/cli/repos.rb
@@ -49,9 +49,12 @@ class RMT::CLI::Repos < RMT::CLI::Base
       return
     end
 
+    print "\n"
     repos_to_delete.each do |repo|
       path = File.join(base_directory, repo.local_path)
       FileUtils.rm_r(path, secure: true)
+      DownloadedFile.where('local_path LIKE ?', "#{path}%").destroy_all
+      puts _("Deleted repository '%{repo}'.") % { repo: repo.description }
     end
 
     print "\n\e[32m"

--- a/lib/rmt/cli/repos_custom.rb
+++ b/lib/rmt/cli/repos_custom.rb
@@ -45,6 +45,8 @@ class RMT::CLI::ReposCustom < RMT::CLI::Base
   desc 'disable ID', _('Disable mirroring of custom repository by ID')
   def disable(id)
     change_mirroring(id, false)
+
+    puts "\n\e[1m" + _("To clean up downloaded files, please run '%{command}'") % { command: 'rmt-cli repos clean' } + "\e[22m"
   end
 
   desc 'remove ID', _('Remove a custom repository')

--- a/lib/tasks/encrypted_key.rake
+++ b/lib/tasks/encrypted_key.rake
@@ -2,16 +2,16 @@ namespace :rmt do
   namespace :secrets do
     desc 'Create encryption key for Rails secrets'
     task create_encryption_key: :environment do
-      require "rails/generators/rails/encryption_key_file/encryption_key_file_generator"
+      require 'rails/generators/rails/encryption_key_file/encryption_key_file_generator'
 
       Rails::Generators::EncryptionKeyFileGenerator
-        .new.add_key_file("config/secrets.yml.key")
+        .new.add_key_file('config/secrets.yml.key')
     end
 
     desc 'Create the `secret_key_base` for Rails'
     task create_secret_key_base: :environment do
       Rails::Secrets.write(
-        { 'production' => {'secret_key_base' => SecureRandom.hex(64) } }.to_yaml
+        { 'production' => { 'secret_key_base' => SecureRandom.hex(64) } }.to_yaml
       )
     end
   end

--- a/spec/factories/repositories.rb
+++ b/spec/factories/repositories.rb
@@ -2,6 +2,7 @@ FactoryGirl.define do
   factory :repository do
     sequence(:scc_id) { |n| n }
     sequence(:name) { |n| "Repository #{n}" }
+    sequence(:description) { |n| "Repository #{n}" }
     sequence(:external_url) { |n| "https://updates.suse.com/suse/repository_#{n}" }
     enabled true
     autorefresh true

--- a/spec/lib/rmt/cli/repos_custom_spec.rb
+++ b/spec/lib/rmt/cli/repos_custom_spec.rb
@@ -178,8 +178,15 @@ describe RMT::CLI::ReposCustom do
 
     context 'by repo id' do
       let(:argv) { ['disable', repository.id.to_s] }
+      let(:expected_output) do
+        <<-OUTPUT
+Repository successfully disabled.
 
-      before { expect { command }.to output("Repository successfully disabled.\n").to_stdout }
+\e[1mTo clean up downloaded files, please run 'rmt-cli repos clean'\e[22m
+        OUTPUT
+      end
+
+      before { expect { command }.to output(expected_output).to_stdout }
 
       its(:mirroring_enabled) { is_expected.to be(false) }
     end

--- a/spec/lib/rmt/cli/repos_spec.rb
+++ b/spec/lib/rmt/cli/repos_spec.rb
@@ -1,6 +1,107 @@
 require 'rails_helper'
 
 RSpec.describe RMT::CLI::Repos do
+  describe '#clean' do
+    let(:repository_1) { create :repository, mirroring_enabled: false }
+    let(:repository_2) { create :repository, mirroring_enabled: false }
+    let(:repository_3) { create :repository, mirroring_enabled: true }
+
+    let(:argv) { ['clean'] }
+    let(:input) { 'yes' }
+    let(:dir) { Dir.mktmpdir }
+    let(:repo_1_path) { File.join(dir, repository_1.local_path) }
+    let(:repo_2_path) { File.join(dir, repository_2.local_path) }
+    let(:repo_3_path) { File.join(dir, repository_3.local_path) }
+
+    let(:command) do
+      described_class.start(argv)
+    end
+
+    let(:expected_output) do
+      <<-OUTPUT
+RMT found the following un-mirrored repositories:
+
+\e[31m#{repository_1.description}
+#{repository_2.description}
+
+\e[0m\e[1mWould you like to continue and remove these directories from your local disk?
+\e[22m\s\sOnly 'yes' will be accepted.
+
+  \e[1mEnter a value:\e[22m\s\s
+\e[32mClean finished.\e[0m
+      OUTPUT
+    end
+
+    before do
+      RMT.send(:remove_const, 'DEFAULT_MIRROR_DIR')
+      RMT.const_set('DEFAULT_MIRROR_DIR', dir)
+      FileUtils.mkdir_p(repo_1_path)
+      FileUtils.mkdir_p(repo_2_path)
+      FileUtils.mkdir_p(repo_3_path)
+      $stdin = StringIO.new("#{input}\n")
+    end
+
+    after do
+      FileUtils.rm_r(repo_1_path) if Dir.exist?(repo_1_path)
+      FileUtils.rm_r(repo_2_path) if Dir.exist?(repo_2_path)
+      FileUtils.rm_r(repo_3_path) if Dir.exist?(repo_3_path)
+      $stdin = STDIN
+    end
+
+    it 'deletes repository non-mirrored repository directories' do
+      expect { command }.to output(expected_output).to_stdout.and output('').to_stderr
+
+      expect(Dir.exist?(repo_1_path)).to be(false)
+      expect(Dir.exist?(repo_2_path)).to be(false)
+      expect(Dir.exist?(repo_3_path)).to be(true)
+    end
+
+    context 'cancelled task' do
+      let(:input) { 'no' }
+      let(:expected_output) do
+        <<-OUTPUT
+RMT found the following un-mirrored repositories:
+
+\e[31m#{repository_1.description}
+#{repository_2.description}
+
+\e[0m\e[1mWould you like to continue and remove these directories from your local disk?
+\e[22m\s\sOnly 'yes' will be accepted.
+
+\s\s\e[1mEnter a value:\e[22m\s\s
+Clean cancelled.
+        OUTPUT
+      end
+
+      it 'does not delete repository directories when cancelled' do
+        expect { command }.to output(expected_output).to_stdout.and output('').to_stderr
+
+        expect(Dir.exist?(repo_1_path)).to be(true)
+        expect(Dir.exist?(repo_2_path)).to be(true)
+        expect(Dir.exist?(repo_3_path)).to be(true)
+      end
+    end
+
+    context 'all repositories are mirrored' do
+      let(:repository_1) { create :repository, mirroring_enabled: true }
+      let(:repository_2) { create :repository, mirroring_enabled: true }
+      let(:repository_3) { create :repository, mirroring_enabled: true }
+      let(:expected_output) do
+        <<-OUTPUT
+No un-mirrored repositories found on local disk.
+        OUTPUT
+      end
+
+      it 'does not delete repositories from the disk when they are marked to be mirrored' do
+        expect { command }.to output(expected_output).to_stdout.and output('').to_stderr
+
+        expect(Dir.exist?(repo_1_path)).to be(true)
+        expect(Dir.exist?(repo_2_path)).to be(true)
+        expect(Dir.exist?(repo_3_path)).to be(true)
+      end
+    end
+  end
+
   describe '#enable' do
     subject(:repository) { create :repository, :with_products }
 
@@ -19,7 +120,7 @@ RSpec.describe RMT::CLI::Repos do
 Repository by ID #{repository.scc_id} successfully enabled.
 Repository by ID #{repository_2.scc_id} successfully enabled.
 Repository by ID #{repository_3.scc_id} successfully enabled.
-OUTPUT
+        OUTPUT
       end
 
       it 'enables repository' do
@@ -90,7 +191,9 @@ OUTPUT
 Repository by ID #{repository.scc_id} successfully disabled.
 Repository by ID #{repository_2.scc_id} successfully disabled.
 Repository by ID #{repository_3.scc_id} successfully disabled.
-OUTPUT
+
+\e[1mTo clean up downloaded files, please run 'rmt-cli repos clean'\e[22m
+        OUTPUT
       end
 
       it 'disables repository' do
@@ -138,8 +241,15 @@ OUTPUT
 
     context 'by repo id' do
       let(:argv) { ['disable', repository.scc_id.to_s] }
+      let(:expected_output) do
+        <<-OUTPUT
+Repository by ID #{repository.scc_id} successfully disabled.
 
-      before { expect { command }.to output("Repository by ID #{repository.scc_id} successfully disabled.\n").to_stdout }
+\e[1mTo clean up downloaded files, please run 'rmt-cli repos clean'\e[22m
+        OUTPUT
+      end
+
+      before { expect { command }.to output(expected_output).to_stdout }
 
       its(:mirroring_enabled) { is_expected.to be(false) }
     end

--- a/spec/lib/rmt/cli/repos_spec.rb
+++ b/spec/lib/rmt/cli/repos_spec.rb
@@ -19,17 +19,17 @@ RSpec.describe RMT::CLI::Repos do
 
     let(:expected_output) do
       <<-OUTPUT
-RMT found the following un-mirrored repositories:
+RMT found locally mirrored files from the following repositories which are not marked to be mirrored:
 
 \e[31m#{repository_1.description}
 #{repository_2.description}
 
-\e[0m\e[1mWould you like to continue and remove these directories from your local disk?
+\e[0m\e[1mWould you like to continue and remove the locally mirrored files of these repositories?
 \e[22m\s\sOnly 'yes' will be accepted.
 
   \e[1mEnter a value:\e[22m\s\s
-Deleted repository '#{repository_1.description}'.
-Deleted repository '#{repository_2.description}'.
+Deleted locally mirrored files from repository '#{repository_1.description}'.
+Deleted locally mirrored files from repository '#{repository_2.description}'.
 
 \e[32mClean finished.\e[0m
       OUTPUT
@@ -72,12 +72,12 @@ Deleted repository '#{repository_2.description}'.
       let(:input) { 'no' }
       let(:expected_output) do
         <<-OUTPUT
-RMT found the following un-mirrored repositories:
+RMT found locally mirrored files from the following repositories which are not marked to be mirrored:
 
 \e[31m#{repository_1.description}
 #{repository_2.description}
 
-\e[0m\e[1mWould you like to continue and remove these directories from your local disk?
+\e[0m\e[1mWould you like to continue and remove the locally mirrored files of these repositories?
 \e[22m\s\sOnly 'yes' will be accepted.
 
 \s\s\e[1mEnter a value:\e[22m\s\s
@@ -108,7 +108,7 @@ Clean cancelled.
       let(:repository_3) { create :repository, mirroring_enabled: true }
       let(:expected_output) do
         <<-OUTPUT
-No un-mirrored repositories found on local disk.
+RMT only found locally mirrored files of repositories that are marked to be mirrored.
         OUTPUT
       end
 

--- a/spec/support/deduplication_helpers.rb
+++ b/spec/support/deduplication_helpers.rb
@@ -2,12 +2,6 @@ def deduplication_method(method)
   Settings['mirroring'].dedup_method = method
 end
 
-def add_downloaded_file(checksum_type, checksum, path)
-  DownloadedFile.add_file(checksum_type, checksum, File.size(path), path)
-rescue StandardError
-  nil
-end
-
 def deduplicate(checksum_type, checksum, path)
   ::RMT::Deduplicator.deduplicate(checksum_type, checksum, path)
 rescue ::RMT::Deduplicator::MismatchException

--- a/spec/support/downloaded_files.rb
+++ b/spec/support/downloaded_files.rb
@@ -6,7 +6,7 @@ end
 
 def create_repository_file(dir)
   file_dest = File.join(dir, "#{SecureRandom.alphanumeric(10)}.rpm")
-  File.open(file_dest, "w+") { |file| file.write(SecureRandom.uuid) }
+  File.open(file_dest, 'w+') { |file| file.write(SecureRandom.uuid) }
   digest = Digest.const_get(:SHA256).file(file_dest)
   add_downloaded_file('SHA256', digest, file_dest)
 end

--- a/spec/support/downloaded_files.rb
+++ b/spec/support/downloaded_files.rb
@@ -1,0 +1,12 @@
+def add_downloaded_file(checksum_type, checksum, path)
+  DownloadedFile.add_file(checksum_type, checksum, File.size(path), path)
+rescue StandardError
+  nil
+end
+
+def create_repository_file(dir)
+  file_dest = File.join(dir, "#{SecureRandom.alphanumeric(10)}.rpm")
+  File.open(file_dest, "w+") { |file| file.write(SecureRandom.uuid) }
+  digest = Digest.const_get(:SHA256).file(file_dest)
+  add_downloaded_file('SHA256', digest, file_dest)
+end


### PR DESCRIPTION
We did not give users the ability to remove unused repositories. To fix this, we created a command to delete repository directories which aren't marked to be mirrored.