### PR TITLE
Fix RMT::Downloader cache mechanism

### DIFF
--- a/lib/rmt.rb
+++ b/lib/rmt.rb
@@ -1,5 +1,5 @@
 module RMT
-  VERSION ||= '2.6.0'.freeze
+  VERSION ||= '2.6.2'.freeze
 
   DEFAULT_USER = '_rmt'.freeze
   DEFAULT_GROUP = 'nginx'.freeze

--- a/lib/rmt/cli/import.rb
+++ b/lib/rmt/cli/import.rb
@@ -20,7 +20,9 @@ class RMT::CLI::Import < RMT::CLI::Base
       raise RMT::CLI::Error.new(_('%{file} does not exist.') % { file: repos_file }) unless File.exist?(repos_file)
 
       begin
-        mirror.mirror_suma_product_tree(repository_url: 'file://' + path + '/suma/')
+        exported_suma_path = File.join(path, '/suma/')
+        suma_repo_url = URI.join('file://', exported_suma_path).to_s
+        mirror.mirror_suma_product_tree(repository_url: suma_repo_url)
       rescue RMT::Mirror::Exception => e
         logger.warn(e.message)
       end
@@ -34,8 +36,10 @@ class RMT::CLI::Import < RMT::CLI::Base
         end
 
         begin
+          exported_repo_path = File.join(path, Repository.make_local_path(repo_json['url']))
+          repo_url = URI.join('file://', exported_repo_path).to_s
           mirror.mirror(
-            repository_url: 'file://' + path + Repository.make_local_path(repo_json['url']),
+            repository_url: repo_url,
             local_path: Repository.make_local_path(repo.external_url),
             auth_token: repo.auth_token,
             repo_name: repo.name

--- a/lib/rmt/fiber_request.rb
+++ b/lib/rmt/fiber_request.rb
@@ -2,11 +2,11 @@
 class RMT::FiberRequest < RMT::HttpRequest
   attr_accessor :base_url, :download_path, :remote_file
 
-  def initialize(base_url, download_path:, request_fiber:, remote_file:, **options)
+  def initialize(base_url, download_path:, request_fiber:, **options)
     @base_url = base_url
     @download_path = download_path
     @request_fiber = request_fiber
-    @remote_file = remote_file
+    @remote_file = base_url.split('?').first
 
     super(base_url, options)
 

--- a/lib/rmt/mirror/file_reference.rb
+++ b/lib/rmt/mirror/file_reference.rb
@@ -26,6 +26,6 @@ class RMT::Mirror::FileReference
   end
 
   def cache_timestamp
-    File.mtime(cache_path).utc.httpdate if cache_path && File.exist?(cache_path)
+    File.mtime(cache_path).utc if cache_path && File.exist?(cache_path)
   end
 end

--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -1,4 +1,20 @@
 -------------------------------------------------------------------
+Tue Sep 29 14:53:12 UTC 2020 - Luís Caparroz <luis.caparroz@suse.com>
+
+- Version 2.6.2
+- Fix RMT file caching based on timestamps:
+
+  Previously, RMT sent GET requests with the header 'If-Modified-Since' to a
+  repository server and if the response had a 304 (Not Modified), it would copy
+  a file from the local cache instead of downloading. However, if the local file
+  timestamp accidentally changed to a date newer than the one on the repository
+  server, RMT would have an outdated file, which caused some errors.
+
+  Now, RMT makes HEAD requests to the repositories servers and inspect the
+  'Last-Modified' header to decide whether to download a file or copy it from
+  cache, by comparing the equalness of timestamps.
+
+-------------------------------------------------------------------
 Mon Sep 21 16:44:23 UTC 2020 - Thomas Muntaner <tmuntaner@suse.com>
 
 - Version 2.6.0

--- a/package/obs/rmt-server.spec
+++ b/package/obs/rmt-server.spec
@@ -29,7 +29,7 @@
 %define ruby_version          %{rb_default_ruby_suffix}
 
 Name:           rmt-server
-Version:        2.6.0
+Version:        2.6.2
 Release:        0
 Summary:        Repository mirroring tool and registration proxy for SCC
 License:        GPL-2.0-or-later

--- a/spec/fixtures/vcr_cassettes/mirroring_product_with_cached_metadata.yml
+++ b/spec/fixtures/vcr_cassettes/mirroring_product_with_cached_metadata.yml
@@ -1,388 +1,366 @@
 ---
 http_interactions:
 - request:
-    method: get
+    method: head
     uri: http://localhost/dummy_product/product.license/directory.yast
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RMT/0.0.2
-      If-Modified-Since:
-      - Mon, 01 Jan 2018 10:10:00 GMT
+      - RMT/2.5.20
       Expect:
       - ''
   response:
     status:
-      code: 304
-      message: Not Modified
+      code: 200
+      message: OK
     headers:
       Server:
-      - nginx/1.13.1
+      - SimpleHTTP/0.6 Python/3.8.5
       Date:
-      - Thu, 25 Jan 2018 16:29:13 GMT
+      - Fri, 25 Sep 2020 12:51:15 GMT
+      Content-type:
+      - application/octet-stream
+      Content-Length:
+      - '57'
       Last-Modified:
-      - Mon, 01 Jan 2018 10:10:00 GMT
-      Connection:
-      - keep-alive
-      ETag:
-      - '"5a4a08f8-39"'
+      - Mon, 18 May 2020 09:24:25 GMT
     body:
-      encoding: US-ASCII
+      encoding: UTF-8
       string: ''
-    http_version: '1.1'
+    http_version: '1.0'
     adapter_metadata:
       effective_url: http://localhost/dummy_product/product.license/directory.yast
-  recorded_at: Thu, 25 Jan 2018 16:29:13 GMT
+  recorded_at: Fri, 25 Sep 2020 12:51:15 GMT
 - request:
-    method: get
+    method: head
     uri: http://localhost/dummy_product/product.license/license.de.txt
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RMT/0.0.2
-      If-Modified-Since:
-      - Mon, 01 Jan 2018 10:10:00 GMT
+      - RMT/2.5.20
       Expect:
       - ''
   response:
     status:
-      code: 304
-      message: Not Modified
+      code: 200
+      message: OK
     headers:
       Server:
-      - nginx/1.13.1
+      - SimpleHTTP/0.6 Python/3.8.5
       Date:
-      - Thu, 25 Jan 2018 16:29:13 GMT
+      - Fri, 25 Sep 2020 12:51:15 GMT
+      Content-type:
+      - text/plain
+      Content-Length:
+      - '141'
       Last-Modified:
-      - Mon, 01 Jan 2018 10:10:00 GMT
-      Connection:
-      - keep-alive
-      ETag:
-      - '"5a4a08f8-8d"'
+      - Mon, 18 May 2020 09:24:25 GMT
     body:
-      encoding: US-ASCII
+      encoding: UTF-8
       string: ''
-    http_version: '1.1'
+    http_version: '1.0'
     adapter_metadata:
       effective_url: http://localhost/dummy_product/product.license/license.de.txt
-  recorded_at: Thu, 25 Jan 2018 16:29:13 GMT
+  recorded_at: Fri, 25 Sep 2020 12:51:15 GMT
 - request:
-    method: get
+    method: head
     uri: http://localhost/dummy_product/product.license/license.ru.txt
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RMT/0.0.2
-      If-Modified-Since:
-      - Mon, 01 Jan 2018 10:10:00 GMT
+      - RMT/2.5.20
       Expect:
       - ''
   response:
     status:
-      code: 304
-      message: Not Modified
+      code: 200
+      message: OK
     headers:
       Server:
-      - nginx/1.13.1
+      - SimpleHTTP/0.6 Python/3.8.5
       Date:
-      - Thu, 25 Jan 2018 16:29:13 GMT
+      - Fri, 25 Sep 2020 12:51:15 GMT
+      Content-type:
+      - text/plain
+      Content-Length:
+      - '141'
       Last-Modified:
-      - Mon, 01 Jan 2018 10:10:00 GMT
-      Connection:
-      - keep-alive
-      ETag:
-      - '"5a4a08f8-8d"'
+      - Mon, 18 May 2020 09:24:25 GMT
     body:
-      encoding: US-ASCII
+      encoding: UTF-8
       string: ''
-    http_version: '1.1'
+    http_version: '1.0'
     adapter_metadata:
       effective_url: http://localhost/dummy_product/product.license/license.ru.txt
-  recorded_at: Thu, 25 Jan 2018 16:29:13 GMT
+  recorded_at: Fri, 25 Sep 2020 12:51:15 GMT
 - request:
-    method: get
+    method: head
     uri: http://localhost/dummy_product/product.license/license.txt
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RMT/0.0.2
-      If-Modified-Since:
-      - Mon, 01 Jan 2018 10:10:00 GMT
+      - RMT/2.5.20
       Expect:
       - ''
   response:
     status:
-      code: 304
-      message: Not Modified
+      code: 200
+      message: OK
     headers:
       Server:
-      - nginx/1.13.1
+      - SimpleHTTP/0.6 Python/3.8.5
       Date:
-      - Thu, 25 Jan 2018 16:29:13 GMT
+      - Fri, 25 Sep 2020 12:51:15 GMT
+      Content-type:
+      - text/plain
+      Content-Length:
+      - '141'
       Last-Modified:
-      - Mon, 01 Jan 2018 10:10:00 GMT
-      Connection:
-      - keep-alive
-      ETag:
-      - '"5a4a08f8-8d"'
+      - Mon, 18 May 2020 09:24:25 GMT
     body:
-      encoding: US-ASCII
+      encoding: UTF-8
       string: ''
-    http_version: '1.1'
+    http_version: '1.0'
     adapter_metadata:
       effective_url: http://localhost/dummy_product/product.license/license.txt
-  recorded_at: Thu, 25 Jan 2018 16:29:13 GMT
+  recorded_at: Fri, 25 Sep 2020 12:51:15 GMT
 - request:
-    method: get
+    method: head
     uri: http://localhost/dummy_product/product/repodata/repomd.xml?repo_auth_token
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RMT/0.0.2
-      If-Modified-Since:
-      - Mon, 01 Jan 2018 10:10:00 GMT
+      - RMT/2.5.20
       Expect:
       - ''
   response:
     status:
-      code: 304
-      message: Not Modified
+      code: 200
+      message: OK
     headers:
       Server:
-      - nginx/1.13.1
+      - SimpleHTTP/0.6 Python/3.8.5
       Date:
-      - Thu, 25 Jan 2018 16:29:13 GMT
+      - Fri, 25 Sep 2020 12:51:15 GMT
+      Content-type:
+      - text/xml
+      Content-Length:
+      - '1939'
       Last-Modified:
-      - Mon, 01 Jan 2018 10:10:00 GMT
-      Connection:
-      - keep-alive
-      ETag:
-      - '"5a4a08f8-793"'
+      - Mon, 18 May 2020 09:24:25 GMT
     body:
-      encoding: US-ASCII
+      encoding: UTF-8
       string: ''
-    http_version: '1.1'
+    http_version: '1.0'
     adapter_metadata:
       effective_url: http://localhost/dummy_product/product/repodata/repomd.xml?repo_auth_token
-  recorded_at: Thu, 25 Jan 2018 16:29:13 GMT
+  recorded_at: Fri, 25 Sep 2020 12:51:15 GMT
 - request:
-    method: get
-    uri: http://localhost/dummy_product/product/repodata/repomd.xml.key?repo_auth_token
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - RMT/0.0.2
-      If-Modified-Since:
-      - Mon, 01 Jan 2018 10:10:00 GMT
-      Expect:
-      - ''
-  response:
-    status:
-      code: 304
-      message: Not Modified
-    headers:
-      Server:
-      - nginx/1.13.1
-      Date:
-      - Thu, 25 Jan 2018 16:29:13 GMT
-      Last-Modified:
-      - Mon, 01 Jan 2018 10:10:00 GMT
-      Connection:
-      - keep-alive
-      ETag:
-      - '"5a4a08f8-b"'
-    body:
-      encoding: US-ASCII
-      string: ''
-    http_version: '1.1'
-    adapter_metadata:
-      effective_url: http://localhost/dummy_product/product/repodata/repomd.xml.key?repo_auth_token
-  recorded_at: Thu, 25 Jan 2018 16:29:13 GMT
-- request:
-    method: get
+    method: head
     uri: http://localhost/dummy_product/product/repodata/repomd.xml.asc?repo_auth_token
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RMT/0.0.2
-      If-Modified-Since:
-      - Mon, 01 Jan 2018 10:10:00 GMT
+      - RMT/2.5.20
       Expect:
       - ''
   response:
     status:
-      code: 304
-      message: Not Modified
+      code: 200
+      message: OK
     headers:
       Server:
-      - nginx/1.13.1
+      - SimpleHTTP/0.6 Python/3.8.5
       Date:
-      - Thu, 25 Jan 2018 16:29:13 GMT
+      - Fri, 25 Sep 2020 12:51:15 GMT
+      Content-type:
+      - text/plain
+      Content-Length:
+      - '17'
       Last-Modified:
-      - Mon, 01 Jan 2018 10:10:00 GMT
-      Connection:
-      - keep-alive
-      ETag:
-      - '"5a4a08f8-11"'
+      - Mon, 18 May 2020 09:24:25 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: '1.0'
+    adapter_metadata:
+      effective_url: http://localhost/dummy_product/product/repodata/repomd.xml.asc?repo_auth_token
+  recorded_at: Fri, 25 Sep 2020 12:51:15 GMT
+- request:
+    method: head
+    uri: http://localhost/dummy_product/product/repodata/repomd.xml.key?repo_auth_token
     body:
       encoding: US-ASCII
       string: ''
-    http_version: '1.1'
+    headers:
+      User-Agent:
+      - RMT/2.5.20
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - SimpleHTTP/0.6 Python/3.8.5
+      Date:
+      - Fri, 25 Sep 2020 12:51:15 GMT
+      Content-type:
+      - application/octet-stream
+      Content-Length:
+      - '11'
+      Last-Modified:
+      - Mon, 18 May 2020 09:24:25 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: '1.0'
     adapter_metadata:
-      effective_url: http://localhost/dummy_product/product/repodata/repomd.xml.asc?repo_auth_token
-  recorded_at: Thu, 25 Jan 2018 16:29:13 GMT
+      effective_url: http://localhost/dummy_product/product/repodata/repomd.xml.key?repo_auth_token
+  recorded_at: Fri, 25 Sep 2020 12:51:15 GMT
 - request:
-    method: get
+    method: head
     uri: http://localhost/dummy_product/product/repodata/837fb50abc9680b1e11e050901a56721855a5e854e85e46ceaad2c6816297e69-filelists.xml.gz?repo_auth_token
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RMT/0.0.2
-      If-Modified-Since:
-      - Mon, 01 Jan 2018 10:10:00 GMT
+      - RMT/2.5.20
       Expect:
       - ''
   response:
     status:
-      code: 304
-      message: Not Modified
+      code: 200
+      message: OK
     headers:
       Server:
-      - nginx/1.13.1
+      - SimpleHTTP/0.6 Python/3.8.5
       Date:
-      - Thu, 25 Jan 2018 16:29:13 GMT
+      - Fri, 25 Sep 2020 12:51:15 GMT
+      Content-type:
+      - application/x-gzip
+      Content-Length:
+      - '402'
       Last-Modified:
-      - Mon, 01 Jan 2018 10:10:00 GMT
-      Connection:
-      - keep-alive
-      ETag:
-      - '"5a4a08f8-192"'
+      - Mon, 18 May 2020 09:24:25 GMT
     body:
-      encoding: US-ASCII
+      encoding: UTF-8
       string: ''
-    http_version: '1.1'
+    http_version: '1.0'
     adapter_metadata:
       effective_url: http://localhost/dummy_product/product/repodata/837fb50abc9680b1e11e050901a56721855a5e854e85e46ceaad2c6816297e69-filelists.xml.gz?repo_auth_token
-  recorded_at: Thu, 25 Jan 2018 16:29:13 GMT
+  recorded_at: Fri, 25 Sep 2020 12:51:15 GMT
 - request:
-    method: get
+    method: head
     uri: http://localhost/dummy_product/product/repodata/a546b430098b8a3fb7d65493a9ce608fafcb32f451d0ce8bf85410191f347cc3-deltainfo.xml.gz?repo_auth_token
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RMT/0.0.2
-      If-Modified-Since:
-      - Mon, 01 Jan 2018 10:10:00 GMT
+      - RMT/2.5.20
       Expect:
       - ''
   response:
     status:
-      code: 304
-      message: Not Modified
+      code: 200
+      message: OK
     headers:
       Server:
-      - nginx/1.13.1
+      - SimpleHTTP/0.6 Python/3.8.5
       Date:
-      - Thu, 25 Jan 2018 16:29:13 GMT
+      - Fri, 25 Sep 2020 12:51:15 GMT
+      Content-type:
+      - application/x-gzip
+      Content-Length:
+      - '451'
       Last-Modified:
-      - Mon, 01 Jan 2018 10:10:00 GMT
-      Connection:
-      - keep-alive
-      ETag:
-      - '"5a4a08f8-1c3"'
+      - Mon, 18 May 2020 09:24:25 GMT
     body:
-      encoding: US-ASCII
+      encoding: UTF-8
       string: ''
-    http_version: '1.1'
+    http_version: '1.0'
     adapter_metadata:
       effective_url: http://localhost/dummy_product/product/repodata/a546b430098b8a3fb7d65493a9ce608fafcb32f451d0ce8bf85410191f347cc3-deltainfo.xml.gz?repo_auth_token
-  recorded_at: Thu, 25 Jan 2018 16:29:13 GMT
+  recorded_at: Fri, 25 Sep 2020 12:51:15 GMT
 - request:
-    method: get
+    method: head
     uri: http://localhost/dummy_product/product/repodata/2d12587a74d924bad597fd8e25b8955270dfbe7591e020f9093edbb4a0d04444-other.xml.gz?repo_auth_token
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RMT/0.0.2
-      If-Modified-Since:
-      - Mon, 01 Jan 2018 10:10:00 GMT
+      - RMT/2.5.20
       Expect:
       - ''
   response:
     status:
-      code: 304
-      message: Not Modified
+      code: 200
+      message: OK
     headers:
       Server:
-      - nginx/1.13.1
+      - SimpleHTTP/0.6 Python/3.8.5
       Date:
-      - Thu, 25 Jan 2018 16:29:13 GMT
+      - Fri, 25 Sep 2020 12:51:15 GMT
+      Content-type:
+      - application/x-gzip
+      Content-Length:
+      - '379'
       Last-Modified:
-      - Mon, 01 Jan 2018 10:10:00 GMT
-      Connection:
-      - keep-alive
-      ETag:
-      - '"5a4a08f8-17b"'
+      - Mon, 18 May 2020 09:24:25 GMT
     body:
-      encoding: US-ASCII
+      encoding: UTF-8
       string: ''
-    http_version: '1.1'
+    http_version: '1.0'
     adapter_metadata:
       effective_url: http://localhost/dummy_product/product/repodata/2d12587a74d924bad597fd8e25b8955270dfbe7591e020f9093edbb4a0d04444-other.xml.gz?repo_auth_token
-  recorded_at: Thu, 25 Jan 2018 16:29:13 GMT
+  recorded_at: Fri, 25 Sep 2020 12:51:15 GMT
 - request:
-    method: get
+    method: head
     uri: http://localhost/dummy_product/product/repodata/abf421e45af5cd686f050bab3d2a98e0a60d1b5ca3b07c86cb948fc1abfa675e-primary.xml.gz?repo_auth_token
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RMT/0.0.2
-      If-Modified-Since:
-      - Mon, 01 Jan 2018 10:10:00 GMT
+      - RMT/2.5.20
       Expect:
       - ''
   response:
     status:
-      code: 304
-      message: Not Modified
+      code: 200
+      message: OK
     headers:
       Server:
-      - nginx/1.13.1
+      - SimpleHTTP/0.6 Python/3.8.5
       Date:
-      - Thu, 25 Jan 2018 16:29:13 GMT
+      - Fri, 25 Sep 2020 12:51:15 GMT
+      Content-type:
+      - application/x-gzip
+      Content-Length:
+      - '920'
       Last-Modified:
-      - Mon, 01 Jan 2018 10:10:00 GMT
-      Connection:
-      - keep-alive
-      ETag:
-      - '"5a4a08f8-398"'
+      - Mon, 18 May 2020 09:24:25 GMT
     body:
-      encoding: US-ASCII
+      encoding: UTF-8
       string: ''
-    http_version: '1.1'
+    http_version: '1.0'
     adapter_metadata:
       effective_url: http://localhost/dummy_product/product/repodata/abf421e45af5cd686f050bab3d2a98e0a60d1b5ca3b07c86cb948fc1abfa675e-primary.xml.gz?repo_auth_token
-  recorded_at: Thu, 25 Jan 2018 16:29:13 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Fri, 25 Sep 2020 12:51:15 GMT
+recorded_with: VCR 6.0.0

--- a/spec/lib/rmt/downloader_spec.rb
+++ b/spec/lib/rmt/downloader_spec.rb
@@ -289,14 +289,21 @@ RSpec.describe RMT::Downloader do
     subject(:download) { downloader.download(repomd_xml_file) }
 
     let(:repository_dir) { Dir.mktmpdir }
-    let(:repository_url) { 'file://' + File.expand_path(file_fixture('dummy_repo/')) + '/' }
+    let(:repository_url_local_path) { File.expand_path(file_fixture('dummy_repo/')) + '/' }
+    let(:repository_url) { URI.join('file://', repository_url_local_path) }
     let(:downloader) { described_class.new(logger: RMT::Logger.new('/dev/null')) }
     let(:repomd_xml_file) do
       RMT::Mirror::FileReference.new(
         relative_path: 'repodata/repomd.xml',
         base_url: repository_url,
-        base_dir: repository_dir
+        base_dir: repository_dir,
+        cache_dir: repository_url_local_path
       )
+    end
+
+    before do
+      stub_request(:head, /#{repository_url_local_path}/)
+        .to_raise('should not make HEAD requests')
     end
 
     # WebMock doesn't work nicely with file://

--- a/spec/lib/rmt/downloader_spec.rb
+++ b/spec/lib/rmt/downloader_spec.rb
@@ -412,7 +412,7 @@ RSpec.describe RMT::Downloader do
     context 'when there are cached files' do
       let(:cache_dir) { Dir.mktmpdir }
 
-      context 'when a HEAD request fails and the ignore_erros = false' do
+      context 'when a HEAD request fails and the ignore_errors = false' do
         before do
           queue.each do |file|
             FileUtils.touch(file.cache_path)
@@ -430,7 +430,7 @@ RSpec.describe RMT::Downloader do
         end
       end
 
-      context 'when a HEAD request fails and the ignore_erros = true' do
+      context 'when a HEAD request fails and the ignore_errors = true' do
         before do
           queue.each do |file|
             FileUtils.touch(file.cache_path)
@@ -439,7 +439,7 @@ RSpec.describe RMT::Downloader do
           end
         end
 
-        it 'raises an error' do
+        it 'returns a list of failed downloads' do
           failed_downloads = downloader.download_multi(queue.dup, ignore_errors: true)
           expect(failed_downloads).to match_array(queue.map(&:local_path))
         end

--- a/spec/lib/rmt/mirror/file_reference_spec.rb
+++ b/spec/lib/rmt/mirror/file_reference_spec.rb
@@ -46,11 +46,11 @@ RSpec.describe RMT::Mirror::FileReference do
       before do
         absolute_path = File.join(cache_dir, relative_path)
         FileUtils.mkpath(File.dirname(absolute_path))
-        FileUtils.touch(absolute_path, mtime: Time.parse(timestamp).utc)
+        FileUtils.touch(absolute_path, mtime: timestamp)
       end
 
       let(:cache_dir) { tmp_dir }
-      let(:timestamp) { 'Fri, 18 Sep 2020 18:13:57 GMT' }
+      let(:timestamp) { Time.parse('Fri, 18 Sep 2020 18:13:57 GMT').utc }
 
       it "returns the file's mtime" do
         expect(file_reference.cache_timestamp).to eq(timestamp)

--- a/spec/lib/rmt/mirror_spec.rb
+++ b/spec/lib/rmt/mirror_spec.rb
@@ -652,10 +652,14 @@ RSpec.describe RMT::Mirror do
         }
       end
 
-      let(:timestamp) { 'Mon, 01 Jan 2018 10:10:00 GMT' }
+      let(:timestamp) { 'Mon, 18 May 2020 09:24:25 GMT' }
 
       before do
-        FileUtils.touch "#{mirroring_dir}/dummy_product/product/repodata/repomd.xml", mtime: Time.parse(timestamp).utc
+        metadata_files = [
+          File.join(mirroring_dir, 'dummy_product', 'product.license', '**'),
+          File.join(mirroring_dir, 'dummy_product', 'product', 'repodata', '**')
+        ].reduce([]) { |files, path| files + Dir.glob(path) }
+        metadata_files.each { |file| FileUtils.touch(file, mtime: Time.parse(timestamp).utc) }
 
         VCR.use_cassette 'mirroring_product_with_cached_metadata' do
           rmt_mirror.mirror(**mirror_params)


### PR DESCRIPTION
## Description

`RMT::Downloader` decided whether to download a file or copy it from cache based on a combination of the file timestamp and the HTTP header `'If-Modified-Since'`: if the file timestamp on disk is newer than on
server, the HTTP response code would be 304 (not modified).

This caused some unexpected behavior if, accidentally, the file timestamp on disk changed. The timeline example below better illustrates the bug:

1. The first time 'repomd.xml' is downloaded from a repo, its `mtime` attribute on the RMT server is correct, since it's been just created;
2. A new version of 'repomd.xml' has been released and is available for mirroring;
3. Accidentally, the file's `mtime` on the RMT server changed to a time newer than the new 'repomd.xml' timestamp on the repo;
4. The next time RMT server tries to mirror `repomd.xml`, it sends a request with the header `'If-Modified-Since'` containing the newer `mtime`, which causes the response HTTP code to be 304;
5. Then, RMT decides to use the cached version of `repomd.xml`, which is outdated;
6. However, since 'repomd.xml' is outdated, when RMT parses it, probably the other files listed in it are no more available (the other `.xml` metadata files are named after their checksum);
7. Mirroring the repository will fail with some HTTP responses 404.

What has changed to avoid trouble with accidental 'mtime' messing:

* Instead of making a "greater than or equal to" comparison using the `'If-Modified-Since'` header, RMT makes a `HEAD` request and compare the `Last-Modified` header with the file `mtime`, deciding to download the file if those are different;
* RMT overwrites the file's `mtime` on disk after downloading with the value of the `'Last-Modified'` header.

Fixes #628.

## Change Type

*Please select the correct option.*

- [x] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [x] I have verified that my code follows RMT's coding standards with `rubocop`.
- [x] I have reviewed my own code and believe that it's ready for an external review.
- [x] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [x] RMT's test coverage remains at 100%.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.