### PR TITLE
Raise an exception when there is an extension activated which has no migration successor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,10 +42,10 @@ group :development, :test do
   gem 'danger'
   gem 'danger-rubocop'
   gem 'strong_migrations'
+  gem 'awesome_print'
 end
 
 group :development do
-  gem 'awesome_print'
   gem 'listen', '>= 3.0.5', '<= 3.2.1'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'

--- a/app/models/migration_engine.rb
+++ b/app/models/migration_engine.rb
@@ -55,7 +55,13 @@ class MigrationEngine
     migrations = add_python2_module(migrations)
     migrations = yield(migrations) if block_given?
     # NB: It's possible to migrate to any product that's available on RMT, entitlement checks not needed.
-
+    extensions_without_successor = (@system.products - [base_product]).select { |p| p.successors.empty? }
+    if migrations.empty? && extensions_without_successor.present?
+      raise MigrationEngineError.new(
+        N_("There are activated extensions/modules on this system which cannot be migrated. De-activate them first, and then try migrating again. \n" \
+              "The product(s) are '%s'."), extensions_without_successor.map(&:friendly_name).join(', ')
+)
+    end
     # Offering the most recent products first
     sort_migrations(migrations)
   end

--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -4,6 +4,8 @@ Tue Mar 16 19:53:15 UTC 2021 - Ivan Kapelyukhin <ikapelyukhin@suse.com>
 - Version 2.6.7
 - Clean out `subscriptions` table only if replacement data is already
   available (bsc#1183615)
+- Raise an error when there is an extension activated which has no
+  migration successor (like LTSS)
 
 -------------------------------------------------------------------
 Tue Mar 16 08:20:24 UTC 2021 - Jens Mammen <jmammen@suse.com>

--- a/spec/models/migration_engine_spec.rb
+++ b/spec/models/migration_engine_spec.rb
@@ -14,7 +14,7 @@ describe MigrationEngine do
     subject(:migrations) { engine.generate }
 
     let(:sle12sub) { create(:subscription, product_classes: [sle12.product_class]) }
-    let(:system) { FactoryBot.create(:system, :with_activated_base_product) }
+    let(:system) { FactoryBot.create(:system) }
     let!(:activation) { create :activation, system: system, service: sle12.service }
 
     context 'error handling' do
@@ -59,7 +59,7 @@ describe MigrationEngine do
     context 'with no upgradeable products' do
       let!(:slepos) { create(:product, :with_mirrored_repositories, name: 'SLEPOS') }
       let!(:slepossub) { create(:subscription, product_classes: [slepos.product_class]) }
-      let!(:system) { FactoryBot.create(:system, :with_activated_base_product) }
+      let!(:system) { FactoryBot.create(:system) }
       let!(:activation) { create :activation, system: system, service: slepos.service }
       let(:installed_products) { [slepos] }
 
@@ -274,15 +274,15 @@ describe MigrationEngine do
       end
 
       context 'when not all products are upgradeable' do
-        let(:slewe12) do
-          create(
-            :product, :with_mirrored_repositories, :activated,
-            system: system, base_products: [sle12], name: 'slewe12', product_type: 'extension'
-          )
-        end
-        let(:installed_products) { [sle12, slewe12] }
+        let(:sle12ltss) { create :product, :extension, :with_repositories, :activated, system: system, base_products: [sle12], name: 'sle12ltss' }
+        let(:installed_products) { [sle12, sle12ltss] }
 
-        it { is_expected.to be_empty }
+        it 'raises error with help message' do
+          expect { migrations }.to raise_error do |error|
+            expect(error).to be_a(MigrationEngine::MigrationEngineError)
+            expect(error.data).to eq(sle12ltss.friendly_name)
+          end
+        end
       end
 
       context 'with base plus free extension of beta class' do


### PR DESCRIPTION
## Description

This makes https://github.com/SUSE/happy-customer/pull/5256 available for RMT.


## Change Type

*Please select the correct option.*

- [ ] **Bug Fix** (a non-breaking change which fixes an issue)
- [x] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [ ] I have verified that my code follows RMT's coding standards with `rubocop`.
- [ ] I have reviewed my own code and believe that it's ready for an external review.
- [ ] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] RMT's test coverage remains at 100%.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Other Notes

Please use this space to provide notes or thoughts to the team, such as tips on how to review/demo your changes.