### PR TITLE
Refactor RMT Mirror Downloader

### DIFF
--- a/lib/rmt/mirror.rb
+++ b/lib/rmt/mirror.rb
@@ -39,7 +39,7 @@ class RMT::Mirror
     }
 
     logger.info _('Mirroring SUSE Manager product tree to %{dir}') % { dir: repository_dir }
-    downloader.download(FileReference.new(location: 'product_tree.json', **mirroring_paths))
+    downloader.download(FileReference.new(relative_path: 'product_tree.json', **mirroring_paths))
   rescue RMT::Downloader::Exception => e
     raise RMT::Mirror::Exception.new(_('Could not mirror SUSE Manager product tree with error: %{error}') % { error: e.message })
   end
@@ -90,12 +90,12 @@ class RMT::Mirror
       cache_dir: repository_dir
     }
 
-    repomd_xml = FileReference.new(location: 'repodata/repomd.xml', **mirroring_paths)
+    repomd_xml = FileReference.new(relative_path: 'repodata/repomd.xml', **mirroring_paths)
     downloader.download(repomd_xml)
 
     begin
-      signature_file = FileReference.new(location: 'repodata/repomd.xml.asc', **mirroring_paths)
-      key_file       = FileReference.new(location: 'repodata/repomd.xml.key', **mirroring_paths)
+      signature_file = FileReference.new(relative_path: 'repodata/repomd.xml.asc', **mirroring_paths)
+      key_file       = FileReference.new(relative_path: 'repodata/repomd.xml.key', **mirroring_paths)
       downloader.download(signature_file)
       downloader.download(key_file)
 
@@ -131,7 +131,7 @@ class RMT::Mirror
     }
 
     begin
-      directory_yast = FileReference.new(location: 'directory.yast', **mirroring_paths)
+      directory_yast = FileReference.new(relative_path: 'directory.yast', **mirroring_paths)
       downloader.download(directory_yast)
     rescue RMT::Downloader::Exception
       FileUtils.remove_entry(temp_licenses_dir) # the repository would have an empty licenses directory unless removed
@@ -140,7 +140,7 @@ class RMT::Mirror
 
     license_files = File.readlines(directory_yast.local_path)
       .map(&:strip).reject { |item| item == 'directory.yast' }
-      .map { |location| FileReference.new(location: location, **mirroring_paths) }
+      .map { |relative_path| FileReference.new(relative_path: relative_path, **mirroring_paths) }
     downloader.download_multi(license_files)
   rescue StandardError => e
     raise RMT::Mirror::Exception.new(_('Error while mirroring license: %{error}') % { error: e.message })

--- a/lib/rmt/mirror.rb
+++ b/lib/rmt/mirror.rb
@@ -4,35 +4,6 @@ require 'repomd_parser'
 require 'time'
 
 class RMT::Mirror
-  class FileReference
-    class << self
-      def build_from_metadata(metadata, base_dir:, base_url:, cache_dir: nil)
-        new(base_dir: base_dir, base_url: base_url, cache_dir: cache_dir, location: metadata.location)
-          .tap do |file|
-            file.arch = metadata.arch
-            file.checksum = metadata.checksum
-            file.checksum_type = metadata.checksum_type
-            file.size = metadata.size
-            file.type = metadata.type
-          end
-      end
-    end
-
-    attr_reader :cache_path, :local_path, :remote_path, :location
-    attr_accessor :arch, :checksum, :checksum_type, :size, :type
-
-    def initialize(base_dir:, base_url:, cache_dir: nil, location:)
-      @cache_path = (cache_dir ? File.join(cache_dir, location) : nil)
-      @local_path = File.join(base_dir, location.gsub(/\.\./, '__'))
-      @remote_path = URI.join(base_url, location)
-      @location = location
-    end
-
-    def cache_timestamp
-      File.mtime(cache_path).utc.httpdate if cache_path && File.exist?(cache_path)
-    end
-  end
-
   class RMT::Mirror::Exception < RuntimeError
   end
 

--- a/lib/rmt/mirror/file_reference.rb
+++ b/lib/rmt/mirror/file_reference.rb
@@ -1,0 +1,28 @@
+class RMT::Mirror::FileReference
+  class << self
+    def build_from_metadata(metadata, base_dir:, base_url:, cache_dir: nil)
+      new(base_dir: base_dir, base_url: base_url, cache_dir: cache_dir, location: metadata.location)
+        .tap do |file|
+          file.arch = metadata.arch
+          file.checksum = metadata.checksum
+          file.checksum_type = metadata.checksum_type
+          file.size = metadata.size
+          file.type = metadata.type
+        end
+    end
+  end
+
+  attr_reader :cache_path, :local_path, :remote_path, :location
+  attr_accessor :arch, :checksum, :checksum_type, :size, :type
+
+  def initialize(base_dir:, base_url:, cache_dir: nil, location:)
+    @cache_path = (cache_dir ? File.join(cache_dir, location) : nil)
+    @local_path = File.join(base_dir, location.gsub(/\.\./, '__'))
+    @remote_path = URI.join(base_url, location)
+    @location = location
+  end
+
+  def cache_timestamp
+    File.mtime(cache_path).utc.httpdate if cache_path && File.exist?(cache_path)
+  end
+end

--- a/lib/rmt/mirror/file_reference.rb
+++ b/lib/rmt/mirror/file_reference.rb
@@ -1,25 +1,28 @@
 class RMT::Mirror::FileReference
   class << self
     def build_from_metadata(metadata, base_dir:, base_url:, cache_dir: nil)
-      new(base_dir: base_dir, base_url: base_url, cache_dir: cache_dir, location: metadata.location)
-        .tap do |file|
-          file.arch = metadata.arch
-          file.checksum = metadata.checksum
-          file.checksum_type = metadata.checksum_type
-          file.size = metadata.size
-          file.type = metadata.type
-        end
+      new(
+        relative_path: metadata.location,
+        base_dir: base_dir,
+        base_url: base_url,
+        cache_dir: cache_dir
+      ).tap do |file|
+        file.arch = metadata.arch
+        file.checksum = metadata.checksum
+        file.checksum_type = metadata.checksum_type
+        file.size = metadata.size
+        file.type = metadata.type
+      end
     end
   end
 
-  attr_reader :cache_path, :local_path, :remote_path, :location
+  attr_reader :cache_path, :local_path, :remote_path
   attr_accessor :arch, :checksum, :checksum_type, :size, :type
 
-  def initialize(base_dir:, base_url:, cache_dir: nil, location:)
-    @cache_path = (cache_dir ? File.join(cache_dir, location) : nil)
-    @local_path = File.join(base_dir, location.gsub(/\.\./, '__'))
-    @remote_path = URI.join(base_url, location)
-    @location = location
+  def initialize(relative_path:, base_dir:, base_url:, cache_dir: nil)
+    @cache_path = (cache_dir ? File.join(cache_dir, relative_path) : nil)
+    @local_path = File.join(base_dir, relative_path.gsub(/\.\./, '__'))
+    @remote_path = URI.join(base_url, relative_path)
   end
 
   def cache_timestamp

--- a/spec/lib/rmt/downloader_spec.rb
+++ b/spec/lib/rmt/downloader_spec.rb
@@ -2,18 +2,33 @@ require 'rails_helper'
 require 'webmock/rspec'
 
 RSpec.describe RMT::Downloader do
-  let(:dir) { Dir.mktmpdir }
+  let(:repository_url) { 'http://example.com' }
+  let(:repository_dir) { Dir.mktmpdir }
+  let(:cache_dir) { nil }
   let(:headers) { { 'User-Agent' => "RMT/#{RMT::VERSION}" } }
   let(:track_files) { false }
   let(:downloader) do
-    described_class.new(repository_url: 'http://example.com',
-                        destination_dir: dir,
-                        logger: RMT::Logger.new('/dev/null'),
+    described_class.new(logger: RMT::Logger.new('/dev/null'),
                         track_files: track_files)
   end
 
+  let(:expected_checksum) { nil }
+  let(:expected_checksum_type) { nil }
+  let(:repomd_xml_file) do
+    RMT::Mirror::FileReference.new(
+      location: 'repomd.xml',
+      base_url: repository_url,
+      base_dir: repository_dir,
+      cache_dir: cache_dir
+    ).tap do |file|
+      file.checksum = expected_checksum
+      file.checksum_type = expected_checksum_type
+    end
+  end
+
   after do
-    FileUtils.remove_entry(dir)
+    FileUtils.remove_entry(repository_dir)
+    FileUtils.remove_entry(cache_dir) if cache_dir
   end
 
   describe '#download over http://' do
@@ -25,9 +40,8 @@ RSpec.describe RMT::Downloader do
       end
 
       it 'raises an exception' do
-        expect do
-          downloader.download('/repomd.xml')
-        end.to raise_error(RMT::Downloader::Exception, '/repomd.xml - HTTP request failed with code 404')
+        expect { downloader.download(repomd_xml_file) }
+          .to raise_error(RMT::Downloader::Exception, 'http://example.com/repomd.xml - HTTP request failed with code 404')
       end
     end
 
@@ -45,79 +59,99 @@ RSpec.describe RMT::Downloader do
           response_double
         end
 
-        expect do
-          downloader.download('/repomd.xml')
-        end.to raise_error(RMT::Downloader::Exception, '/repomd.xml - return code error')
+        expect { downloader.download(repomd_xml_file) }
+          .to raise_error(RMT::Downloader::Exception, 'http://example.com/repomd.xml - return code error')
       end
     end
 
     context 'when HTTP code is 200' do
       let(:content) { 'test' }
-      let(:checksum_type) { 'SHA256' }
-      let(:checksum) { Digest.const_get(checksum_type).hexdigest(content) }
+      let(:expected_checksum_type) { 'SHA256' }
+      let(:expected_checksum) { Digest.const_get(expected_checksum_type).hexdigest(content) }
 
       before do
         stub_request(:get, 'http://example.com/repomd.xml')
           .with(headers: headers)
-          .to_return(status: 200, body: 'test', headers: {})
+          .to_return(status: 200, body: content, headers: {})
       end
 
       context 'and hash function is unknown' do
+        let(:expected_checksum_type) { 'CHUNKYBACON42' }
+        let(:expected_checksum) { '0xDEADBEEF' }
+
         it 'raises an exception' do
-          expect do
-            downloader.download('/repomd.xml', checksum_type: 'CHUNKYBACON42', checksum_value: '0xDEADBEEF')
-          end.to raise_error(RMT::ChecksumVerifier::Exception, 'Unknown hash function CHUNKYBACON42')
+          expect { downloader.download(repomd_xml_file) }
+            .to raise_error(RMT::ChecksumVerifier::Exception, 'Unknown hash function CHUNKYBACON42')
         end
       end
 
       context 'and checksum is wrong' do
+        let(:expected_checksum_type) { 'SHA256' }
+        let(:expected_checksum) { '0xDEADBEEF' }
+
         it 'raises an exception' do
-          expect do
-            downloader.download('/repomd.xml', checksum_type: 'SHA256', checksum_value: '0xDEADBEEF')
-          end.to raise_error(RMT::Downloader::Exception, 'Checksum doesn\'t match')
+          expect { downloader.download(repomd_xml_file) }
+            .to raise_error(RMT::Downloader::Exception, 'Checksum doesn\'t match')
         end
       end
 
       context 'and checksum is correct' do
-        let(:filename) { downloader.download('/repomd.xml', checksum_type: checksum_type, checksum_value: checksum) }
+        let(:filename) { downloader.download(repomd_xml_file) }
 
         it('has correct content') { expect(File.read(filename)).to eq(content) }
       end
 
       context 'tracking files' do
+        let(:track_files) { true }
+        let(:rpm_package_content) { 'rpm package' }
+        let(:rpm_package_file) do
+          RMT::Mirror::FileReference.new(
+            location: 'package.rpm',
+            base_url: repository_url,
+            base_dir: repository_dir
+          ).tap do |file|
+            file.checksum = Digest.const_get('SHA256').hexdigest(rpm_package_content)
+            file.checksum_type = 'SHA256'
+          end
+        end
+        let(:drpm_package_content) { 'drpm package' }
+        let(:drpm_package_file) do
+          RMT::Mirror::FileReference.new(
+            location: 'package.drpm',
+            base_url: repository_url,
+            base_dir: repository_dir
+          ).tap do |file|
+            file.checksum = Digest.const_get('SHA256').hexdigest(drpm_package_content)
+            file.checksum_type = 'SHA256'
+          end
+        end
+
         before do
           stub_request(:get, 'http://example.com/package.rpm')
             .with(headers: headers)
-            .to_return(status: 200, body: 'rpm package', headers: {})
+            .to_return(status: 200, body: rpm_package_content, headers: {})
 
           stub_request(:get, 'http://example.com/package.drpm')
             .with(headers: headers)
-            .to_return(status: 200, body: 'drpm package', headers: {})
-
-          downloader.download('/repomd.xml', checksum_type: checksum_type, checksum_value: checksum)
-          downloader.download(
-            '/package.rpm',
-            checksum_type: 'SHA256',
-            checksum_value: '7e97688a22a5a97a59900c062f36ff7437e86fe4f6758cdf68d78fa6d41b05f8'
-          )
-          downloader.download(
-            '/package.drpm',
-            checksum_type: 'SHA256',
-            checksum_value: '352ee1d1675387e0ba917c3fabdb15211214f1bbd7c87099b346b7c342ed1f06'
-          )
+            .to_return(status: 200, body: drpm_package_content, headers: {})
         end
 
-        let(:track_files) { true }
 
         it 'does not track .xml files' do
+          downloader.download(repomd_xml_file)
+
           expect(DownloadedFile.where("local_path like '%.xml'").count).to eq(0)
         end
 
         it 'tracks .rpm files' do
+          downloader.download(rpm_package_file)
+
           expect(DownloadedFile.where("local_path like '%.rpm'").count).to eq(1)
         end
 
         it 'tracks .drpm files' do
+          downloader.download(drpm_package_file)
+
           expect(DownloadedFile.where("local_path like '%.drpm'").count).to eq(1)
         end
       end
@@ -126,8 +160,6 @@ RSpec.describe RMT::Downloader do
     context 'with auth_token' do
       let(:downloader) do
         described_class.new(
-          repository_url: 'http://example.com',
-          destination_dir: dir,
           logger: RMT::Logger.new('/dev/null'),
           auth_token: 'repo_auth_token'
         )
@@ -141,15 +173,15 @@ RSpec.describe RMT::Downloader do
       end
 
       context 'and checksum is correct' do
-        let(:filename) { downloader.download('/repomd.xml') }
+        let(:filename) { downloader.download(repomd_xml_file) }
 
         it('has correct content') { expect(File.read(filename)).to eq(content) }
       end
 
       context 'and checksum type is SHA and it is is correct' do
-        let(:filename) { downloader.download('/repomd.xml') }
-        let(:checksum_type) { 'sha' }
-        let(:checksum) { Digest.const_get('SHA1').hexdigest(content) }
+        let(:expected_checksum_type) { 'sha' }
+        let(:expected_checksum) { Digest.const_get('SHA1').hexdigest(content) }
+        let(:filename) { downloader.download(repomd_xml_file) }
 
         it('has correct content') { expect(File.read(filename)).to eq(content) }
       end
@@ -157,15 +189,7 @@ RSpec.describe RMT::Downloader do
 
     describe '#download with If-Modified-Since' do
       let(:cache_dir) { Dir.mktmpdir }
-      let(:repo_dir) { Dir.mktmpdir }
-      let(:downloader) do
-        described_class.new(
-          repository_url: 'http://example.com',
-          destination_dir: repo_dir,
-          logger: RMT::Logger.new('/dev/null'),
-          cache_dir: cache_dir
-        )
-      end
+      let(:repository_dir) { Dir.mktmpdir }
       let(:time) { Time.utc(2018, 1, 1, 10, 10, 0) }
       let(:if_modified_headers) do
         {
@@ -173,22 +197,15 @@ RSpec.describe RMT::Downloader do
           'If-Modified-Since' => 'Mon, 01 Jan 2018 10:10:00 GMT'
         }
       end
-      let(:filename) { 'repomd.xml' }
-      let(:downloaded_file) { downloader.download("/#{filename}") }
+      let(:downloaded_file) { downloader.download(repomd_xml_file) }
       let(:cached_content) { 'cached_content' }
       let(:fresh_content) { 'fresh_content' }
 
-      after do
-        FileUtils.remove_entry(cache_dir)
-        FileUtils.remove_entry(repo_dir)
-      end
-
       context 'a file exists in cache and not modified' do
         before do
-          fn = File.join(cache_dir, filename)
-          File.open(fn, 'w') { |file| file.write(cached_content) }
-          File.utime(time, time, fn)
-          stub_request(:get, "http://example.com/#{filename}")
+          File.open(repomd_xml_file.cache_path, 'w') { |file| file.write(cached_content) }
+          File.utime(time, time, repomd_xml_file.cache_path)
+          stub_request(:get, 'http://example.com/repomd.xml')
               .with(headers: if_modified_headers)
               .to_return(status: 304, body: '', headers: {})
         end
@@ -198,10 +215,9 @@ RSpec.describe RMT::Downloader do
 
       context 'a file exists in cache and is modified' do
         before do
-          fn = File.join(cache_dir, filename)
-          File.open(fn, 'w') { |file| file.write(cached_content) }
-          File.utime(time, time, fn)
-          stub_request(:get, "http://example.com/#{filename}")
+          File.open(repomd_xml_file.cache_path, 'w') { |file| file.write(cached_content) }
+          File.utime(time, time, repomd_xml_file.cache_path)
+          stub_request(:get, 'http://example.com/repomd.xml')
               .with(headers: if_modified_headers)
               .to_return(status: 200, body: fresh_content, headers: {})
         end
@@ -210,10 +226,21 @@ RSpec.describe RMT::Downloader do
       end
 
       context "a file doesn't exist in cache" do
-        let(:filename) { 'another_file.xml' }
+        let(:another_file) do
+          RMT::Mirror::FileReference.new(
+            location: 'another_file.xml',
+            base_url: repository_url,
+            base_dir: repository_dir,
+            cache_dir: cache_dir
+          ).tap do |file|
+            file.checksum = expected_checksum
+            file.checksum_type = expected_checksum_type
+          end
+        end
+        let(:downloaded_file) { downloader.download(another_file) }
 
         before do
-          stub_request(:get, "http://example.com/#{filename}")
+          stub_request(:get, 'http://example.com/another_file.xml')
               .with(headers: headers)
               .to_return(status: 200, body: fresh_content, headers: {})
         end
@@ -224,11 +251,18 @@ RSpec.describe RMT::Downloader do
   end
 
   describe '#download over file://' do
-    subject(:download) { downloader.download('repodata/repomd.xml') }
+    subject(:download) { downloader.download(repomd_xml_file) }
 
-    let(:dir2) { Dir.mktmpdir }
-    let(:path) { 'file://' + File.expand_path(file_fixture('dummy_repo/')) + '/' }
-    let(:downloader) { described_class.new(repository_url: path, destination_dir: dir2, logger: RMT::Logger.new('/dev/null')) }
+    let(:repository_dir) { Dir.mktmpdir }
+    let(:repository_url) { 'file://' + File.expand_path(file_fixture('dummy_repo/')) + '/' }
+    let(:downloader) { described_class.new(logger: RMT::Logger.new('/dev/null')) }
+    let(:repomd_xml_file) do
+      RMT::Mirror::FileReference.new(
+        location: 'repodata/repomd.xml',
+        base_url: repository_url,
+        base_dir: repository_dir
+      )
+    end
 
     # WebMock doesn't work nicely with file://
     around do |example|
@@ -242,41 +276,46 @@ RSpec.describe RMT::Downloader do
     end
 
     context "when file doesn't exist" do
-      let(:path) { 'file://' + File.expand_path(file_fixture('.')) + '/non_existent/' }
+      let(:repository_url) { 'file://' + File.expand_path(file_fixture('.')) + '/non_existent/' }
 
       it 'raises and exception' do
-        expect do
-          downloader.download('/repodata/repomd.xml')
-        end.to raise_error(RMT::Downloader::Exception, '/repodata/repomd.xml - File does not exist')
+        expect { downloader.download(repomd_xml_file) }
+          .to raise_error(
+            RMT::Downloader::Exception,
+            %r{/repodata/repomd.xml - File does not exist}
+          )
       end
     end
   end
 
   describe '#download_multi' do
-    context 'when download exceptions occur when ignore_errors is true' do
-      let(:files) { %w[package1 package2 package3] }
-      let(:checksum_type) { 'SHA256' }
-      let(:file_entry_class) { Struct.new(:location, :checksum_type, :checksum, :type) }
-      let(:queue) do
-        files.map do |file|
-          file_entry_class.new(
-            file,
-            checksum_type,
-            Digest.const_get(checksum_type).hexdigest(file),
-            :rpm
-          )
+    let(:files) { %w[package1 package2 package3] }
+    let(:checksum_type) { 'SHA256' }
+    let(:queue) do
+      files.map do |file|
+        RMT::Mirror::FileReference.new(
+          location: file,
+          base_url: repository_url,
+          base_dir: repository_dir
+        ).tap do |file_ref|
+          file_ref.checksum = Digest.const_get(checksum_type).hexdigest(file)
+          file_ref.checksum_type = checksum_type
+          file_ref.type = :rpm
         end
       end
+    end
 
+    context 'when download exceptions occur when ignore_errors is true' do
       before do
         files.each do |file|
           stub_request(:get, "http://example.com/#{file}").with(headers: headers)
             .to_return(status: 404, body: file, headers: {})
         end
-        downloader.download_multi(queue, ignore_errors: true)
       end
 
       it 'requested all files' do
+        downloader.download_multi(queue.dup, ignore_errors: true)
+
         files.each do |file|
           expect(WebMock).to(
             have_requested(:get, "http://example.com/#{file}").with(headers: headers)
@@ -285,16 +324,15 @@ RSpec.describe RMT::Downloader do
       end
 
       it 'but no files were actually saved' do
-        files.each do |file|
-          expect(File.exist?(File.join(dir, file))).to eq(false)
+        downloader.download_multi(queue.dup, ignore_errors: true)
+
+        queue.each do |file|
+          expect(File.exist?(file.local_path)).to eq(false)
         end
       end
     end
 
-    describe 'when download exceptions occur when ignore_errors is false' do
-      let(:files) { %w[package1 package2 package3] }
-      let(:checksum_type) { 'SHA256' }
-
+    context 'when download exceptions occur when ignore_errors is false' do
       before do
         files.each do |file|
           stub_request(:get, "http://example.com/#{file}").with(headers: headers)
@@ -313,15 +351,15 @@ RSpec.describe RMT::Downloader do
 
       it 'raises an exception' do
         expect do
-          downloader.download_multi(files, ignore_errors: false)
-        end.to raise_error('package1 - HTTP request failed with code 404')
+          downloader.download_multi(queue.dup, ignore_errors: false)
+        end.to raise_error('http://example.com/package1 - HTTP request failed with code 404')
       end
 
       it 'cleans up the queue of downloads' do
         expect do
           downloader.concurrency = 1
-          downloader.download_multi(files, ignore_errors: false)
-        end.to raise_error('package1 - HTTP request failed with code 404')
+          downloader.download_multi(queue.dup, ignore_errors: false)
+        end.to raise_error('http://example.com/package1 - HTTP request failed with code 404')
 
         expect(downloader.instance_variable_get(:@hydra).multi.easy_handles).to eq([])
         expect(downloader.instance_variable_get(:@queue)).to eq([])

--- a/spec/lib/rmt/downloader_spec.rb
+++ b/spec/lib/rmt/downloader_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe RMT::Downloader do
   let(:expected_checksum_type) { nil }
   let(:repomd_xml_file) do
     RMT::Mirror::FileReference.new(
-      location: 'repomd.xml',
+      relative_path: 'repomd.xml',
       base_url: repository_url,
       base_dir: repository_dir,
       cache_dir: cache_dir
@@ -106,7 +106,7 @@ RSpec.describe RMT::Downloader do
         let(:rpm_package_content) { 'rpm package' }
         let(:rpm_package_file) do
           RMT::Mirror::FileReference.new(
-            location: 'package.rpm',
+            relative_path: 'package.rpm',
             base_url: repository_url,
             base_dir: repository_dir
           ).tap do |file|
@@ -117,7 +117,7 @@ RSpec.describe RMT::Downloader do
         let(:drpm_package_content) { 'drpm package' }
         let(:drpm_package_file) do
           RMT::Mirror::FileReference.new(
-            location: 'package.drpm',
+            relative_path: 'package.drpm',
             base_url: repository_url,
             base_dir: repository_dir
           ).tap do |file|
@@ -228,7 +228,7 @@ RSpec.describe RMT::Downloader do
       context "a file doesn't exist in cache" do
         let(:another_file) do
           RMT::Mirror::FileReference.new(
-            location: 'another_file.xml',
+            relative_path: 'another_file.xml',
             base_url: repository_url,
             base_dir: repository_dir,
             cache_dir: cache_dir
@@ -258,7 +258,7 @@ RSpec.describe RMT::Downloader do
     let(:downloader) { described_class.new(logger: RMT::Logger.new('/dev/null')) }
     let(:repomd_xml_file) do
       RMT::Mirror::FileReference.new(
-        location: 'repodata/repomd.xml',
+        relative_path: 'repodata/repomd.xml',
         base_url: repository_url,
         base_dir: repository_dir
       )
@@ -294,7 +294,7 @@ RSpec.describe RMT::Downloader do
     let(:queue) do
       files.map do |file|
         RMT::Mirror::FileReference.new(
-          location: file,
+          relative_path: file,
           base_url: repository_url,
           base_dir: repository_dir
         ).tap do |file_ref|

--- a/spec/lib/rmt/mirror/file_reference_spec.rb
+++ b/spec/lib/rmt/mirror/file_reference_spec.rb
@@ -1,0 +1,135 @@
+require 'rails_helper'
+
+RSpec.describe RMT::Mirror::FileReference do
+  subject(:file_reference) do
+    described_class.new(relative_path: relative_path,
+                        base_dir: base_dir,
+                        base_url: base_url,
+                        cache_dir: cache_dir)
+  end
+
+  around do |example|
+    example.run
+    FileUtils.remove_entry(tmp_dir, true)
+  end
+
+  let!(:tmp_dir) { Dir.mktmpdir('rmt') }
+  let(:relative_path) { 'dummy_dir/dummy_file.ext' }
+  let(:base_dir) { '/rmt/mirror/path' }
+  let(:base_url) { 'https://www.repourl.com' }
+  let(:cache_dir) { nil }
+
+  describe '#cache_path' do
+    context 'when instantiated with a cache dir path' do
+      let(:cache_dir) { '/rmt/cache/dir' }
+
+      it 'returns the absolute cache path' do
+        expect(file_reference.cache_path).to eq('/rmt/cache/dir/dummy_dir/dummy_file.ext')
+      end
+    end
+
+    context 'when instantiated without a cache dir path' do
+      subject(:file_reference) do
+        described_class.new(relative_path: relative_path,
+                            base_dir: base_dir,
+                            base_url: base_url)
+      end
+
+      it 'returns nil' do
+        expect(file_reference.cache_path).to be_nil
+      end
+    end
+  end
+
+  describe '#cache_timestamp' do
+    context 'when instantiated with a cache dir path and absolute cache path exists' do
+      before do
+        absolute_path = File.join(cache_dir, relative_path)
+        FileUtils.mkpath(File.dirname(absolute_path))
+        FileUtils.touch(absolute_path, mtime: Time.parse(timestamp).utc)
+      end
+
+      let(:cache_dir) { tmp_dir }
+      let(:timestamp) { 'Fri, 18 Sep 2020 18:13:57 GMT' }
+
+      it "returns the file's mtime" do
+        expect(file_reference.cache_timestamp).to eq(timestamp)
+      end
+    end
+
+    context 'when instantiated with a cache dir path and absolute cache path does not exists' do
+      let(:cache_dir) { tmp_dir }
+
+      it "returns the file's mtime" do
+        expect(file_reference.cache_timestamp).to be_nil
+      end
+    end
+
+    context 'when instantiated without a cache dir path' do
+      subject(:file_reference) do
+        described_class.new(relative_path: relative_path,
+                            base_dir: base_dir,
+                            base_url: base_url)
+      end
+
+      it 'returns nil' do
+        expect(file_reference.cache_timestamp).to be_nil
+      end
+    end
+  end
+
+  describe '#local_path' do
+    it 'returns the absolute local path' do
+      expect(file_reference.local_path).to eq('/rmt/mirror/path/dummy_dir/dummy_file.ext')
+    end
+
+    context "when the relative path containts '..'" do
+      let(:relative_path) { '../dummy/relative/path/file.ext' }
+
+      it "returns the absolute local path replacing '..' w/ '__'" do
+        expect(file_reference.local_path).to eq('/rmt/mirror/path/__/dummy/relative/path/file.ext')
+      end
+    end
+  end
+
+  describe '#remote_path' do
+    it 'returns a URI::Generic instance' do
+      expect(file_reference.remote_path).to be_kind_of(URI::Generic)
+    end
+
+    it 'returns the absolute remote path' do
+      expect(file_reference.remote_path.to_s).to eq('https://www.repourl.com/dummy_dir/dummy_file.ext')
+    end
+  end
+
+  describe 'build_from_metadata' do
+    subject(:file_reference) do
+      described_class.build_from_metadata(metadata_reference,
+                                          base_dir: base_dir,
+                                          base_url: base_url,
+                                          cache_dir: cache_dir)
+    end
+
+    let(:metadata_reference) do
+      instance_double(RepomdParser::Reference,
+                      location: relative_path,
+                      arch: 'x86_64',
+                      checksum: '2c4e3fa1624bd23221eecdda9c7fcefad042992a9eaed227d06dd8210cfe2821',
+                      checksum_type: 'SHA256',
+                      size: 2020,
+                      type: :primary)
+    end
+
+    it { is_expected.to be_instance_of(described_class) }
+
+    it 'returns an object with metadata attributes' do
+      expect(file_reference).to have_attributes(
+        arch: metadata_reference.arch,
+        checksum: metadata_reference.checksum,
+        checksum_type: metadata_reference.checksum_type,
+        size: metadata_reference.size,
+        type: metadata_reference.type
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Description

I refactored the classes `RMT::Mirror` and `RMT::Downloader` to improve how they communicate with each other, focusing on making `RMT::Downloader` to only accept instances of `RMT::Mirror::FileReference`.

### Detailed Description

The RMT::Downloader had a public interface which was quite complex:

* A new instance was initialized with parameters that could be modified later by an external agent: repository URL, and repository and cache directories. `RMT::Mirror` creates a `RMT::Downloader` instance during initialization and then modifies these attributes whenever it wants to download a different set of files, so it was hard to know, at any given point, what was the downloader configuration/state. These parameters were used solely for building URLs and paths for the downloaded files.
* RMT::Downloder public methods `#download/#download_multi` could receive `String`, `RepomdParser::Reference` and `RMT::Mirror::FileReference` instances, deciding how to create a request based on the object's class.  The method #download also accepted  the file checksum as an optional parameter, but the reference objects already hold this information. Both `String` and `RepomdParser::Reference` had just the relative path, used to build the URL.

I refactored `RMT::Mirror` and `RMT::Downloader` in an attempt to eliminate this complexity:

* `RMT::Mirror::FileReference` now has attributes for the file's cache path and remote path (URL), eliminating the need to initialize `RMT::Downloader` with them.
* `RMT::Downloader` should only receive `RMT::Mirror::FileReference` instances instead of accepting `String`. Also, it no longer has the responsibility for building file and URL paths.

Also, `RMT::Mirror` contained several methods relied directly on instance variables, by accessing them with `@var_name` references. Furthermore, these variables were set in one block of the code and used
in another, not making entirely clear where the values were needed.

I rewrote some methods to receive the values as arguments instead of accessing the instance variables, and for values which are set during initialization, I create private attribute readers, so `@var_name` is
only used during `RMT::Mirror.new`.

## Change Type

- [ ] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)
- [x] Code refactoring

## Checklist

*Please check off each item if the requirement is met.*

- [x] I have verified that my code follows RMT's coding standards with `rubocop`.
- [x] I have reviewed my own code and believe that it's ready for an external review.
- [x] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [x] RMT's test coverage remains at 100%.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.
