### PR TITLE
Fix test image issues

### DIFF
--- a/integration/Dockerfile.test
+++ b/integration/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM registry.scc.suse.de/suse/sles15:ga
+FROM registry.scc.suse.de/suse/sles15:15.2
 
 RUN useradd --no-log-init --create-home scc
 

--- a/integration/install.sh
+++ b/integration/install.sh
@@ -6,7 +6,7 @@ zypper --non-interactive ar http://download.opensuse.org/repositories/openSUSE:/
 zypper --non-interactive --gpg-auto-import-keys ref
 zypper --non-interactive up
 zypper --non-interactive in -t pattern devel_osc_build
-zypper --non-interactive install wget curl timezone \
+zypper --non-interactive install --no-recommends wget curl timezone \
   gcc-c++ libffi-devel git-core zlib-devel libxml2-devel libxslt-devel libmariadb-devel \
   mariadb-client mariadb ruby2.5-rubygem-bundler make build sudo ruby-devel nginx obs-service-format_spec_file
 SUSEConnect -d

--- a/integration/install.sh
+++ b/integration/install.sh
@@ -1,12 +1,12 @@
 #!/bin/sh -xe
 SUSEConnect -r $REGCODE
-SUSEConnect -p sle-module-desktop-applications/15/x86_64
-SUSEConnect -p sle-module-development-tools/15/x86_64 # this and above is needed for 'rpm-build' package
+SUSEConnect -p sle-module-desktop-applications/15.2/x86_64
+SUSEConnect -p sle-module-development-tools/15.2/x86_64 # this and above is needed for 'rpm-build' package
 zypper --non-interactive ar http://download.opensuse.org/repositories/openSUSE:/Tools/SLE_15/openSUSE:Tools.repo
 zypper --non-interactive --gpg-auto-import-keys ref
 zypper --non-interactive up
 zypper --non-interactive in -t pattern devel_osc_build
-zypper --non-interactive install --no-recommend wget curl timezone \
+zypper --non-interactive install wget curl timezone \
   gcc-c++ libffi-devel git-core zlib-devel libxml2-devel libxslt-devel libmariadb-devel \
   mariadb-client mariadb ruby2.5-rubygem-bundler make build sudo ruby-devel nginx obs-service-format_spec_file
 SUSEConnect -d


### PR DESCRIPTION
## Description

Since December 2020, SLES15 GA images have been discontinued. The test pipeline uses these images and pipelines have been broken. This PR updates the integration test image.

Related Card: https://trello.com/c/0ZhhKlKD/1803-rmt-update-docker-image-for-integration-tests

## Change Type

*Please select the correct option.*

- [x] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [x] I have verified that my code follows RMT's coding standards with `rubocop`.
- [x] I have reviewed my own code and believe that it's ready for an external review.
- [x] I have provided comments for any hard-to-understand code.
- [x] I have documented the `MANUAL.md` file with any changes to the user experience.
- [x] RMT's test coverage remains at 100%.
- [x] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Other Notes

Please use this space to provide notes or thoughts to the team, such as tips on how to review/demo your changes.
