### PR TITLE
Use name to build friendly_ids for custom repos

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -124,7 +124,7 @@ After successful registration the repositories from RMT will be used by `zypper`
 
     Use the `--csv` flag to output the list in CSV format.
 
-  * `rmt-cli repos custom add <url> <name>`:
+  * `rmt-cli repos custom add <url> <name> [--id]`:
     Adds a new custom repository, for example:
 
     `rmt-cli repos custom add https://download.opensuse.org/repositories/Virtualization:/containers/SLE_12_SP3/ Virtualization:Containers`

--- a/app/services/repository_service.rb
+++ b/app/services/repository_service.rb
@@ -11,7 +11,8 @@ class RepositoryService
     end
 
     if custom
-      repository.friendly_id = attributes[:id].to_s != '' ? attributes[:id] : Repository.make_friendly_url_id(url)
+      id_source = attributes[:id].to_s != '' ? attributes[:id] : attributes[:name]
+      repository.friendly_id ||= Repository.make_friendly_id(id_source)
     else
       repository.scc_id = attributes[:id]
       repository.friendly_id = attributes[:id]

--- a/db/migrate/20200916120607_add_friendly_target_to_repositories.rb
+++ b/db/migrate/20200916120607_add_friendly_target_to_repositories.rb
@@ -5,7 +5,7 @@ class AddFriendlyTargetToRepositories < ActiveRecord::Migration[6.0]
 
     Repository.all.each do |repo|
       if repo.custom?
-        repo.update(friendly_id: Repository.make_friendly_url_id(repo.external_url))
+        repo.update(friendly_id: Repository.make_friendly_id(repo.name))
       else
         repo.update(friendly_id: repo.scc_id)
       end

--- a/lib/rmt.rb
+++ b/lib/rmt.rb
@@ -1,5 +1,5 @@
 module RMT
-  VERSION ||= '2.6.2'.freeze
+  VERSION ||= '2.6.3'.freeze
 
   DEFAULT_USER = '_rmt'.freeze
   DEFAULT_GROUP = 'nginx'.freeze

--- a/lib/rmt/cli/repos_custom.rb
+++ b/lib/rmt/cli/repos_custom.rb
@@ -13,16 +13,18 @@ $ rmt-cli repos custom add https://download.opensuse.org/repositories/Virtualiza
   REPOS
   def add(url, name)
     url += '/' unless url.end_with?('/')
-    friendly_id = options.id.to_s
+    friendly_id = options.id
+    friendly_id ||= name.strip
 
     if Repository.find_by(external_url: url)
       raise RMT::CLI::Error.new(_('A repository by the URL %{url} already exists.') % { url: url })
+    elsif Repository.find_by(friendly_id: options.id.to_s)
+      # When given an ID by a user, don't append to it to make a unique ID.
+      raise RMT::CLI::Error.new(_('A repository by the ID %{id} already exists.') % { id: friendly_id })
     end
 
     if /^[0-9]+$/.match?(friendly_id) # numeric IDs are reserved for SCC repositories
       raise RMT::CLI::Error.new(_('Please provide a non-numeric ID for your custom repository.'))
-    elsif Repository.find_by(friendly_id: friendly_id)
-      raise RMT::CLI::Error.new(_('A repository by the ID %{id} already exists.') % { id: friendly_id })
     end
 
     repository_service.create_repository!(nil, url, {

--- a/lib/rmt/cli/repos_custom.rb
+++ b/lib/rmt/cli/repos_custom.rb
@@ -26,7 +26,7 @@ $ rmt-cli repos custom add https://download.opensuse.org/repositories/Virtualiza
     end
 
     repository_service.create_repository!(nil, url, {
-      name: name,
+      name: name.strip,
       mirroring_enabled: true,
       autorefresh: true,
       enabled: 0,

--- a/lib/rmt/cli/smt_importer.rb
+++ b/lib/rmt/cli/smt_importer.rb
@@ -52,7 +52,7 @@ class RMT::CLI::SMTImporter
       repo = Repository.find_or_create_by(external_url: repo_url) do |repository|
         repository.name = repo_name
         repository.local_path = Repository.make_local_path(repo_url)
-        repository.friendly_id = Repository.make_friendly_url_id(repo_url)
+        repository.friendly_id ||= Repository.make_friendly_id(repo_name)
       end
 
       if product

--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Sep 30 16:19:36 UTC 2020 - Thomas Muntaner <tmuntaner@suse.com>
+
+- Version 2.6.3
+- Instead of using an MD5 of URLs for custom repository friendly_ids,
+  RMT now builds an ID from the name.
+
+-------------------------------------------------------------------
 Tue Sep 29 14:53:12 UTC 2020 - Luís Caparroz <luis.caparroz@suse.com>
 
 - Version 2.6.2

--- a/package/obs/rmt-server.spec
+++ b/package/obs/rmt-server.spec
@@ -29,7 +29,7 @@
 %define ruby_version          %{rb_default_ruby_suffix}
 
 Name:           rmt-server
-Version:        2.6.2
+Version:        2.6.3
 Release:        0
 Summary:        Repository mirroring tool and registration proxy for SCC
 License:        GPL-2.0-or-later

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -118,6 +118,75 @@ RSpec.describe Repository, type: :model do
     end
   end
 
+  describe '#make_friendly_id' do
+    subject(:friendly_id) { described_class.make_friendly_id(input) }
+
+    let(:input) { 'my repo' }
+
+    it 'creates a friendly_id' do
+      expect(friendly_id).to eq('my-repo')
+    end
+
+    it 'will take the requested friendly_id if it can' do
+      create(:repository, friendly_id: 'my-repo-1')
+      expect(friendly_id).to eq('my-repo')
+    end
+
+    it 'will append to the requested friendly_id if taken' do
+      create(:repository, friendly_id: 'my-repo')
+      expect(friendly_id).to eq('my-repo-1')
+    end
+
+    it 'will append to the requested friendly_id if taken with complexity' do
+      create(:repository, friendly_id: 'my-repo')
+      create(:repository, friendly_id: 'my-repo-1')
+      create(:repository, friendly_id: 'my-repo-1-1')
+      create(:repository, friendly_id: 'my-repo-3')
+      create(:repository, friendly_id: 'my-repo-99999')
+      expect(friendly_id).to eq('my-repo-100000')
+    end
+
+    it 'does not consider negative numbers in appends' do
+      create(:repository, friendly_id: 'my-repo')
+      create(:repository, friendly_id: 'my-repo--1')
+      expect(friendly_id).to eq('my-repo-1')
+    end
+
+    context 'id is not in english' do
+      let(:input) { 'モルモット' }
+
+      it 'allows characters from other languages' do
+        expect(friendly_id).to eq('モルモット')
+      end
+
+      it 'will append to non-english friendly_ids' do
+        create(:repository, friendly_id: 'モルモット')
+        expect(friendly_id).to eq('モルモット-1')
+      end
+    end
+
+    context 'numeric friendly_ids' do
+      let(:input) { '9999' }
+
+      it 'accepts a numeric id' do
+        expect(friendly_id).to eq('9999')
+      end
+
+      it 'does not append to a numeirc id' do
+        create(:repository, friendly_id: '9999')
+        expect(friendly_id).to eq('9999')
+      end
+
+      it 'does not append to a numeric id with complexity' do
+        create(:repository, friendly_id: '9999')
+        create(:repository, friendly_id: '9999-1')
+        create(:repository, friendly_id: '9999-1-1')
+        create(:repository, friendly_id: '9999-9999')
+        expect(friendly_id).to eq('9999')
+      end
+    end
+  end
+
   describe '#destroy' do
     context 'when it is an official repository' do
       subject { repository.destroy }


### PR DESCRIPTION
## Description

In the demo of the friendly_id feature, the MD5 of URLs was seen as not as user friendly. This is an attempt to use name instead.

## Change Type

*Please select the correct option.*

- [x] **New Feature** (a non-breaking change which adds new functionality)

## Checklist

*Please check off each item if the requirement is met.*

- [x] I have verified that my code follows RMT's coding standards with `rubocop`.
- [x] I have reviewed my own code and believe that it's ready for an external review.
- [x] I have provided comments for any hard-to-understand code.
- [x] I have documented the `MANUAL.md` file with any changes to the user experience.
- [x] RMT's test coverage remains at 100%.
- [x] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.
