### PR TITLE
Dropping the Gemfile.lock 'BUNDLED WITH' line during build

### DIFF
--- a/package/obs/rmt-server.spec
+++ b/package/obs/rmt-server.spec
@@ -192,7 +192,11 @@ grep -rl '\/usr\/bin\/env ruby' %{buildroot}%{lib_dir}/vendor/bundle/ruby | xarg
     sed -i -e 's@\/usr\/bin\/env ruby.%{ruby_version}@\/usr\/bin\/ruby\.%{ruby_version}@g' \
     -e 's@\/usr\/bin\/env ruby@\/usr\/bin\/ruby\.%{ruby_version}@g'
 grep -rl '\/usr\/bin\/env bash' %{buildroot}%{lib_dir}/vendor/bundle/ruby | xargs \
-    sed -i -e 's@\/usr\/bin\/env bash@\/bin\/bash@g' \
+    sed -i -e 's@\/usr\/bin\/env bash@\/bin\/bash@g'
+
+# Drop 'BUNDLED WITH' line from Gemfile.lock. It causes trouble when the Gemfile.lock
+# was created with a different major version than the distribution's bundler.
+sed -i '/BUNDLED WITH/{N;d;}' %{buildroot}%{app_dir}/Gemfile.lock
 
 # cleanup unneeded files
 find %{buildroot}%{lib_dir} "(" -name "*.c" -o -name "*.h" -o -name .keep ")" -delete


### PR DESCRIPTION
## Description

Dropping the Gemfile.lock 'BUNDLED WITH' line during build.
This caused issues when the distribution already has Bundler >=2 and 
the Gemfile.lock was created with Bundler 1.x

## Change Type

*Please select the correct option.*

- [x] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [ ] I have verified that my code follows RMT's coding standards with `rubocop`.
- [ ] I have reviewed my own code and believe that it's ready for an external review.
- [ ] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] RMT's test coverage remains at 100%.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Other Notes

Please use this space to provide notes or thoughts to the team, such as tips on how to review/demo your changes.