### PR TITLE
Ignore specific request

### DIFF
--- a/package/files/nginx-pubcloud/nginx-https.conf
+++ b/package/files/nginx-pubcloud/nginx-https.conf
@@ -2,11 +2,22 @@ upstream rmt {
     server 127.0.0.1:4224;
 }
 
+# do not log HTTPS requests to services WITHOUT credentials
+map $uri $log_req {
+    ~/services/[0-9]+/repo/repoindex.xml 0;
+    default 1;
+}
+
+map $http_authorization $loggable {
+    "" "${log_req}";
+    default 1;
+}
+
 server {
     listen 443   ssl;
     server_name rmt;
 
-    access_log  /var/log/nginx/rmt_https_access.log;
+    access_log  /var/log/nginx/rmt_https_access.log combined if=$loggable;
     error_log   /var/log/nginx/rmt_https_error.log;
     root        /usr/share/rmt/public;
 


### PR DESCRIPTION
The way zypper queries generates unnecessary
401 errors in the logs.
In order to clear the noise, ignore the HTTPS
request without credentials.

## Description

Please describe your change and provide as much context as possible.

Fixes # (issue)

## Change Type

*Please select the correct option.*

- [ ] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [ ] I have verified that my code follows RMT's coding standards with `rubocop`.
- [ ] I have reviewed my own code and believe that it's ready for an external review.
- [ ] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] RMT's test coverage remains at 100%.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Other Notes

Please use this space to provide notes or thoughts to the team, such as tips on how to review/demo your changes.
