### PR TITLE
Disable danger on forks

### DIFF
--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -66,6 +66,7 @@ jobs:
       # Danger does some weird things to the output,
       # that's why we run it last
       - name: Run Danger
+        if: ${{ github.event.pull_request.head.repo.full_name == 'SUSE/rmt' }}
         uses: MeilCli/danger-action@v5
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
## Description

`Danger` doesn't use the repo github token when a PR is opened from a fork. This will temporarily disable checks for `Danger`.

## Change Type

*Please select the correct option.*

- [x] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [x] I have verified that my code follows RMT's coding standards with `rubocop`.
- [x] I have reviewed my own code and believe that it's ready for an external review.
- [ ] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [x] RMT's test coverage remains at 100%.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Other Notes

Please use this space to provide notes or thoughts to the team, such as tips on how to review/demo your changes.
