### PR TITLE
Fix typo

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -6,4 +6,4 @@ Currently, only the latest version of RMT is supported. Whenever we release a ne
 
 ## Reporting a Vulnerability
 
-**DO NOT CREATE AN ISSUE** to report a security problem. Instead, please contact the [SUSE Security Team](https://www.suse.com/support/security/contact/) instead.
+**DO NOT CREATE AN ISSUE** to report a security problem. Instead, please contact the [SUSE Security Team](https://www.suse.com/support/security/contact/).


### PR DESCRIPTION
## Description

Instead is used two times in one sentence.

## Change Type

*Please select the correct option.*

- [x] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [x] I have verified that my code follows RMT's coding standards with `rubocop`.
- [x] I have reviewed my own code and believe that it's ready for an external review.
- [x] I have provided comments for any hard-to-understand code.
- [x] I have documented the `MANUAL.md` file with any changes to the user experience.
- [x] RMT's test coverage remains at 100%.
- [x] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.