### PR TITLE
Fix appended slash when query is present in custom repo url

### DIFF
--- a/lib/rmt/cli/repos_custom.rb
+++ b/lib/rmt/cli/repos_custom.rb
@@ -12,7 +12,7 @@ $ rmt-cli repos custom add https://download.opensuse.org/repositories/Virtualiza
 $ rmt-cli repos custom add https://download.opensuse.org/repositories/Virtualization:/containers/SLE_12_SP3/ Virtualization:Containers --id containers_sle_12_sp3`
   REPOS
   def add(url, name)
-    url += '/' unless url.end_with?('/')
+    url += '/' unless URI(url).query.present? || url.end_with?('/')
     friendly_id = options.id
     friendly_id ||= Repository.make_friendly_id(name)
 

--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -2,6 +2,7 @@
 Thu Apr 22 11:10:11 UTC 2021 - Jesús Bermúdez Velázquez <jesus.bv@suse.com>
 
 - Version 2.6.9
+- Fix: Don't append slash to custom repository urls 
 - Add enabled attribute to syncing process
   This fixes wrong marked repositories when syncing
   This references bsc#1184814

--- a/spec/lib/rmt/cli/repos_custom_spec.rb
+++ b/spec/lib/rmt/cli/repos_custom_spec.rb
@@ -138,6 +138,19 @@ describe RMT::CLI::ReposCustom do
         expect(Repository.find_by(external_url: external_url).name).to eq('foobar')
       end
     end
+
+    context 'URL with token' do
+      let(:external_url) { 'http://example.com/repo?token' }
+      let(:argv) { ['add', external_url, 'foo'] }
+
+      it 'does not add trailing slash when query is given' do
+        expect do
+          described_class.start(argv)
+        end.to output("Successfully added custom repository.\n").to_stdout.and output('').to_stderr
+
+        expect(Repository.last.external_url.ends_with?('/')).to be_falsy
+      end
+    end
   end
 
   describe '#list' do


### PR DESCRIPTION
## Description

Please describe your change and provide as much context as possible.

Fixes slash at the end of custom repo urls.


## How to test
1. Add a custom repo with url query like `bin/rmt-cli repos custom add http://example.com?token`
2. List the custom repos with `bin/rmt-cli repos custom list`. The url should have the token without a trailing slash.

## Change Type

*Please select the correct option.*

- [x] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [x] I have verified that my code follows RMT's coding standards with `rubocop`.
- [x] I have reviewed my own code and believe that it's ready for an external review.
- [x] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [x] RMT's test coverage remains at 100%.
- [x] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Other Notes

Please use this space to provide notes or thoughts to the team, such as tips on how to review/demo your changes.
