### PR TITLE
Have a Singular Id for SCC and Custom Repositories

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -128,6 +128,8 @@ After successful registration the repositories from RMT will be used by `zypper`
     Adds a new custom repository, for example:
 
     `rmt-cli repos custom add https://download.opensuse.org/repositories/Virtualization:/containers/SLE_12_SP3/ Virtualization:Containers`
+    
+    `rmt-cli repos custom add https://download.opensuse.org/repositories/Virtualization:/containers/SLE_12_SP3/ Virtualization:Containers --id containers_sle_12_sp3`
 
   * `rmt-cli repos custom enable <id>`:
     Enables mirroring for a custom repository.

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -16,6 +16,7 @@ class Repository < ApplicationRecord
   validates :name, presence: true
   validates :external_url, presence: true
   validates :local_path, presence: true
+  validates :friendly_id, presence: true
 
   before_destroy :ensure_destroy_possible
 
@@ -45,6 +46,10 @@ class Repository < ApplicationRecord
 
   def custom?
     scc_id.nil?
+  end
+
+  def self.make_friendly_url_id(url)
+    Digest::MD5.hexdigest(url)
   end
 
   private

--- a/app/services/repository_service.rb
+++ b/app/services/repository_service.rb
@@ -9,7 +9,13 @@ class RepositoryService
     repository.attributes = attributes.select do |k, _|
       repository.attributes.keys.member?(k.to_s) && k.to_s != 'id'
     end
-    repository.scc_id = attributes[:id] unless custom
+
+    if custom
+      repository.friendly_id = attributes[:id].to_s != '' ? attributes[:id] : Repository.make_friendly_url_id(url)
+    else
+      repository.scc_id = attributes[:id]
+      repository.friendly_id = attributes[:id]
+    end
 
     repository.external_url = url
     repository.local_path = Repository.make_local_path(url)

--- a/db/migrate/20200916104804_make_scc_id_unique.rb
+++ b/db/migrate/20200916104804_make_scc_id_unique.rb
@@ -1,0 +1,28 @@
+class MakeSccIdUnique < ActiveRecord::Migration[6.0]
+  def change
+    logger = RMT::Logger.new(STDOUT)
+
+    logger.info(_('Adding index to `repositories.scc_id` before querying duplicates...'))
+    add_index :repositories, :scc_id, unique: false
+
+    logger.info(_('Removing duplicated records on `repositories.scc_id`...'))
+    ActiveRecord::Base.connection.execute(
+      <<~SQL
+      UPDATE repositories as r1
+        JOIN(
+          SELECT scc_id FROM repositories
+          GROUP BY repositories.scc_id
+          HAVING (count(*) > 1)
+        ) AS r2
+        ON r1.scc_id = r2.scc_id
+      SET r1.scc_id = NULL
+      WHERE r1.scc_id = r2.scc_id;
+      SQL
+    )
+
+    # Add unique index to `local_path`
+    logger.info(_('Adding an unique index to `repositories.scc_id`...'))
+    remove_index :repositories, name: :index_repositories_on_scc_id
+    add_index :repositories, :scc_id, unique: true
+  end
+end

--- a/db/migrate/20200916120607_add_friendly_target_to_repositories.rb
+++ b/db/migrate/20200916120607_add_friendly_target_to_repositories.rb
@@ -1,0 +1,14 @@
+class AddFriendlyTargetToRepositories < ActiveRecord::Migration[6.0]
+  def change
+    add_column :repositories, :friendly_id, :string
+    add_index :repositories, :friendly_id, unique: true
+
+    Repository.all.each do |repo|
+      if repo.custom?
+        repo.update(friendly_id: Repository.make_friendly_url_id(repo.external_url))
+      else
+        repo.update(friendly_id: repo.scc_id)
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_16_104804) do
+ActiveRecord::Schema.define(version: 2020_09_16_120607) do
 
   create_table "activations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "service_id", null: false
@@ -104,7 +104,9 @@ ActiveRecord::Schema.define(version: 2020_09_16_104804) do
     t.boolean "mirroring_enabled", default: false, null: false
     t.string "local_path", null: false
     t.datetime "last_mirrored_at"
+    t.string "friendly_id"
     t.index ["external_url"], name: "index_repositories_on_external_url", unique: true
+    t.index ["friendly_id"], name: "index_repositories_on_friendly_id", unique: true
     t.index ["scc_id"], name: "index_repositories_on_scc_id", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,15 +2,15 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_23_124836) do
+ActiveRecord::Schema.define(version: 2020_09_16_104804) do
 
   create_table "activations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "service_id", null: false
@@ -105,6 +105,7 @@ ActiveRecord::Schema.define(version: 2020_07_23_124836) do
     t.string "local_path", null: false
     t.datetime "last_mirrored_at"
     t.index ["external_url"], name: "index_repositories_on_external_url", unique: true
+    t.index ["scc_id"], name: "index_repositories_on_scc_id", unique: true
   end
 
   create_table "repositories_services", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -157,10 +158,6 @@ ActiveRecord::Schema.define(version: 2020_07_23_124836) do
     t.index ["login"], name: "index_systems_on_login", unique: true
   end
 
-  add_foreign_key "activations", "services", on_delete: :cascade
-  add_foreign_key "activations", "systems", on_delete: :cascade
-  add_foreign_key "product_predecessors", "products", column: "predecessor_id"
-  add_foreign_key "product_predecessors", "products", on_delete: :cascade
   add_foreign_key "products_extensions", "products", column: "extension_id", on_delete: :cascade
   add_foreign_key "products_extensions", "products", column: "root_product_id"
   add_foreign_key "products_extensions", "products", on_delete: :cascade

--- a/lib/rmt.rb
+++ b/lib/rmt.rb
@@ -1,5 +1,5 @@
 module RMT
-  VERSION ||= '2.5.20'.freeze
+  VERSION ||= '2.6.0'.freeze
 
   DEFAULT_USER = '_rmt'.freeze
   DEFAULT_GROUP = 'nginx'.freeze

--- a/lib/rmt/cli/decorators/custom_repository_decorator.rb
+++ b/lib/rmt/cli/decorators/custom_repository_decorator.rb
@@ -7,7 +7,7 @@ class RMT::CLI::Decorators::CustomRepositoryDecorator < RMT::CLI::Decorators::Ba
   def to_csv
     data = @repositories.map do |repo|
       [
-        repo.id,
+        repo.friendly_id,
         repo.name,
         repo.external_url,
         repo.enabled,
@@ -28,7 +28,7 @@ class RMT::CLI::Decorators::CustomRepositoryDecorator < RMT::CLI::Decorators::Ba
   def to_table
     data = @repositories.map do |repo|
       [
-        repo.id,
+        repo.friendly_id,
         repo.name,
         repo.external_url,
         repo.enabled ? _('Mandatory') : _('Not Mandatory'),

--- a/lib/rmt/cli/decorators/repository_decorator.rb
+++ b/lib/rmt/cli/decorators/repository_decorator.rb
@@ -7,7 +7,7 @@ class RMT::CLI::Decorators::RepositoryDecorator < RMT::CLI::Decorators::Base
   def to_csv
     data = @repositories.map do |repo|
       [
-        repo.scc_id,
+        repo.friendly_id,
         repo.name,
         repo.description,
         repo.enabled,
@@ -16,7 +16,7 @@ class RMT::CLI::Decorators::RepositoryDecorator < RMT::CLI::Decorators::Base
       ]
     end
     array_to_csv(data, [
-      _('SCC ID'),
+      _('ID'),
       _('Product'),
       _('Description'),
       _('Mandatory?'),
@@ -28,7 +28,7 @@ class RMT::CLI::Decorators::RepositoryDecorator < RMT::CLI::Decorators::Base
   def to_table
     data = @repositories.map do |repo|
       [
-        repo.scc_id,
+        repo.friendly_id,
         repo.description,
         repo.enabled ? _('Mandatory') : _('Not Mandatory'),
         repo.mirroring_enabled ? _('Mirror') : _("Don't Mirror"),
@@ -36,7 +36,7 @@ class RMT::CLI::Decorators::RepositoryDecorator < RMT::CLI::Decorators::Base
       ]
     end
     array_to_table(data, [
-      _('SCC ID'),
+      _('ID'),
       _('Product'),
       _('Mandatory?'),
       _('Mirror?'),
@@ -51,7 +51,7 @@ class RMT::CLI::Decorators::RepositoryDecorator < RMT::CLI::Decorators::Base
     data = @repositories.map do |repo|
       [
         repo.name,
-        repo.scc_id,
+        repo.friendly_id,
         repo.enabled ? _('mandatory') : _('non-mandatory'),
         repo.mirroring_enabled ? _('enabled') : _('not enabled'),
         repo.last_mirrored_at.present? ? _('mirrored at %{time}') % { time: repo.last_mirrored_at.strftime('%Y-%m-%d %H:%M:%S %Z') } : _('not mirrored')

--- a/lib/rmt/cli/mirror.rb
+++ b/lib/rmt/cli/mirror.rb
@@ -34,7 +34,7 @@ class RMT::CLI::Mirror < RMT::CLI::Base
       raise RMT::CLI::Error.new(_('No repository IDs supplied')) if ids.empty?
 
       repos = ids.map do |id|
-        repo = Repository.find_by(scc_id: id)
+        repo = Repository.find_by(friendly_id: id)
         errors << _('Repository with ID %{repo_id} not found') % { repo_id: id } if repo.nil?
 
         repo
@@ -86,7 +86,7 @@ class RMT::CLI::Mirror < RMT::CLI::Base
   def mirror_repos!(repos)
     repos.compact.each do |repo|
       unless repo.mirroring_enabled
-        errors << _('Mirroring of repository with ID %{repo_id} is not enabled') % { repo_id: repo.scc_id }
+        errors << _('Mirroring of repository with ID %{repo_id} is not enabled') % { repo_id: repo.friendly_id }
         next
       end
 

--- a/lib/rmt/cli/repos.rb
+++ b/lib/rmt/cli/repos.rb
@@ -1,7 +1,4 @@
-class RMT::CLI::Repos < RMT::CLI::Base
-
-  class RepoNotFoundException < StandardError
-  end
+class RMT::CLI::Repos < RMT::CLI::ReposBase
 
   desc 'custom', _('List and modify custom repositories')
   subcommand 'custom', RMT::CLI::ReposCustom
@@ -116,41 +113,5 @@ REPOS
       puts _("Only enabled repositories are shown by default. Use the '%{option}' option to see all repositories.") % { option: '--all' }
     end
   end
-
-  def change_repos(ids, set_enabled)
-    ids = clean_target_input(ids)
-    raise RMT::CLI::Error.new(_('No repository ids supplied')) if ids.empty?
-
-    failed_repos = []
-    ids.each do |id|
-      change_repo(id, set_enabled)
-    rescue RepoNotFoundException => e
-      warn e.message
-      failed_repos << id
-    end
-
-    unless failed_repos.empty?
-      message = if set_enabled
-                  n_('Repository %{repos} could not be found and was not enabled.',
-                     'Repositories %{repos} could not be found and were not enabled.',
-                     failed_repos.count) % { repos: failed_repos.join(', ') }
-                else
-                  n_('Repository %{repos} could not be found and was not disabled.',
-                     'Repositories %{repos} could not be found and were not disabled.',
-                     failed_repos.count) % { repos: failed_repos.join(', ') }
-                end
-      raise RMT::CLI::Error.new(message)
-    end
-  end
-
-  def change_repo(id, set_enabled)
-    repository = Repository.find_by!(scc_id: id)
-    repository.change_mirroring!(set_enabled)
-
-    puts set_enabled ? _('Repository by ID %{id} successfully enabled.') % { id: id } : _('Repository by ID %{id} successfully disabled.') % { id: id }
-  rescue ActiveRecord::RecordNotFound
-    raise RepoNotFoundException.new(_('Repository not found by ID %{id}.') % { id: id })
-  end
-
 
 end

--- a/lib/rmt/cli/repos_base.rb
+++ b/lib/rmt/cli/repos_base.rb
@@ -39,12 +39,13 @@ class RMT::CLI::ReposBase < RMT::CLI::Base
   end
 
   def find_repository!(id, custom: false)
-    repository = Repository.find_by!(friendly_id: id)
-    raise StandardError if custom && !repository.custom?
+    repository = Repository.find_by(id: id) if custom # allow fallback for old IDs when dealing with custom repos
+    repository ||= Repository.find_by(friendly_id: id)
+
+    if repository.nil? || (custom && !repository.custom?)
+      raise RepoNotFoundException.new(_('Repository by ID %{id} not found.') % { id: id })
+    end
 
     repository
-  rescue ActiveRecord::RecordNotFound, StandardError
-    raise RepoNotFoundException.new(_('Repository by ID %{id} not found.') % { id: id })
   end
-
 end

--- a/lib/rmt/cli/repos_custom.rb
+++ b/lib/rmt/cli/repos_custom.rb
@@ -1,20 +1,36 @@
-class RMT::CLI::ReposCustom < RMT::CLI::Base
+class RMT::CLI::ReposCustom < RMT::CLI::ReposBase
 
   desc 'add URL NAME', _('Creates a custom repository.')
+  option :id, type: :string, desc: _('Provide a custom ID instead of allowing RMT to generate one.')
+  long_desc <<-REPOS
+#{_('Creates a custom repository.')}
+
+#{_('Examples:')}
+
+$ rmt-cli repos custom add https://download.opensuse.org/repositories/Virtualization:/containers/SLE_12_SP3/ Virtualization:Containers
+
+$ rmt-cli repos custom add https://download.opensuse.org/repositories/Virtualization:/containers/SLE_12_SP3/ Virtualization:Containers --id containers_sle_12_sp3`
+  REPOS
   def add(url, name)
     url += '/' unless url.end_with?('/')
+    friendly_id = options.id.to_s
 
-    previous_repository = Repository.find_by(external_url: url)
-
-    if previous_repository
+    if Repository.find_by(external_url: url)
       raise RMT::CLI::Error.new(_('A repository by the URL %{url} already exists.') % { url: url })
+    end
+
+    if /^[0-9]+$/.match?(friendly_id) # numeric IDs are reserved for SCC repositories
+      raise RMT::CLI::Error.new(_('Please provide a non-numeric ID for your custom repository.'))
+    elsif Repository.find_by(friendly_id: friendly_id)
+      raise RMT::CLI::Error.new(_('A repository by the ID %{id} already exists.') % { id: friendly_id })
     end
 
     repository_service.create_repository!(nil, url, {
       name: name,
       mirroring_enabled: true,
       autorefresh: true,
-      enabled: 0
+      enabled: 0,
+      id: friendly_id
     }, custom: true)
 
     puts _('Successfully added custom repository.')
@@ -22,7 +38,6 @@ class RMT::CLI::ReposCustom < RMT::CLI::Base
 
   desc 'list', _('List all custom repositories')
   option :csv, type: :boolean, desc: _('Output data in CSV format')
-
   def list
     repositories = Repository.only_custom.order(:name)
     decorator = ::RMT::CLI::Decorators::CustomRepositoryDecorator.new(repositories)
@@ -37,24 +52,44 @@ class RMT::CLI::ReposCustom < RMT::CLI::Base
   end
   map 'ls' => :list
 
-  desc 'enable ID', _('Enable mirroring of custom repository by ID')
-  def enable(id)
-    change_mirroring(id, true)
+  desc 'enable ID', _('Enable mirroring of custom repositories by a list of IDs')
+  long_desc <<-REPOS
+#{_('Enable mirroring of custom repositories by a list of IDs')}
+
+#{_('Examples:')}
+
+$ rmt-cli repos custom enable e133a7b26a7701b1d65a61683e50512b
+
+$ rmt-cli repos custom enable e133a7b26a7701b1d65a61683e50512b 7726fb7f1954d786860426b47748856c
+  REPOS
+  def enable(*ids)
+    change_repos(ids, true, custom: true)
   end
 
-  desc 'disable ID', _('Disable mirroring of custom repository by ID')
-  def disable(id)
-    change_mirroring(id, false)
+  desc 'disable ID', _('Disable mirroring of custom repository by a list of IDs')
+  long_desc <<-REPOS
+#{_('Disable mirroring of custom repositories by a list of IDs')}
+
+#{_('Examples:')}
+
+$ rmt-cli repos custom disable e133a7b26a7701b1d65a61683e50512b
+
+$ rmt-cli repos custom disable e133a7b26a7701b1d65a61683e50512b 7726fb7f1954d786860426b47748856c
+  REPOS
+  def disable(*ids)
+    change_repos(ids, false, custom: true)
 
     puts "\n\e[1m" + _("To clean up downloaded files, please run '%{command}'") % { command: 'rmt-cli repos clean' } + "\e[22m"
   end
 
   desc 'remove ID', _('Remove a custom repository')
   def remove(id)
-    repository = find_repository!(id)
+    repository = find_repository!(id, custom: true)
     repository.destroy!
 
     puts _('Removed custom repository by ID %{id}.') % { id: id }
+  rescue RepoNotFoundException => e
+    raise RMT::CLI::Error.new(e.message)
   end
   map 'rm' => :remove
 
@@ -62,7 +97,7 @@ class RMT::CLI::ReposCustom < RMT::CLI::Base
   option :csv, type: :boolean, desc: _('Output data in CSV format')
 
   def products(id)
-    repository = find_repository!(id)
+    repository = find_repository!(id, custom: true)
     products = repository.products
     decorator = ::RMT::CLI::Decorators::CustomRepositoryProductsDecorator.new(products)
 
@@ -72,42 +107,33 @@ class RMT::CLI::ReposCustom < RMT::CLI::Base
     else
       puts decorator.to_table
     end
+  rescue RepoNotFoundException => e
+    raise RMT::CLI::Error.new(e.message)
   end
 
   desc 'attach ID PRODUCT_ID', _('Attach an existing custom repository to a product')
   def attach(id, product_id)
-    repository = find_repository!(id)
+    repository = find_repository!(id, custom: true)
     product = find_product!(product_id)
     repository_service.attach_product!(product, repository)
 
     puts _("Attached repository to product '%{product_name}'.") % { product_name: product.name }
+  rescue RepoNotFoundException => e
+    raise RMT::CLI::Error.new(e.message)
   end
 
   desc 'detach ID PRODUCT_ID', _('Detach an existing custom repository from a product')
   def detach(id, product_id)
-    repository = find_repository!(id)
+    repository = find_repository!(id, custom: true)
     product = find_product!(product_id)
     repository_service.detach_product!(product, repository)
 
     puts _("Detached repository from product '%{product_name}'.") % { product_name: product.name }
+  rescue RepoNotFoundException => e
+    raise RMT::CLI::Error.new(e.message)
   end
 
   private
-
-  def change_mirroring(id, set_enabled)
-    repository = find_repository!(id)
-    repository.change_mirroring!(set_enabled)
-
-    puts set_enabled ? _('Repository successfully enabled.') : _('Repository successfully disabled.')
-  end
-
-  def find_repository!(id)
-    repository = Repository.find_by!(id: id)
-    raise StandardError unless repository.custom?
-    repository
-  rescue
-    raise RMT::CLI::Error.new(_('Cannot find custom repository by ID %{id}.') % { id: id })
-  end
 
   def find_product!(id)
     Product.find_by!(id: id)

--- a/lib/rmt/cli/smt_importer.rb
+++ b/lib/rmt/cli/smt_importer.rb
@@ -31,7 +31,7 @@ class RMT::CLI::SMTImporter
   def import_repositories
     read_csv('enabled_repos').each do |row|
       repo_id, _ = row
-      repo = Repository.find_by(scc_id: repo_id)
+      repo = Repository.find_by(friendly_id: repo_id)
       if repo
         repo.mirroring_enabled = true
         repo.save!
@@ -52,6 +52,7 @@ class RMT::CLI::SMTImporter
       repo = Repository.find_or_create_by(external_url: repo_url) do |repository|
         repository.name = repo_name
         repository.local_path = Repository.make_local_path(repo_url)
+        repository.friendly_id = Repository.make_friendly_url_id(repo_url)
       end
 
       if product

--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -15,6 +15,8 @@ Mon Sep 21 16:44:23 UTC 2020 - Thomas Muntaner <tmuntaner@suse.com>
 
   Deprecation Warnings:
   * RMT now uses a different ID for custom repositories than before.
+    RMT still supports that old ID, but it's recommended to start
+    using the new ID to ensure future compatibility.
 
 -------------------------------------------------------------------
 Mon Sep 10 14:10:45 UTC 2020 - Thomas Muntaner <tmuntaner@suse.com>

--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -1,4 +1,22 @@
 -------------------------------------------------------------------
+Mon Sep 21 16:44:23 UTC 2020 - Thomas Muntaner <tmuntaner@suse.com>
+
+- Version 2.6.0
+- Friendlier IDs for custom repositories:
+  In an effort to simplify the handling of SCC and custom repositories,
+  RMT now has friendly IDs. For SCC repositories, it's the same SCC ID
+  as before. For custom repositories, it can either be user provided
+  or RMT generated (MD5 of the provided URL).
+
+  Benefits:
+  * `rmt-cli mirror repositories` now works for custom repositories.
+  * Custom repository IDs can be the same across RMT instances.
+  * No more confusing "SCC ID" vs "ID" in `rmt-cli` output.
+
+  Deprecation Warnings:
+  * RMT now uses a different ID for custom repositories than before.
+
+-------------------------------------------------------------------
 Mon Sep 10 14:10:45 UTC 2020 - Thomas Muntaner <tmuntaner@suse.com>
 
 - Version 2.5.20

--- a/package/obs/rmt-server.spec
+++ b/package/obs/rmt-server.spec
@@ -29,7 +29,7 @@
 %define ruby_version          %{rb_default_ruby_suffix}
 
 Name:           rmt-server
-Version:        2.5.20
+Version:        2.6.0
 Release:        0
 Summary:        Repository mirroring tool and registration proxy for SCC
 License:        GPL-2.0-or-later

--- a/spec/factories/repositories.rb
+++ b/spec/factories/repositories.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :repository do
     sequence(:scc_id) { |n| n }
+    sequence(:friendly_id) { |n| n }
     sequence(:name) { |n| "Repository #{n}" }
     sequence(:description) { |n| "Repository #{n}" }
     sequence(:external_url) { |n| "https://updates.suse.com/suse/repository_#{n}" }

--- a/spec/factories/repositories.rb
+++ b/spec/factories/repositories.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :repository do
     sequence(:scc_id) { |n| n }
-    sequence(:friendly_id) { |n| n }
+    sequence(:friendly_id) { |n| "aRepO#{n}" }
     sequence(:name) { |n| "Repository #{n}" }
     sequence(:description) { |n| "Repository #{n}" }
     sequence(:external_url) { |n| "https://updates.suse.com/suse/repository_#{n}" }

--- a/spec/lib/rmt/cli/mirror_spec.rb
+++ b/spec/lib/rmt/cli/mirror_spec.rb
@@ -159,7 +159,7 @@ RSpec.describe RMT::CLI::Mirror do
 
     context 'when repository mirroring is enabled' do
       let!(:repository) { create :repository, :with_products, mirroring_enabled: true }
-      let(:argv) { ['repository', repository.scc_id] }
+      let(:argv) { ['repository', repository.friendly_id] }
 
       it 'mirrors the repository' do
         expect_any_instance_of(RMT::Mirror).to receive(:mirror).with(
@@ -175,7 +175,7 @@ RSpec.describe RMT::CLI::Mirror do
 
     context 'when an exception is raised during mirroring' do
       let!(:repository) { create :repository, :with_products, mirroring_enabled: true }
-      let(:argv) { ['repository', repository.scc_id] }
+      let(:argv) { ['repository', repository.friendly_id] }
       let(:mirroring_error) { 'mirroring failed' }
       let(:error_messages) { /Repository '#{repository.name}' \(#{repository.id}\): #{mirroring_error}\./ }
 
@@ -193,8 +193,8 @@ RSpec.describe RMT::CLI::Mirror do
 
     context 'when repository mirroring is disabled' do
       let!(:repository) { create :repository, :with_products, mirroring_enabled: false }
-      let(:argv) { ['repository', repository.scc_id] }
-      let(:error_messages) { "Mirroring of repository with ID #{repository.scc_id} is not enabled." }
+      let(:argv) { ['repository', repository.friendly_id] }
+      let(:error_messages) { "Mirroring of repository with ID #{repository.friendly_id} is not enabled." }
 
       it 'raises an error' do
         expect { command }

--- a/spec/lib/rmt/cli/products_spec.rb
+++ b/spec/lib/rmt/cli/products_spec.rb
@@ -484,7 +484,7 @@ RSpec.describe RMT::CLI::Products do
         mandatory = repo.enabled ? 'mandatory' : 'non-mandatory'
         enabled = repo.mirroring_enabled ? 'enabled' : 'not enabled'
         mirrored = repo.last_mirrored_at.present? ? "mirrored at #{repo.last_mirrored_at.strftime('%Y-%m-%d %H:%M:%S %Z')}" : 'not mirrored'
-        output += "* #{repo.name} (id: #{repo.scc_id}) (#{mandatory}, #{enabled}, #{mirrored})\n"
+        output += "* #{repo.name} (id: #{repo.friendly_id}) (#{mandatory}, #{enabled}, #{mirrored})\n"
       end
       output
     end

--- a/spec/lib/rmt/cli/repos_custom_spec.rb
+++ b/spec/lib/rmt/cli/repos_custom_spec.rb
@@ -8,12 +8,42 @@ describe RMT::CLI::ReposCustom do
   let(:repository_service) { RepositoryService.new }
 
   describe '#add' do
-    context 'product exists' do
-      let(:argv) { ['add', external_url, 'foo'] }
+    let(:argv) { ['add', external_url, 'foo'] }
+
+    it 'adds the repository to the database' do
+      expect { described_class.start(argv) }.to output("Successfully added custom repository.\n").to_stdout.and output('').to_stderr
+      expect(Repository.find_by(external_url: external_url)).not_to be_nil
+    end
+
+    context 'numeric IDs' do
+      let(:argv) { ['add', external_url, 'foo', '--id', '123'] }
 
       it 'adds the repository to the database' do
-        expect { described_class.start(argv) }.to output("Successfully added custom repository.\n").to_stdout.and output('').to_stderr
-        expect(Repository.find_by(name: 'foo')).not_to be_nil
+        expect(described_class).to receive(:exit)
+        expect { described_class.start(argv) }.to output("Please provide a non-numeric ID for your custom repository.\n").to_stderr
+            .and output('').to_stdout
+        expect(Repository.find_by(external_url: external_url)).to be_nil
+      end
+    end
+
+    context 'without parameters' do
+      let(:argv) { ['add'] }
+
+      it 'shows usage' do
+        expect { command }.to output(/Usage:/).to_stderr
+      end
+    end
+
+    context 'duplicate ID' do
+      let(:argv) { ['add', external_url, 'foo', '--id', 'foo'] }
+
+      it 'does not create a repository by the same friendly_id' do
+        expect(described_class).to receive(:exit)
+        expect do
+          create :repository, external_url: 'http://foo.bar', name: 'foobar', friendly_id: 'foo'
+          described_class.start(argv)
+        end.to output("A repository by the ID foo already exists.\n").to_stderr.and output('').to_stdout
+        expect(Repository.find_by(external_url: external_url)).to be_nil
       end
     end
 
@@ -68,7 +98,7 @@ describe RMT::CLI::ReposCustom do
         let(:argv) { [command, '--csv'] }
         let(:rows) do
           [[
-            custom_repository.id,
+            custom_repository.friendly_id,
             custom_repository.name,
             custom_repository.external_url,
             custom_repository.enabled,
@@ -91,7 +121,7 @@ describe RMT::CLI::ReposCustom do
           Terminal::Table.new(
             headings: ['ID', 'Name', 'URL', 'Mandatory?', 'Mirror?', 'Last Mirrored'],
             rows: [[
-              custom_repository.id,
+              custom_repository.friendly_id,
               custom_repository.name,
               custom_repository.external_url,
               custom_repository.enabled ? 'Mandatory' : 'Not Mandatory',
@@ -123,7 +153,11 @@ describe RMT::CLI::ReposCustom do
     context 'without parameters' do
       let(:argv) { ['enable'] }
 
-      before { expect { command }.to output(/Usage:/).to_stderr }
+
+      before do
+        expect(described_class).to receive(:exit)
+        expect { command }.to output(/No repository ids supplied/).to_stderr
+      end
 
       its(:mirroring_enabled) { is_expected.to be(false) }
     end
@@ -133,16 +167,17 @@ describe RMT::CLI::ReposCustom do
 
       before do
         expect(described_class).to receive(:exit)
-        expect { command }.to output("Cannot find custom repository by ID 0.\n").to_stderr.and output('').to_stdout
+        expect { command }.to output("Repository by ID 0 not found.\nRepository by ID 0 could not be found and was not enabled.\n").to_stderr
+                                  .and output('').to_stdout
       end
 
       its(:mirroring_enabled) { is_expected.to be(false) }
     end
 
-    context 'by repo id' do
-      let(:argv) { ['enable', repository.id.to_s] }
+    context 'by repo friendly_id' do
+      let(:argv) { ['enable', repository.friendly_id] }
 
-      before { expect { command }.to output("Repository successfully enabled.\n").to_stdout }
+      before { expect { command }.to output("Repository by ID #{repository.friendly_id} successfully enabled.\n").to_stdout }
 
       its(:mirroring_enabled) { is_expected.to be(true) }
     end
@@ -160,7 +195,10 @@ describe RMT::CLI::ReposCustom do
     context 'without parameters' do
       let(:argv) { ['disable'] }
 
-      before { expect { command }.to output(/Usage:/).to_stderr }
+      before do
+        expect(described_class).to receive(:exit)
+        expect { command }.to output(/No repository ids supplied/).to_stderr
+      end
 
       its(:mirroring_enabled) { is_expected.to be(true) }
     end
@@ -170,17 +208,18 @@ describe RMT::CLI::ReposCustom do
 
       before do
         expect(described_class).to receive(:exit)
-        expect { command }.to output("Cannot find custom repository by ID 0.\n").to_stderr.and output('').to_stdout
+        expect { command }.to output("Repository by ID 0 not found.\nRepository by ID 0 could not be found and was not disabled.\n").to_stderr
+                                  .and output('').to_stdout
       end
 
       its(:mirroring_enabled) { is_expected.to be(true) }
     end
 
-    context 'by repo id' do
-      let(:argv) { ['disable', repository.id.to_s] }
+    context 'by repo friendly_id' do
+      let(:argv) { ['disable', repository.friendly_id] }
       let(:expected_output) do
         <<-OUTPUT
-Repository successfully disabled.
+Repository by ID #{repository.friendly_id} successfully disabled.
 
 \e[1mTo clean up downloaded files, please run 'rmt-cli repos clean'\e[22m
         OUTPUT
@@ -202,7 +241,7 @@ Repository successfully disabled.
 
         before do
           expect(described_class).to receive(:exit)
-          expect { described_class.start(argv) }.to output("Cannot find custom repository by ID totally_wrong.\n").to_stderr
+          expect { described_class.start(argv) }.to output("Repository by ID totally_wrong not found.\n").to_stderr
         end
 
         it 'does not delete suse repository' do
@@ -215,11 +254,11 @@ Repository successfully disabled.
       end
 
       context 'non-custom repository' do
-        let(:argv) { [command, suse_repository.id] }
+        let(:argv) { [command, suse_repository.friendly_id] }
 
         before do
           expect(described_class).to receive(:exit)
-          expect { described_class.start(argv) }.to output("Cannot find custom repository by ID #{suse_repository.id}.\n").to_stderr
+          expect { described_class.start(argv) }.to output("Repository by ID #{suse_repository.friendly_id} not found.\n").to_stderr
         end
 
         it 'does not delete suse non-custom repository' do
@@ -228,10 +267,10 @@ Repository successfully disabled.
       end
 
       context 'custom repository' do
-        let(:argv) { [command, custom_repository.id] }
+        let(:argv) { [command, custom_repository.friendly_id] }
 
         before do
-          expect { described_class.start(argv) }.to output("Removed custom repository by ID #{custom_repository.id}.\n").to_stdout
+          expect { described_class.start(argv) }.to output("Removed custom repository by ID #{custom_repository.friendly_id}.\n").to_stdout
         end
 
         it 'deletes custom repository' do
@@ -250,26 +289,26 @@ Repository successfully disabled.
 
       it 'fails' do
         expect(described_class).to receive(:exit)
-        expect { described_class.start(argv) }.to output("Cannot find custom repository by ID foo.\n").to_stderr.and output('').to_stdout
+        expect { described_class.start(argv) }.to output("Repository by ID foo not found.\n").to_stderr.and output('').to_stdout
       end
     end
 
     context 'repository is from scc' do
       let(:repository) { create :repository }
-      let(:argv) { ['attach', repository.id, product.id] }
+      let(:argv) { ['attach', repository.friendly_id, product.id] }
 
       it('does not have an attached product') { expect(repository.products.count).to eq(0) }
 
       it 'fails' do
         expect(described_class).to receive(:exit)
-        expect { described_class.start(argv) }.to output("Cannot find custom repository by ID #{repository.id}.\n").to_stderr.and output('').to_stdout
+        expect { described_class.start(argv) }.to output("Repository by ID #{repository.friendly_id} not found.\n").to_stderr.and output('').to_stdout
         expect(repository.products.count).to eq(0)
       end
     end
 
     context 'product does not exist' do
       let(:repository) { create :repository, :custom }
-      let(:argv) { ['attach', repository.id, 'foo'] }
+      let(:argv) { ['attach', repository.friendly_id, 'foo'] }
 
       it('does not have an attached product') { expect(repository.products.count).to eq(0) }
 
@@ -282,7 +321,7 @@ Repository successfully disabled.
 
     context 'product and repo exist' do
       let(:repository) { create :repository, :custom }
-      let(:argv) { ['attach', repository.id, product.id] }
+      let(:argv) { ['attach', repository.friendly_id, product.id] }
 
       it('does not have an attached product') { expect(repository.products.count).to eq(0) }
 
@@ -299,13 +338,13 @@ Repository successfully disabled.
 
       it 'fails' do
         expect(described_class).to receive(:exit)
-        expect { described_class.start(argv) }.to output("Cannot find custom repository by ID foo.\n").to_stderr.and output('').to_stdout
+        expect { described_class.start(argv) }.to output("Repository by ID foo not found.\n").to_stderr.and output('').to_stdout
       end
     end
 
     context 'repository is from scc' do
       let(:repository) { create :repository }
-      let(:argv) { ['detach', 'foo', repository.id] }
+      let(:argv) { ['detach', 'foo', repository.friendly_id] }
 
       before do
         repository_service.attach_product!(product, repository)
@@ -315,14 +354,14 @@ Repository successfully disabled.
 
       it 'fails' do
         expect(described_class).to receive(:exit)
-        expect { described_class.start(argv) }.to output("Cannot find custom repository by ID foo.\n").to_stderr.and output('').to_stdout
+        expect { described_class.start(argv) }.to output("Repository by ID foo not found.\n").to_stderr.and output('').to_stdout
         expect(repository.products.count).to eq(1)
       end
     end
 
     context 'product does not exist' do
       let(:repository) { create :repository, :custom }
-      let(:argv) { ['detach', repository.id, 'foo'] }
+      let(:argv) { ['detach', repository.friendly_id, 'foo'] }
 
       before do
         repository_service.attach_product!(product, repository)
@@ -339,7 +378,7 @@ Repository successfully disabled.
 
     context 'product and repo exist' do
       let(:repository) { create :repository, :custom }
-      let(:argv) { ['detach', repository.id, product.id] }
+      let(:argv) { ['detach', repository.friendly_id, product.id] }
 
       before do
         repository_service.attach_product!(product, repository)
@@ -357,7 +396,7 @@ Repository successfully disabled.
   describe '#products' do
     context 'scc repository' do
       let(:repository) { create :repository }
-      let(:argv) { ['product', repository.id] }
+      let(:argv) { ['product', repository.friendly_id] }
 
       before do
         repository_service.attach_product!(product, repository)
@@ -367,13 +406,13 @@ Repository successfully disabled.
 
       it 'does not displays the product' do
         expect(described_class).to receive(:exit)
-        expect { described_class.start(argv) }.to output("Cannot find custom repository by ID #{repository.id}.\n").to_stderr.and output('').to_stdout
+        expect { described_class.start(argv) }.to output("Repository by ID #{repository.friendly_id} not found.\n").to_stderr.and output('').to_stdout
       end
     end
 
     context 'custom repository with products' do
       let(:repository) { create :repository, :custom }
-      let(:argv) { ['products', repository.id] }
+      let(:argv) { ['products', repository.friendly_id] }
       let(:rows) do
         [[
           product.id,
@@ -400,7 +439,7 @@ Repository successfully disabled.
       end
 
       describe 'products --csv' do
-        let(:argv) { ['products', repository.id, '--csv'] }
+        let(:argv) { ['products', repository.friendly_id, '--csv'] }
         let(:expected_output) do
           CSV.generate { |csv| rows.unshift(['ID', 'Name', 'Version', 'Architecture']).each { |row| csv << row } }
         end
@@ -413,7 +452,7 @@ Repository successfully disabled.
 
     context 'custom repository without products' do
       let(:repository) { create :repository, :custom }
-      let(:argv) { ['products', repository.id] }
+      let(:argv) { ['products', repository.friendly_id] }
 
       it('does not have an attached product') { expect(repository.products.count).to eq(0) }
 

--- a/spec/lib/rmt/cli/repos_spec.rb
+++ b/spec/lib/rmt/cli/repos_spec.rb
@@ -148,12 +148,12 @@ RMT only found locally mirrored files of repositories that are marked to be mirr
     context 'with multiple ids' do
       let(:repository_2) { create :repository, :with_products }
       let(:repository_3) { create :repository, :with_products }
-      let(:argv) { ['enable', repository.scc_id.to_s, repository_2.scc_id.to_s, repository_3.scc_id.to_s] }
+      let(:argv) { ['enable', repository.friendly_id, repository_2.friendly_id, repository_3.friendly_id] }
       let(:expected_output) do
         <<-OUTPUT
-Repository by ID #{repository.scc_id} successfully enabled.
-Repository by ID #{repository_2.scc_id} successfully enabled.
-Repository by ID #{repository_3.scc_id} successfully enabled.
+Repository by ID #{repository.friendly_id} successfully enabled.
+Repository by ID #{repository_2.friendly_id} successfully enabled.
+Repository by ID #{repository_3.friendly_id} successfully enabled.
         OUTPUT
       end
 
@@ -191,7 +191,7 @@ Repository by ID #{repository_3.scc_id} successfully enabled.
 
       before do
         expect(described_class).to receive(:exit)
-        expect { command }.to output("Repository not found by ID 0.\nRepository 0 could not be found and was not enabled.\n").to_stderr
+        expect { command }.to output("Repository by ID 0 not found.\nRepository by ID 0 could not be found and was not enabled.\n").to_stderr
                                   .and output('').to_stdout
       end
 
@@ -199,9 +199,9 @@ Repository by ID #{repository_3.scc_id} successfully enabled.
     end
 
     context 'by repo id' do
-      let(:argv) { ['enable', repository.scc_id.to_s] }
+      let(:argv) { ['enable', repository.friendly_id] }
 
-      before { expect { command }.to output("Repository by ID #{repository.scc_id} successfully enabled.\n").to_stdout }
+      before { expect { command }.to output("Repository by ID #{repository.friendly_id} successfully enabled.\n").to_stdout }
 
       its(:mirroring_enabled) { is_expected.to be(true) }
     end
@@ -219,12 +219,12 @@ Repository by ID #{repository_3.scc_id} successfully enabled.
     context 'with multiple ids' do
       let(:repository_2) { create :repository, :with_products, mirroring_enabled: true  }
       let(:repository_3) { create :repository, :with_products, mirroring_enabled: true  }
-      let(:argv) { ['disable', repository.scc_id.to_s, repository_2.scc_id.to_s, repository_3.scc_id.to_s] }
+      let(:argv) { ['disable', repository.friendly_id, repository_2.friendly_id, repository_3.friendly_id] }
       let(:expected_output) do
         <<-OUTPUT
-Repository by ID #{repository.scc_id} successfully disabled.
-Repository by ID #{repository_2.scc_id} successfully disabled.
-Repository by ID #{repository_3.scc_id} successfully disabled.
+Repository by ID #{repository.friendly_id} successfully disabled.
+Repository by ID #{repository_2.friendly_id} successfully disabled.
+Repository by ID #{repository_3.friendly_id} successfully disabled.
 
 \e[1mTo clean up downloaded files, please run 'rmt-cli repos clean'\e[22m
         OUTPUT
@@ -262,7 +262,7 @@ Repository by ID #{repository_3.scc_id} successfully disabled.
     context 'repo id does not exist' do
       let(:argv) { ['disable', 0] }
       let(:error_message) do
-        "Repository not found by ID 0.\nRepository 0 could not be found and was not disabled.\n"
+        "Repository by ID 0 not found.\nRepository by ID 0 could not be found and was not disabled.\n"
       end
 
       before do
@@ -274,10 +274,10 @@ Repository by ID #{repository_3.scc_id} successfully disabled.
     end
 
     context 'by repo id' do
-      let(:argv) { ['disable', repository.scc_id.to_s] }
+      let(:argv) { ['disable', repository.friendly_id] }
       let(:expected_output) do
         <<-OUTPUT
-Repository by ID #{repository.scc_id} successfully disabled.
+Repository by ID #{repository.friendly_id} successfully disabled.
 
 \e[1mTo clean up downloaded files, please run 'rmt-cli repos clean'\e[22m
         OUTPUT
@@ -316,7 +316,7 @@ Repository by ID #{repository.scc_id} successfully disabled.
         let!(:repository_two) { FactoryBot.create :repository, :with_products, mirroring_enabled: false }
         let(:rows) do
           [[
-            repository_one.scc_id,
+            repository_one.friendly_id,
             repository_one.description,
             repository_one.enabled ? 'Mandatory' : 'Not Mandatory',
             repository_one.mirroring_enabled ? 'Mirror' : "Don't Mirror",
@@ -328,7 +328,7 @@ Repository by ID #{repository.scc_id} successfully disabled.
           let(:argv) { [command_name] }
           let(:expected_output) do
             Terminal::Table.new(
-              headings: ['SCC ID', 'Product', 'Mandatory?', 'Mirror?', 'Last mirrored'],
+              headings: ['ID', 'Product', 'Mandatory?', 'Mirror?', 'Last mirrored'],
               rows: rows
             ).to_s + "\n" + 'Only enabled repositories are shown by default. Use the \'--all\' option to see all repositories.' + "\n"
           end
@@ -341,7 +341,7 @@ Repository by ID #{repository.scc_id} successfully disabled.
         describe "#{command_name} --csv" do
           let(:rows) do
             [[
-              repository_one.scc_id,
+              repository_one.friendly_id,
               repository_one.name,
               repository_one.description,
               repository_one.enabled,
@@ -351,7 +351,7 @@ Repository by ID #{repository.scc_id} successfully disabled.
           end
           let(:argv) { [command_name, '--csv'] }
           let(:expected_output) do
-            CSV.generate { |csv| rows.unshift(['SCC ID', 'Product', 'Description', 'Mandatory?', 'Mirror?', 'Last mirrored']).each { |row| csv << row } }
+            CSV.generate { |csv| rows.unshift(['ID', 'Product', 'Description', 'Mandatory?', 'Mirror?', 'Last mirrored']).each { |row| csv << row } }
           end
 
           it 'outputs only the expected format' do
@@ -368,21 +368,21 @@ Repository by ID #{repository.scc_id} successfully disabled.
           let(:expected_output) do
             rows = []
             rows << [
-              repository_one.scc_id,
+              repository_one.friendly_id,
               repository_one.description,
               repository_one.enabled ? 'Mandatory' : 'Not Mandatory',
               repository_one.mirroring_enabled ? 'Mirror' : "Don't Mirror",
               repository_one.last_mirrored_at
             ]
             rows << [
-              repository_two.scc_id,
+              repository_two.friendly_id,
               repository_two.description,
               repository_two.enabled ? 'Mandatory' : 'Not Mandatory',
               repository_two.mirroring_enabled ? 'Mirror' : "Don't Mirror",
               repository_two.last_mirrored_at
             ]
             Terminal::Table.new(
-              headings: ['SCC ID', 'Product', 'Mandatory?', 'Mirror?', 'Last mirrored'],
+              headings: ['ID', 'Product', 'Mandatory?', 'Mirror?', 'Last mirrored'],
               rows: rows
             ).to_s + "\n"
           end

--- a/spec/lib/rmt/cli/smt_importer_spec.rb
+++ b/spec/lib/rmt/cli/smt_importer_spec.rb
@@ -34,12 +34,12 @@ describe RMT::CLI::SMTImporter do
     let(:repo_2) { create :repository }
 
     context 'when repository exists' do
-      let(:enabled_repos) { [repo_1.scc_id, repo_2.scc_id] }
+      let(:enabled_repos) { [repo_1.friendly_id, repo_2.friendly_id] }
 
       it 'enables mirroring for given repositories' do
         expect { importer.import_repositories }.to output(<<-OUTPUT.strip_heredoc).to_stdout
-          Enabled mirroring for repository #{repo_1.scc_id}
-          Enabled mirroring for repository #{repo_2.scc_id}
+          Enabled mirroring for repository #{repo_1.friendly_id}
+          Enabled mirroring for repository #{repo_2.friendly_id}
         OUTPUT
 
         expect(repo_1.reload.mirroring_enabled).to be(true)

--- a/spec/lib/rmt/scc_spec.rb
+++ b/spec/lib/rmt/scc_spec.rb
@@ -52,10 +52,11 @@ describe RMT::SCC do
       all_repositories.map.each do |repository|
         db_repository = Repository.find_by(scc_id: repository[:id])
 
-        (db_repository.attributes.keys - %w[id scc_id external_url mirroring_enabled local_path auth_token]).each do |key|
+        (db_repository.attributes.keys - %w[id scc_id external_url mirroring_enabled local_path auth_token friendly_id]).each do |key|
           expect(db_repository[key].to_s).to eq(repository[key.to_sym].to_s)
         end
         expect(db_repository[:scc_id]).to eq(repository[:id])
+        expect(db_repository[:friendly_id].to_s).to eq(repository[:id].to_s)
 
         uri = URI(repository[:url])
         auth_token = uri.query

--- a/spec/services/repository_service_spec.rb
+++ b/spec/services/repository_service_spec.rb
@@ -8,17 +8,36 @@ describe RepositoryService do
   let(:suse_repository) { create :repository }
 
   describe '#create_repository' do
-    before do
-      service.create_repository!(product, 'http://foo.bar/repos', {
+    let(:attributes) do
+      {
         name: 'foo',
         mirroring_enabled: true,
         description: 'foo',
         autorefresh: true,
-        enabled: false
-      })
+        enabled: false,
+        id: 50
+      }
     end
 
-    it('creates the repository') { expect(Repository.find_by(external_url: 'http://foo.bar/repos').name).to eq('foo') }
+    context 'scc repositories' do
+      before do
+        service.create_repository!(product, 'http://foo.bar/repos', attributes)
+      end
+
+      it('creates the repository') { expect(Repository.find_by(external_url: 'http://foo.bar/repos').name).to eq('foo') }
+
+      it('has the correct friendly_id') { expect(Repository.find_by(external_url: 'http://foo.bar/repos').friendly_id).to eq('50') }
+    end
+
+    context 'custom repositories' do
+      before do
+        service.create_repository!(nil, 'http://foo.bar/repos', attributes, custom: true)
+      end
+
+      it('creates the repository') { expect(Repository.find_by(external_url: 'http://foo.bar/repos').name).to eq('foo') }
+
+      it('has the correct friendly_id') { expect(Repository.find_by(external_url: 'http://foo.bar/repos').friendly_id).to eq('50') }
+    end
   end
 
   describe '#add_product' do


### PR DESCRIPTION
## Description

### Fix 1: `scc_id`

The code assumes scc_id is unique, and under normal circumstances, scc_id should always be unique, but the database didn't ensure this (non-unique index).

Note:

* For duplicated scc_ids, we remove the scc_id column, making it null. The next sync to SCC will bring the duplicated repository to a healthy state and set the scc_id to the correct repository.

### Fix 2: `id` + `scc_id` -> `friendly_id`

Instead of using two columns for IDs, we should use one to lower the confusion. This PR adds the column `friendly_id`. For SCC repositories, it's the same `scc_id` as before. For custom repositories, it's either user provided or RMT generated (MD5 checksum of URL).

**Note:**

* `scc_id` was left for backwards compatibility reasons and to determine whether or not a repository comes from SCC.
* Custom repositories can use the old `id` within the `rmt-cli repos custom` namespace.
* Users can provide a custom friendly id for custom repositories within `rmt-cli repos custom add` with `--id=<ID>`.
## Change Type

*Please select the correct option.*

- [x] **New Feature** (a non-breaking change which adds new functionality)

## Checklist

*Please check off each item if the requirement is met.*

- [x] I have verified that my code follows RMT's coding standards with `rubocop`.
- [x] I have reviewed my own code and believe that it's ready for an external review.
- [x] I have provided comments for any hard-to-understand code.
- [x] I have documented the `MANUAL.md` file with any changes to the user experience.
- [x] RMT's test coverage remains at 100%.
- [x] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Other Notes

Please use this space to provide notes or thoughts to the team, such as tips on how to review/demo your changes.
