### PR TITLE
Enforce packing Rubygems in platform agnostic way

### DIFF
--- a/.bundle/config_packaging
+++ b/.bundle/config_packaging
@@ -5,3 +5,4 @@ BUNDLE_PATH: "vendor/bundle/"
 BUNDLE_DISABLE_SHARED_GEMS: "true"
 BUNDLE_BUILD__NOKOGIRI: "--use-system-libraries"
 BUNDLE_JOBS: 4
+BUNDLE_FORCE_RUBY_PLATFORM: "true"

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 #   git config --global core.excludesfile '~/.gitignore_global'
 
 # Ignore bundler config.
-/.bundle
+/.bundle/config
 
 # Ignore the default SQLite database.
 /db/*.sqlite3

--- a/package/obs/rmt-server.spec
+++ b/package/obs/rmt-server.spec
@@ -217,7 +217,6 @@ find %{buildroot}%{lib_dir}/vendor/bundle/ruby/*/gems/yard*/ -type f -exec chmod
 # drop custom rpath from native gems
 chrpath -d %{buildroot}%{lib_dir}/vendor/bundle/ruby/*/gems/mysql2-*/lib/mysql2/mysql2.so
 chrpath -d %{buildroot}%{lib_dir}/vendor/bundle/ruby/*/extensions/*/*/mysql2-*/mysql2/mysql2.so
-chrpath -d %{buildroot}%{lib_dir}/vendor/bundle/ruby/2.5.0/gems/nokogiri-*/lib/nokogiri/*/nokogiri.so
 
 %files
 %attr(-,%{rmt_user},%{rmt_group}) %{app_dir}


### PR DESCRIPTION
The latest Nokogiri which includes native binaries broke the build on non-x86 platforms.