### PR TITLE
Protect Against Changing SCC Repo URLs

### DIFF
--- a/app/services/repository_service.rb
+++ b/app/services/repository_service.rb
@@ -4,15 +4,23 @@ class RepositoryService
   end
 
   def create_repository!(product, url, attributes, custom: false)
-    repository = Repository.find_or_initialize_by(external_url: url)
+    repository = if custom
+                   Repository.find_or_initialize_by(external_url: url)
+                 else
+                   # Self Heal and guard against a custom repository with the same URL as the SCC repository
+                   # See the migration 20200916104804_make_scc_id_unique.rb for an instance where this is possible
+                   Repository.where(external_url: url).where.not(scc_id: attributes[:id]).update(scc_id: nil)
+                   Repository.only_custom.where(external_url: url).delete_all
+
+                   Repository.find_or_initialize_by(scc_id: attributes[:id])
+                 end
 
     repository.attributes = attributes.select do |k, _|
       repository.attributes.keys.member?(k.to_s) && k.to_s != 'id'
     end
 
     if custom
-      id_source = attributes[:id].to_s != '' ? attributes[:id] : attributes[:name]
-      repository.friendly_id ||= Repository.make_friendly_id(id_source)
+      repository.friendly_id ||= attributes[:id]
     else
       repository.scc_id = attributes[:id]
       repository.friendly_id = attributes[:id]

--- a/lib/rmt/cli/repos_custom.rb
+++ b/lib/rmt/cli/repos_custom.rb
@@ -14,7 +14,7 @@ $ rmt-cli repos custom add https://download.opensuse.org/repositories/Virtualiza
   def add(url, name)
     url += '/' unless url.end_with?('/')
     friendly_id = options.id
-    friendly_id ||= name.strip
+    friendly_id ||= Repository.make_friendly_id(name)
 
     if Repository.find_by(external_url: url)
       raise RMT::CLI::Error.new(_('A repository by the URL %{url} already exists.') % { url: url })

--- a/spec/services/repository_service_spec.rb
+++ b/spec/services/repository_service_spec.rb
@@ -4,10 +4,10 @@ describe RepositoryService do
   subject(:service) { described_class.new }
 
   let(:product) { create :product, :with_service }
-  let(:custom_repository) { create :repository, :custom }
-  let(:suse_repository) { create :repository }
 
   describe '#create_repository' do
+    subject(:repository) { service.create_repository!(product, url, attributes, custom: custom).reload }
+
     let(:attributes) do
       {
         name: 'foo',
@@ -15,28 +15,88 @@ describe RepositoryService do
         description: 'foo',
         autorefresh: true,
         enabled: false,
-        id: 50
+        id: id
       }
     end
+    let(:url) { 'http://foo.bar/repos' }
+    let(:custom) { false }
+    let(:id) { '50' }
 
-    context 'scc repositories' do
-      before do
-        service.create_repository!(product, 'http://foo.bar/repos', attributes)
+    shared_examples 'scc repositories' do
+      it('creates the repository') { expect(repository.name).to eq('foo') }
+
+      it('has the correct URL') { expect(repository.external_url).to eq(url) }
+
+      it('has the correct friendly_id') { expect(repository.friendly_id).to eq('50') }
+
+      it('has the correct scc_id') { expect(repository.friendly_id).to eq(id) }
+
+      it('is not custom') { expect(repository.custom?).to eq(false) }
+    end
+
+    it_behaves_like 'scc repositories'
+
+    context 'URLs of SCC repositories changes' do
+      subject(:repository) do
+        service.create_repository!(product, old_url, attributes, custom: custom)
+        expect(Repository.find_by(external_url: old_url)).not_to eq(nil)
+
+        service.create_repository!(product, url, attributes, custom: custom).reload
       end
 
-      it('creates the repository') { expect(Repository.find_by(external_url: 'http://foo.bar/repos').name).to eq('foo') }
+      let(:old_url) { 'https://foo.bar.com/bar/foo' }
 
-      it('has the correct friendly_id') { expect(Repository.find_by(external_url: 'http://foo.bar/repos').friendly_id).to eq('50') }
+      it_behaves_like 'scc repositories'
+
+      it('does not have a repository by the old URL') { expect(Repository.find_by(external_url: old_url)).to eq(nil) }
+    end
+
+    context 'self heals SCC repos' do
+      subject(:repository) do
+        service.create_repository!(product, url, attributes, custom: custom).update(scc_id: old_scc_id)
+        expect(Repository.find_by(scc_id: old_scc_id)).not_to eq(nil)
+
+        service.create_repository!(product, url, attributes, custom: custom).reload
+      end
+
+      let(:old_scc_id) { 666 }
+
+      it_behaves_like 'scc repositories'
+
+      it('does not have a repository by the old scc_id') { expect(Repository.find_by(scc_id: old_scc_id)).to eq(nil) }
+    end
+
+    context 'custom repo with same url' do
+      subject(:repository) do
+        service.create_repository!(product, url, attributes, custom: custom).update(scc_id: nil)
+        service.create_repository!(product, url, attributes, custom: custom).reload
+      end
+
+      it_behaves_like 'scc repositories'
     end
 
     context 'custom repositories' do
-      before do
-        service.create_repository!(nil, 'http://foo.bar/repos', attributes, custom: true)
+      let(:product) { nil }
+      let(:custom) { true }
+      let(:id) { 'foo-bar' }
+
+      it('creates the repository') { expect(repository.name).to eq('foo') }
+
+      it('has the correct URL') { expect(repository.external_url).to eq(url) }
+
+      it('has the correct friendly_id') { expect(repository.friendly_id).to eq('foo-bar') }
+
+      it('is not custom') { expect(repository.custom?).to eq(true) }
+
+      context 'already existing repositories with changing URL' do
+        subject(:repository) do
+          service.create_repository!(product, url, attributes, custom: custom).reload
+          url = 'https://foo.bar.com/bar/foo'
+          service.create_repository!(product, url, attributes, custom: custom).reload
+        end
+
+        it('raises error when the id is the same') { expect { repository }.to raise_error(/Duplicate entry/) }
       end
-
-      it('creates the repository') { expect(Repository.find_by(external_url: 'http://foo.bar/repos').name).to eq('foo') }
-
-      it('has the correct friendly_id') { expect(Repository.find_by(external_url: 'http://foo.bar/repos').friendly_id).to eq('50') }
     end
   end
 


### PR DESCRIPTION
## Description

If SCC repositories changed their URLs, RMT had issues. This is because we expect scc_id to be unique, and with a new URL, it tries to create a new repository with the same scc_id. Instead of finding by the URL for SCC repositories, we can find by scc_id instead and avoid this issue.

## Change Type

*Please select the correct option.*

- [x] **Bug Fix** (a non-breaking change which fixes an issue)

## Checklist

*Please check off each item if the requirement is met.*

- [x] I have verified that my code follows RMT's coding standards with `rubocop`.
- [x] I have reviewed my own code and believe that it's ready for an external review.
- [x] I have provided comments for any hard-to-understand code.
- [x] I have documented the `MANUAL.md` file with any changes to the user experience.
- [x] RMT's test coverage remains at 100%.
- [x] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.