### PR TITLE
Expand Input Paths

### DIFF
--- a/lib/rmt.rb
+++ b/lib/rmt.rb
@@ -1,5 +1,5 @@
 module RMT
-  VERSION ||= '2.6.0'.freeze
+  VERSION ||= '2.6.1'.freeze
 
   DEFAULT_USER = '_rmt'.freeze
   DEFAULT_GROUP = 'nginx'.freeze

--- a/lib/rmt/cli/base.rb
+++ b/lib/rmt/cli/base.rb
@@ -112,7 +112,11 @@ class RMT::CLI::Base < Thor
   private
 
   def needs_path(path, writable: false)
+    # expand the path to make it easier to work with
+    path = File.expand_path(path)
+
     raise RMT::CLI::Error.new(_('%{path} is not a directory.') % { path: path }) unless File.directory?(path)
+
     if writable
       unless File.writable?(path)
         raise RMT::CLI::Error.new(_('%{path} is not writable by user %{username}.') % {
@@ -121,6 +125,8 @@ class RMT::CLI::Base < Thor
         })
       end
     end
+
+    path
   end
 
   # Allows to have any type of multi input that you want:

--- a/lib/rmt/cli/export.rb
+++ b/lib/rmt/cli/export.rb
@@ -2,13 +2,13 @@ class RMT::CLI::Export < RMT::CLI::Base
 
   desc 'data PATH', _('Store SCC data in files at given path')
   def data(path)
-    needs_path(path, writable: true)
+    path = needs_path(path, writable: true)
     RMT::SCC.new(options).export(path)
   end
 
   desc 'settings PATH', _('Store repository settings at given path')
   def settings(path)
-    needs_path(path, writable: true)
+    path = needs_path(path, writable: true)
     filename = File.join(path, 'repos.json')
 
     data = Repository.only_mirroring_enabled.inject([]) { |data, repo| data << { url: repo.external_url, auth_token: repo.auth_token.to_s } }
@@ -28,7 +28,7 @@ class RMT::CLI::Export < RMT::CLI::Base
    #{_('RMT will mirror the specified repositories in %{file} to PATH, usually a portable storage device.' % { file: 'repos.json' })}
   REPOS
   def repos(path)
-    needs_path(path, writable: true)
+    path = needs_path(path, writable: true)
 
     logger = RMT::Logger.new(STDOUT)
     mirror = RMT::Mirror.new(mirroring_base_dir: path, logger: logger, airgap_mode: true)

--- a/lib/rmt/cli/import.rb
+++ b/lib/rmt/cli/import.rb
@@ -3,7 +3,7 @@ class RMT::CLI::Import < RMT::CLI::Base
   desc 'data PATH', _('Read SCC data from given path')
   def data(path)
     RMT::Lockfile.lock do
-      needs_path(path)
+      path = needs_path(path)
       RMT::SCC.new(options).import(path)
     end
   end
@@ -11,7 +11,7 @@ class RMT::CLI::Import < RMT::CLI::Base
   desc 'repos PATH', _('Mirror repos from given path')
   def repos(path)
     RMT::Lockfile.lock do
-      needs_path(path)
+      path = needs_path(path)
 
       logger = RMT::Logger.new(STDOUT)
       mirror = RMT::Mirror.new(logger: logger, airgap_mode: true)

--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Sep 29 10:19:12 UTC 2020 - Thomas Muntaner <tmuntaner@suse.com>
+
+- Version 2.6.1
+- Fixed an issue where relative paths supplied to `rmt-cli import repos`
+  caused the command to fail.
+
+-------------------------------------------------------------------
 Mon Sep 21 16:44:23 UTC 2020 - Thomas Muntaner <tmuntaner@suse.com>
 
 - Version 2.6.0

--- a/package/obs/rmt-server.spec
+++ b/package/obs/rmt-server.spec
@@ -29,7 +29,7 @@
 %define ruby_version          %{rb_default_ruby_suffix}
 
 Name:           rmt-server
-Version:        2.6.0
+Version:        2.6.1
 Release:        0
 Summary:        Repository mirroring tool and registration proxy for SCC
 License:        GPL-2.0-or-later

--- a/spec/lib/rmt/cli/export_spec.rb
+++ b/spec/lib/rmt/cli/export_spec.rb
@@ -22,6 +22,19 @@ describe RMT::CLI::Export, :with_fakefs do
       expect(File.exist?(expected_filename)).to be true
       expect(File.read(expected_filename).chomp).to eq expected_json
     end
+
+    context 'relative path' do
+      let(:path) { '/mnt/usb/../usb' }
+
+      it 'writes ids of enabled repos to file' do
+        FileUtils.mkdir_p path
+        expect { command }.to output(%r{Settings saved at /mnt/usb}).to_stdout
+        expected_filename = File.join('/mnt/usb', 'repos.json')
+        expected_json = [{ url: repository.external_url, auth_token: repository.auth_token.to_s }].to_json
+        expect(File.exist?(expected_filename)).to be true
+        expect(File.read(expected_filename).chomp).to eq expected_json
+      end
+    end
   end
 
   describe 'data' do
@@ -35,6 +48,17 @@ describe RMT::CLI::Export, :with_fakefs do
 
       expect_any_instance_of(RMT::SCC).to receive(:export).with(path)
       command
+    end
+
+    context 'relative path' do
+      let(:path) { '/mnt/usb/../usb' }
+
+      it 'triggers export to path' do
+        FileUtils.mkdir_p path
+
+        expect_any_instance_of(RMT::SCC).to receive(:export).with('/mnt/usb')
+        command
+      end
     end
   end
 
@@ -70,6 +94,38 @@ describe RMT::CLI::Export, :with_fakefs do
 
         expect_any_instance_of(RMT::Mirror).to receive(:mirror_suma_product_tree)
         expect { command }.to raise_error(SystemExit).and(output("#{File.join(path, 'repos.json')} does not exist.\n").to_stderr)
+      end
+    end
+
+    context 'with relative path' do
+      let(:path) { '/mnt/usb/../usb' }
+
+      before do
+        expect(RMT::Mirror).to receive(:new).with(
+          mirroring_base_dir: '/mnt/usb',
+          logger: instance_of(RMT::Logger),
+          airgap_mode: true
+        ).once.and_return(mirror_double)
+      end
+
+      it 'reads repo ids from file at path and mirrors these repos' do
+        FileUtils.mkdir_p path
+        File.write('/mnt/usb/repos.json', repo_settings.to_json)
+
+        expect(mirror_double).to receive(:mirror_suma_product_tree)
+        expect(mirror_double).to receive(:mirror).with(
+          repository_url: 'http://foo.bar/repo1',
+          auth_token: 'foobar',
+          local_path: '/repo1'
+        )
+
+        expect(mirror_double).to receive(:mirror).with(
+          repository_url: 'http://foo.bar/repo2',
+          auth_token: '',
+          local_path: '/repo2'
+        )
+
+        command
       end
     end
 


### PR DESCRIPTION
## Description

We didn't expand relative paths before, and this mostly worked, but it caused an issue with `rmt-cli import repos`. This is because RMT tried to build URIs from a relative path like "./test" to "file://./test", which is wrong.

## Change Type

*Please select the correct option.*

- [x] **Bug Fix** (a non-breaking change which fixes an issue)

## Checklist

*Please check off each item if the requirement is met.*

- [x] I have verified that my code follows RMT's coding standards with `rubocop`.
- [x] I have reviewed my own code and believe that it's ready for an external review.
- [x] I have provided comments for any hard-to-understand code.
- [x] I have documented the `MANUAL.md` file with any changes to the user experience.
- [x] RMT's test coverage remains at 100%.
- [x] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.
