### PR TITLE
Improve migration error message with uninstall command

### DIFF
--- a/app/models/migration_engine.rb
+++ b/app/models/migration_engine.rb
@@ -55,13 +55,6 @@ class MigrationEngine
     migrations = add_python2_module(migrations)
     migrations = yield(migrations) if block_given?
     # NB: It's possible to migrate to any product that's available on RMT, entitlement checks not needed.
-    extensions_without_successor = (@system.products - [base_product]).select { |p| p.successors.empty? }
-    if migrations.empty? && extensions_without_successor.present?
-      raise MigrationEngineError.new(
-        N_("There are activated extensions/modules on this system which cannot be migrated. De-activate them first, and then try migrating again. \n" \
-              "The product(s) are '%s'."), extensions_without_successor.map(&:friendly_name).join(', ')
-)
-    end
     # Offering the most recent products first
     sort_migrations(migrations)
   end
@@ -80,7 +73,7 @@ class MigrationEngine
   def migration_targets(migration_kind: :online)
     migration_path_scope = (migration_kind == :online) ? ProductPredecessorAssociation.online : ProductPredecessorAssociation.all
     installed_extensions = @installed_products.reject { |product| product == base_product }
-    base_successors = base_product.successors.merge(migration_path_scope).to_a
+    base_successors = base_successors(migration_path_scope)
     base_successors.push(base_product) if migration_kind == :online
     combinations = []
     # adding all valid combinations of extension successors to the base successors
@@ -93,7 +86,23 @@ class MigrationEngine
       combinations += [base].product(*extensions_successors)
     end
     combinations.delete([base_product] + installed_extensions)
+
+    if base_successors(migration_path_scope).present? && combinations.empty?
+      extensions_without_successor = installed_extensions.select { |ext| ext.successors.empty? }
+      uninstall_command = extensions_without_successor.map { |p| "SUSEConnect -d -p #{p.identifier}/#{p.version}/#{p.arch}" }.join('\n ')
+      raise MigrationEngineError.new(
+        N_("There are activated extensions/modules on this system which cannot be migrated. \n" \
+           "De-activate them first, and then try migrating again. \n" \
+           "The product(s) are '%s'. \n" \
+           "You can de-activate them with: \n%s"), [extensions_without_successor.map(&:friendly_name).join(', '), uninstall_command]
+         )
+    end
+
     combinations
+  end
+
+  def base_successors(migration_path_scope)
+    base_product.successors.merge(migration_path_scope).to_a
   end
 
   # automatically add modules that are flagged as `migration_extra` or `recommended`

--- a/spec/models/migration_engine_spec.rb
+++ b/spec/models/migration_engine_spec.rb
@@ -280,7 +280,7 @@ describe MigrationEngine do
         it 'raises error with help message' do
           expect { migrations }.to raise_error do |error|
             expect(error).to be_a(MigrationEngine::MigrationEngineError)
-            expect(error.data).to eq(sle12ltss.friendly_name)
+            expect(error.data).to include(sle12ltss.friendly_name)
           end
         end
       end

--- a/spec/models/migration_engine_spec.rb
+++ b/spec/models/migration_engine_spec.rb
@@ -280,7 +280,7 @@ describe MigrationEngine do
         it 'raises error with help message' do
           expect { migrations }.to raise_error do |error|
             expect(error).to be_a(MigrationEngine::MigrationEngineError)
-            expect(error.data).to include(sle12ltss.friendly_name)
+            expect(error.message).to match(%r{There are activated extensions/modules on this system which cannot be migrated})
           end
         end
       end

--- a/spec/requests/api/connect/v3/systems/products_controller_spec.rb
+++ b/spec/requests/api/connect/v3/systems/products_controller_spec.rb
@@ -474,7 +474,7 @@ RSpec.describe Api::Connect::V3::Systems::ProductsController do
           end
         end
 
-        context 'when not all products are upgradeable' do
+        context 'when not all extensions are upgradeable' do
           let(:first_product) { FactoryBot.create(:product, :with_mirrored_repositories, :activated, system: system, product_type: 'base') }
           let(:module_without_successor) { FactoryBot.create(:product, :with_mirrored_repositories, :activated, system: system, product_type: 'module') }
           let(:second_product) do


### PR DESCRIPTION
## Description

Improve migration error message with uninstall command, 
only raise error when extensions have no successor. 
A base without successor is expected, ie. latest product like SLES 15 SP3.

Fixes https://trello.com/c/r6zomyoz/1652-raise-error-message-in-migration-when-there-is-no-successor

## Change Type

*Please select the correct option.*

- [x **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [ ] I have verified that my code follows RMT's coding standards with `rubocop`.
- [ ] I have reviewed my own code and believe that it's ready for an external review.
- [ ] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] RMT's test coverage remains at 100%.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Other Notes

Please use this space to provide notes or thoughts to the team, such as tips on how to review/demo your changes.