### PR TITLE
Show what it's "Deleting..." instead of what was "Deleted"

### DIFF
--- a/lib/rmt/cli/repos.rb
+++ b/lib/rmt/cli/repos.rb
@@ -49,12 +49,12 @@ class RMT::CLI::Repos < RMT::CLI::ReposBase
     print "\n"
     total_size = 0
     repos_to_delete.each do |repo|
+      puts _("Deleting locally mirrored files from repository '%{repo}'...") % { repo: repo.description }
       path = File.join(base_directory, repo.local_path)
       downloaded_files = DownloadedFile.where('local_path LIKE ?', "#{path}%")
       total_size += downloaded_files.sum(:file_size)
       FileUtils.rm_r(path, secure: true)
       downloaded_files.destroy_all
-      puts _("Deleted locally mirrored files from repository '%{repo}'.") % { repo: repo.description }
     end
 
     print "\n\e[32m"

--- a/spec/lib/rmt/cli/repos_spec.rb
+++ b/spec/lib/rmt/cli/repos_spec.rb
@@ -34,8 +34,8 @@ RMT found locally mirrored files from the following repositories which are not m
 \e[22m\s\sOnly 'yes' will be accepted.
 
   \e[1mEnter a value:\e[22m\s\s
-Deleted locally mirrored files from repository '#{repository_1.description}'.
-Deleted locally mirrored files from repository '#{repository_2.description}'.
+Deleting locally mirrored files from repository '#{repository_1.description}'...
+Deleting locally mirrored files from repository '#{repository_2.description}'...
 
 \e[32mClean finished. An estimated #{ActiveSupport::NumberHelper.number_to_human_size(total_removed_file_size)} were removed.\e[0m
       OUTPUT


### PR DESCRIPTION
When using the repos clean command it is a bit more helpful to output the currently running deletion like:
```
Deleting locally mirrored files from repository 'SLE-Module-Containers12-Pool for sle-12-x86_64'...
```

Especially when it takes longer because it's a large repo, it indicates that the process is still running.

Fixes #661