### PR TITLE
Store auth tokens for custom repos

### DIFF
--- a/lib/rmt/cli/repos_custom.rb
+++ b/lib/rmt/cli/repos_custom.rb
@@ -10,9 +10,12 @@ class RMT::CLI::ReposCustom < RMT::CLI::ReposBase
 $ rmt-cli repos custom add https://download.opensuse.org/repositories/Virtualization:/containers/SLE_12_SP3/ Virtualization:Containers
 
 $ rmt-cli repos custom add https://download.opensuse.org/repositories/Virtualization:/containers/SLE_12_SP3/ Virtualization:Containers --id containers_sle_12_sp3`
+
+$ rmt-cli repos custom add https://download.example.com?some_auth_token
   REPOS
   def add(url, name)
-    url += '/' unless URI(url).query.present? || url.end_with?('/')
+    url, query = url.split('?')
+    url += '/' unless query.present? || url.end_with?('/')
     friendly_id = options.id
     friendly_id ||= Repository.make_friendly_id(name)
 
@@ -36,6 +39,7 @@ $ rmt-cli repos custom add https://download.opensuse.org/repositories/Virtualiza
       name: name.strip,
       mirroring_enabled: true,
       autorefresh: true,
+      auth_token: query,
       enabled: 0,
       id: friendly_id
     }, custom: true)

--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -1,8 +1,9 @@
 -------------------------------------------------------------------
 Thu Apr 22 11:10:11 UTC 2021 - Jesús Bermúdez Velázquez <jesus.bv@suse.com>
 
-- Version 2.6.9
-- Fix: Don't append slash to custom repository urls 
+- Version 2.6.
+- Fix: Store authorization tokens when adding custom repositories
+- Fix: Don't append slash to custom repository urls
 - Add enabled attribute to syncing process
   This fixes wrong marked repositories when syncing
   This references bsc#1184814

--- a/spec/lib/rmt/cli/repos_custom_spec.rb
+++ b/spec/lib/rmt/cli/repos_custom_spec.rb
@@ -150,6 +150,14 @@ describe RMT::CLI::ReposCustom do
 
         expect(Repository.last.external_url.ends_with?('/')).to be_falsy
       end
+
+      it 'stores the query parameter as an auth token' do
+        expect do
+          described_class.start(argv)
+        end.to output("Successfully added custom repository.\n").to_stdout.and output('').to_stderr
+        expect(Repository.last.auth_token.present?).to be_truthy
+        expect(Repository.last.external_url).not_to include('?')
+      end
     end
   end
 


### PR DESCRIPTION
## Description

Authorization tokens for custom repositories are not stored which causes failures when mirroring.

## Testing steps

### Prerequisite
Update `config/rmt.config.yml` with mirroring credentials for A127499.

### Steps

```bash
bin/rmt-cli sync
bin/rmt-cli products enable 1357 # SLES 12 sp2 LTSS
# Add the repository with a valid token
bin/rmt-cli repos custom add https://updates.suse.com/SUSE/Updates/SLE-SERVER/12-SP2-LTSS-ERICSSON/x86_64/update/?<token>
bin/rmt-cli repos custom attach ptf_12sp2_ltss 1357
bin/rmt-cli mirror repository ptf_12sp2_ltss
```

The mirror should work without any errors


Extends fixes for https://bugzilla.suse.com/show_bug.cgi?id=1185005

## Change Type

*Please select the correct option.*

- [x] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [x] I have verified that my code follows RMT's coding standards with `rubocop`.
- [x] I have reviewed my own code and believe that it's ready for an external review.
- [x] I have provided comments for any hard-to-understand code.
- [x] I have documented the `MANUAL.md` file with any changes to the user experience.
- [x] RMT's test coverage remains at 100%.
- [x] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Other Notes

Please use this space to provide notes or thoughts to the team, such as tips on how to review/demo your changes.
