### PR TITLE
Add check for numeric ids to not convert strings into numbers

### DIFF
--- a/lib/rmt.rb
+++ b/lib/rmt.rb
@@ -1,5 +1,5 @@
 module RMT
-  VERSION ||= '2.6.7'.freeze
+  VERSION ||= '2.6.8'.freeze
 
   DEFAULT_USER = '_rmt'.freeze
   DEFAULT_GROUP = 'nginx'.freeze

--- a/lib/rmt/cli/repos_base.rb
+++ b/lib/rmt/cli/repos_base.rb
@@ -38,8 +38,18 @@ class RMT::CLI::ReposBase < RMT::CLI::Base
     puts set_enabled ? _('Repository by ID %{id} successfully enabled.') % { id: id } : _('Repository by ID %{id} successfully disabled.') % { id: id }
   end
 
+  def is_numeric_id?(str)
+    # Check if given string is a plain number without any additional characters
+    # like '15sp3-ptf-repo-id'.
+    !!Integer(str) rescue false
+  end
+
   def find_repository!(id, custom: false)
-    repository = Repository.find_by(id: id) if custom # allow fallback for old IDs when dealing with custom repos
+    # allow fallback for old IDs when dealing with custom repos
+    if is_numeric_id?(id) && custom
+      repository = Repository.find_by(id: id)
+    end
+
     repository ||= Repository.find_by(friendly_id: id)
 
     if repository.nil? || (custom && !repository.custom?)

--- a/lib/rmt/cli/repos_base.rb
+++ b/lib/rmt/cli/repos_base.rb
@@ -41,7 +41,7 @@ class RMT::CLI::ReposBase < RMT::CLI::Base
   def is_numeric_id?(str)
     # Check if given string is a plain number without any additional characters
     # like '15sp3-ptf-repo-id'.
-    !!Integer(str) rescue false
+    Integer(str) rescue false
   end
 
   def find_repository!(id, custom: false)

--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -1,3 +1,8 @@
+Mon Mar 29 10:51:13 UTC 2021 - Felix Schnizlein <fschnizlein@suse.com>
+
+- Version 2.6.8
+- Fixing wrong handling of ids starting with numeric characters (bsc#1182736)
+
 -------------------------------------------------------------------
 Tue Mar 16 19:53:15 UTC 2021 - Ivan Kapelyukhin <ikapelyukhin@suse.com>
 

--- a/package/obs/rmt-server.spec
+++ b/package/obs/rmt-server.spec
@@ -29,7 +29,7 @@
 %define ruby_version          %{rb_default_ruby_suffix}
 
 Name:           rmt-server
-Version:        2.6.7
+Version:        2.6.8
 Release:        0
 Summary:        Repository mirroring tool and registration proxy for SCC
 License:        GPL-2.0-or-later

--- a/spec/lib/rmt/cli/repos_custom_spec.rb
+++ b/spec/lib/rmt/cli/repos_custom_spec.rb
@@ -371,6 +371,21 @@ Repository by ID #{repository.friendly_id} successfully disabled.
           expect(Repository.find_by(id: custom_repository.id)).to be_nil
         end
       end
+
+      context 'custom repository with id starting with numbers' do
+        let(:friendly_id) { "#{suse_repository.id}-repo-name" }
+        let(:custom) { create :repository, :custom, friendly_id: friendly_id }
+
+        let(:argv) { [command, custom.friendly_id] }
+
+        before do
+          expect { described_class.start(argv) }.to output("Removed custom repository by ID #{friendly_id}.\n").to_stdout
+        end
+
+        it 'deletes custom repository' do
+          expect(Repository.find_by(friendly_id: friendly_id)).to be_nil
+        end
+      end
     end
 
     it_behaves_like 'rmt-cli custom repos remove', 'remove'


### PR DESCRIPTION
## Description

card: https://trello.com/c/ReYjExvX/1866-rmt-fix-management-of-custom-repositories
bug: https://bugzilla.suse.com/show_bug.cgi?id=1182736

This is a bug occuring if the first characters of an ID are numbers e.g `15ptf-repo`. In `ActiveRecord` the `find_by` searches for the numeric id and strings automatically translated to an integer and trailing characters get truncated. This results in odd behaviour.

* How to test the change:

```
1) bin/rmt-cli repos custom add "https://download.opensuse.org/repositories/server:/http/SLE_15/" 15sp1-basesystem-ptf
2) bin/rmt-cli repos custom list
3) bin/rmt-cli repos custom remove 15sp1-basesystem-ptf
4) bin/rmt-cli repos custom list
```

❤️ Thank you! ❤️