### PR TITLE
Fix integration tests

### DIFF
--- a/features/repos_spec.rb
+++ b/features/repos_spec.rb
@@ -14,6 +14,9 @@ describe 'enable repos' do
   end
 
   it do
-    expect(`/usr/bin/rmt-cli repos list | wc -l`.strip&.to_i ).to eq(10) # 5 lines for table headers
+    # We need to remove the Installer-Updates from our list of repos because they are added by default.
+    # We cannot just keep them and change the expectation because the number will grow with every newly released product
+    # and break this test.
+    expect(`/usr/bin/rmt-cli repos list | grep -v Installer-Updates | wc -l`.strip&.to_i).to eq(10) # 5 lines for table headers
   end
 end


### PR DESCRIPTION
## Description

Because we've enabled the installer updates repository, we have more repositories in our list than before. If we don't remove them from the list with grep, the list will grow with every newly released product and break our tests.

## Change Type

*Please select the correct option.*

- [x] **Bug Fix** (a non-breaking change which fixes an issue)

## Checklist

*Please check off each item if the requirement is met.*

- [x] I have verified that my code follows RMT's coding standards with `rubocop`.
- [x] I have reviewed my own code and believe that it's ready for an external review.
- [x] I have provided comments for any hard-to-understand code.
- [x] I have documented the `MANUAL.md` file with any changes to the user experience.
- [x] RMT's test coverage remains at 100%.
- [x] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.