### PR TITLE
Replace outdated deeplink with link to SCC landing URL

### DIFF
--- a/lib/rmt/cli/base.rb
+++ b/lib/rmt/cli/base.rb
@@ -72,7 +72,7 @@ class RMT::CLI::Base < Thor
       raise RMT::CLI::Error.new(
         _("The SCC credentials are not configured correctly in '%{path}'. You can obtain them from %{url}") % {
           path: '/etc/rmt.conf',
-          url: 'https://scc.suse.com/organization'
+          url: 'https://scc.suse.com'
         },
         RMT::CLI::Error::ERROR_SCC
       )

--- a/spec/lib/rmt/cli/main_spec.rb
+++ b/spec/lib/rmt/cli/main_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe RMT::CLI::Main, :with_fakefs do
 
           it 'outputs custom error message' do
             expect { command }.to output(
-              "The SCC credentials are not configured correctly in '/etc/rmt.conf'. You can obtain them from https://scc.suse.com/organization\n"
+              "The SCC credentials are not configured correctly in '/etc/rmt.conf'. You can obtain them from https://scc.suse.com\n"
             ).to_stderr
           end
         end
@@ -123,7 +123,7 @@ RSpec.describe RMT::CLI::Main, :with_fakefs do
 
           it 'outputs custom error message' do
             expect { command }.to output(
-              "The SCC credentials are not configured correctly in '/etc/rmt.conf'. You can obtain them from https://scc.suse.com/organization\n"
+              "The SCC credentials are not configured correctly in '/etc/rmt.conf'. You can obtain them from https://scc.suse.com\n"
             ).to_stderr
           end
         end


### PR DESCRIPTION
The `/organization` route in SCC doesn't exist anymore.
Also we should avoid linking to specific routes as they might change.
Linking to just SCC should be enough to guide the user where the credentials can be found.

## Change Type

Trivial update of CLI output.

## Notes for reviewer

- Blank your `scc` credentials in your local config file.
- I think this change is trivial enough to not require a changelog update. Do you agree?