### PR TITLE
Check if fully mirrored before activating product

### DIFF
--- a/app/controllers/api/connect/v3/systems/products_controller.rb
+++ b/app/controllers/api/connect/v3/systems/products_controller.rb
@@ -91,9 +91,9 @@ class Api::Connect::V3::Systems::ProductsController < Api::Connect::BaseControll
     end
 
     mandatory_repos = @product.repositories.only_enabled
-    mirrored_repos = @product.repositories.only_enabled.only_mirrored
+    mirrored_repos = @product.repositories.only_enabled.only_fully_mirrored
 
-    unless (mandatory_repos.size == mirrored_repos.size)
+    unless mandatory_repos.size == mirrored_repos.size
       fail ActionController::TranslatedError.new(N_('Not all mandatory repositories are mirrored for product %s'), @product.friendly_name)
     end
   end

--- a/app/controllers/api/connect/v4/repositories/installer_controller.rb
+++ b/app/controllers/api/connect/v4/repositories/installer_controller.rb
@@ -6,7 +6,7 @@ class Api::Connect::V4::Repositories::InstallerController < Api::Connect::BaseCo
 
     if product
       respond_with ActiveModel::Serializer::CollectionSerializer.new(
-        product.repositories.only_installer_updates.only_mirrored,
+        product.repositories.only_installer_updates.only_mirroring_enabled,
         serializer: ::V3::RepositorySerializer,
         base_url: request.base_url
       )

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -6,7 +6,7 @@ class Repository < ApplicationRecord
   has_many :products, -> { distinct }, through: :services
 
   scope :only_installer_updates, -> { where(installer_updates: true) }
-  scope :only_mirrored, -> { where(mirroring_enabled: true) }
+  scope :only_mirroring_enabled, -> { where(mirroring_enabled: true) }
   scope :only_fully_mirrored, -> { where(mirroring_enabled: true).where.not(last_mirrored_at: nil) }
   scope :only_enabled, -> { where(enabled: true) }
   scope :only_custom, -> { where(scc_id: nil) }

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -7,6 +7,7 @@ class Repository < ApplicationRecord
 
   scope :only_installer_updates, -> { where(installer_updates: true) }
   scope :only_mirrored, -> { where(mirroring_enabled: true) }
+  scope :only_fully_mirrored, -> { where(mirroring_enabled: true).where.not(last_mirrored_at: nil) }
   scope :only_enabled, -> { where(enabled: true) }
   scope :only_custom, -> { where(scc_id: nil) }
   scope :only_scc, -> { where.not(scc_id: nil) }

--- a/lib/rmt.rb
+++ b/lib/rmt.rb
@@ -1,5 +1,5 @@
 module RMT
-  VERSION ||= '2.5.14'.freeze
+  VERSION ||= '2.5.15'.freeze
 
   DEFAULT_USER = '_rmt'.freeze
   DEFAULT_GROUP = 'nginx'.freeze

--- a/lib/rmt/cli/export.rb
+++ b/lib/rmt/cli/export.rb
@@ -11,7 +11,7 @@ class RMT::CLI::Export < RMT::CLI::Base
     needs_path(path, writable: true)
     filename = File.join(path, 'repos.json')
 
-    data = Repository.only_mirrored.inject([]) { |data, repo| data << { url: repo.external_url, auth_token: repo.auth_token.to_s } }
+    data = Repository.only_mirroring_enabled.inject([]) { |data, repo| data << { url: repo.external_url, auth_token: repo.auth_token.to_s } }
     File.write(filename, data.to_json)
     puts _('Settings saved at %{file}.') % { file: filename }
   end

--- a/lib/rmt/cli/repos.rb
+++ b/lib/rmt/cli/repos.rb
@@ -98,7 +98,7 @@ REPOS
   protected
 
   def list_repositories(scope: :enabled)
-    repositories = ((scope == :all) ? Repository.only_scc : Repository.only_scc.only_mirrored).order(:name, :description)
+    repositories = ((scope == :all) ? Repository.only_scc : Repository.only_scc.only_mirroring_enabled).order(:name, :description)
     decorator = ::RMT::CLI::Decorators::RepositoryDecorator.new(repositories)
 
     if repositories.empty?

--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -1,4 +1,14 @@
 -------------------------------------------------------------------
+Mon Aug 31 14:04:20 UTC 2020 - Thomas Muntaner <tmuntaner@suse.com>
+
+- Version 2.5.15
+- RMT now checks if repositories are fully mirrored during the
+  activation process. Previously, RMT only checked if the repositories
+  were enabled to be mirrored, but not that they were actually mirrored.
+  In this case, RMTs were not able to provide the repository data which
+  systems assumed it had.
+
+-------------------------------------------------------------------
 Mon Aug 24 10:04:26 UTC 2020 - Jesús Bermúdez Velázquez <jesus.bv@suse.com>
 
 - Version 2.5.14

--- a/package/obs/rmt-server.spec
+++ b/package/obs/rmt-server.spec
@@ -29,7 +29,7 @@
 %define ruby_version          %{rb_default_ruby_suffix}
 
 Name:           rmt-server
-Version:        2.5.14
+Version:        2.5.15
 Release:        0
 Summary:        Repository mirroring tool and registration proxy for SCC
 License:        GPL-2.0-or-later

--- a/spec/factories/activations.rb
+++ b/spec/factories/activations.rb
@@ -11,7 +11,7 @@ FactoryGirl.define do
 
     trait :with_mirrored_product do
       after :build do |activation, _evaluator|
-        activation.service.product.repositories.update_all(mirroring_enabled: true)
+        activation.service.product.repositories.update_all(mirroring_enabled: true, last_mirrored_at: Time.zone.now)
       end
     end
   end

--- a/spec/factories/services.rb
+++ b/spec/factories/services.rb
@@ -9,14 +9,16 @@ FactoryGirl.define do
 
       after :create do |service, evaluator|
         name_prefix = service.product.name
+        last_mirrored_at = evaluator.mirroring_enabled ? Time.zone.now : nil
 
         service.repositories << [
-          FactoryGirl.create(:repository, name: "#{name_prefix}-Pool", mirroring_enabled: evaluator.mirroring_enabled),
-          FactoryGirl.create(:repository, name: "#{name_prefix}-Updates", mirroring_enabled: evaluator.mirroring_enabled),
+          FactoryGirl.create(:repository, name: "#{name_prefix}-Pool", mirroring_enabled: evaluator.mirroring_enabled, last_mirrored_at: last_mirrored_at),
+          FactoryGirl.create(:repository, name: "#{name_prefix}-Updates", mirroring_enabled: evaluator.mirroring_enabled, last_mirrored_at: last_mirrored_at),
           FactoryGirl.create(
             :repository,
             name: "#{name_prefix}-Installer-Updates",
             mirroring_enabled: evaluator.mirroring_enabled,
+            last_mirrored_at: last_mirrored_at,
             installer_updates: true,
             enabled: false
           ),
@@ -24,6 +26,7 @@ FactoryGirl.define do
             :repository,
             name: "#{name_prefix}-Debuginfo-Updates",
             mirroring_enabled: evaluator.mirroring_enabled,
+            last_mirrored_at: last_mirrored_at,
             installer_updates: false,
             enabled: false
           )
@@ -38,12 +41,14 @@ FactoryGirl.define do
 
       after :create do |service, evaluator|
         name_prefix = service.product.name
+        last_mirrored_at = evaluator.mirroring_enabled ? Time.zone.now : nil
 
         service.repositories << [
           FactoryGirl.create(
             :repository,
             name: "#{name_prefix}-Installer-Updates",
             mirroring_enabled: evaluator.mirroring_enabled,
+            last_mirrored_at: last_mirrored_at,
             installer_updates: true,
             enabled: false
           ),
@@ -51,6 +56,7 @@ FactoryGirl.define do
             :repository,
             name: "#{name_prefix}-Debuginfo-Updates",
             mirroring_enabled: evaluator.mirroring_enabled,
+            last_mirrored_at: last_mirrored_at,
             installer_updates: false,
             enabled: false
           )

--- a/spec/lib/rmt/cli/products_spec.rb
+++ b/spec/lib/rmt/cli/products_spec.rb
@@ -483,7 +483,7 @@ RSpec.describe RMT::CLI::Products do
       repos.each do |repo|
         mandatory = repo.enabled ? 'mandatory' : 'non-mandatory'
         enabled = repo.mirroring_enabled ? 'enabled' : 'not enabled'
-        mirrored = repo.last_mirrored_at.present? ? "last mirrored at #{repo.last_mirrored_at.strftime('%Y-%m-%d %H:%M:%S %Z')}" : 'not mirrored'
+        mirrored = repo.last_mirrored_at.present? ? "mirrored at #{repo.last_mirrored_at.strftime('%Y-%m-%d %H:%M:%S %Z')}" : 'not mirrored'
         output += "* #{repo.name} (id: #{repo.scc_id}) (#{mandatory}, #{enabled}, #{mirrored})\n"
       end
       output

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -27,6 +27,16 @@ RSpec.describe Repository, type: :model do
       it { is_expected.to contain_exactly(mirrored) }
     end
 
+    describe '.only_fully_mirrored' do
+      subject { described_class.only_fully_mirrored }
+
+      let!(:mirrored) { create :repository, mirroring_enabled: true, last_mirrored_at: Time.zone.now }
+
+      before { create :repository, mirroring_enabled: true }
+
+      it { is_expected.to contain_exactly(mirrored) }
+    end
+
     describe '.only_enabled' do
       subject { described_class.only_enabled }
 

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe Repository, type: :model do
   it { is_expected.to have_db_column(:external_url).of_type(:string).with_options(null: false) }
 
   describe 'scopes' do
-    describe '.only_mirrored' do
-      subject { described_class.only_mirrored }
+    describe '.only_mirroring_enabled' do
+      subject { described_class.only_mirroring_enabled }
 
       let!(:mirrored) { create :repository, mirroring_enabled: true }
 


### PR DESCRIPTION
## Description

When we checked if a product was mirrored for product activation, we only verified that a product was enabled for mirroring. Instead, let's check if RMT mirrored that product at least once with last_mirrored_at.

## Change Type

*Please select the correct option.*

- [x] **Bug Fix** (a non-breaking change which fixes an issue)

## Checklist

*Please check off each item if the requirement is met.*

- [x] I have verified that my code follows RMT's coding standards with `rubocop`.
- [x] I have reviewed my own code and believe that it's ready for an external review.
- [x] I have provided comments for any hard-to-understand code.
- [x] I have documented the `MANUAL.md` file with any changes to the user experience.
- [x] RMT's test coverage remains at 100%.
- [x] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.