### PR TITLE
Fix thor deprecation warning

### DIFF
--- a/lib/rmt/cli/base.rb
+++ b/lib/rmt/cli/base.rb
@@ -107,6 +107,9 @@ class RMT::CLI::Base < Thor
       Etc.getpwuid(Process.euid).name
     end
 
+    def exit_on_failure?
+      true
+    end
   end
 
   private


### PR DESCRIPTION
## Description

In the upgrade to thor 1.0.0, we missed a deprecation warning for thor.
If we don't define exit_on_failure? for RMT::CLI::Main, thor gives a
deprecation warning when it encounters a failure.

To keep previous behaviour, the recommendation is to return false.
However, as we were returning 0 for errors, the previous behaviour
wasn't correct. To fix that, let's return true instead.

See: https://github.com/erikhuda/thor/blob/master/CHANGELOG.md#100

## Change Type

*Please select the correct option.*

- [x] **Bug Fix** (a non-breaking change which fixes an issue)

## Checklist

*Please check off each item if the requirement is met.*

- [x] I have verified that my code follows RMT's coding standards with `rubocop`.
- [x] I have reviewed my own code and believe that it's ready for an external review.
- [x] I have provided comments for any hard-to-understand code.
- [x] I have documented the `MANUAL.md` file with any changes to the user experience.
- [x] RMT's test coverage remains at 100%.
- [x] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.
