### PR TITLE
Fix rails 6.1 autoloading

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,3 +1,4 @@
+require_relative '../../lib/rmt/logger'
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 


### PR DESCRIPTION
## Description

This PR fixes Rails 6.1 autoloading which is breaking rmt server startup. Here's a [PR on the rails repo](https://github.com/rails/rails/issues/40904)

## How to test
1. Run the production server with `bundle exec rails s -e production`

Server should start with no issues.

## Change Type

*Please select the correct option.*

- [x] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [x] I have verified that my code follows RMT's coding standards with `rubocop`.
- [x] I have reviewed my own code and believe that it's ready for an external review.
- [x] I have provided comments for any hard-to-understand code.
- [x] I have documented the `MANUAL.md` file with any changes to the user experience.
- [x] RMT's test coverage remains at 100%.
- [x] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Other Notes

Please use this space to provide notes or thoughts to the team, such as tips on how to review/demo your changes.
