### PR TITLE
Move to GH Tokens for Prophet

### DIFF
--- a/integration/prophet/prophet.rb
+++ b/integration/prophet/prophet.rb
@@ -12,14 +12,14 @@ Prophet.setup do |config|
   if File.exist?(CONFIG_FILE)
     options = YAML.load_file(CONFIG_FILE)
     # The GitHub (GH) username/password to use for commenting on a successful run.
-    config.username = options['default']['gh_username']
-    config.password = options['default']['gh_password']
+    config.username_pass = options['default']['gh_username']
+    config.access_token_pass = options['default']['gh_token']
 
     # The GH credentials for commenting on failing runs (can be the same as above).
     # NOTE: If you specify two different accounts with different avatars, it's
     # a lot easier to spot failing test runs at first glance.
     config.username_fail = options['default']['gh_username_fail']
-    config.password_fail = options['default']['gh_password_fail']
+    config.access_token_fail = options['default']['gh_token_fail']
   end
 
   # Setup logging.


### PR DESCRIPTION
## Description

Github is deprecating usage of its API by password authentication, so we need to move to token authentication.

## Change Type

*Please select the correct option.*

- [x] **Bug Fix** (a non-breaking change which fixes an issue)

## Checklist

*Please check off each item if the requirement is met.*

- [x] I have verified that my code follows RMT's coding standards with `rubocop`.
- [x] I have reviewed my own code and believe that it's ready for an external review.
- [x] I have provided comments for any hard-to-understand code.
- [x] I have documented the `MANUAL.md` file with any changes to the user experience.
- [x] RMT's test coverage remains at 100%.
- [x] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.