### PR TITLE
Added a starting Security Policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,3 +143,7 @@ Do you have suggestions for improvement? Let us know!
 Go to [Issues](https://github.com/SUSE/rmt/issues/new), create a new issue and describe what you think could be improved.
 
 Feedback is always welcome!
+
+## Security Policy
+
+Please see our [security policy](docs/SECURITY.md) for more information.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,9 @@
+# Security Policy
+
+## Supported Versions
+
+Currently, only the latest version of RMT is supported. Whenever we release a new version of RMT, we submit it to all supported versions of SLE and openSUSE which support RMT.
+
+## Reporting a Vulnerability
+
+**DO NOT CREATE AN ISSUE** to report a security problem. Instead, please contact the [SUSE Security Team](https://www.suse.com/support/security/contact/) instead.


### PR DESCRIPTION
## Description

Let's avoid users creating security issues in github and instead point
them to the SUSE Security Team.

## Change Type

*Please select the correct option.*

- [x] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [x] I have verified that my code follows RMT's coding standards with `rubocop`.
- [x] I have reviewed my own code and believe that it's ready for an external review.
- [x] I have provided comments for any hard-to-understand code.
- [x] I have documented the `MANUAL.md` file with any changes to the user experience.
- [x] RMT's test coverage remains at 100%.
- [x] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.