### PR TITLE
Handle special characters in package names (bsc#1189805)

### DIFF
--- a/lib/rmt/mirror/file_reference.rb
+++ b/lib/rmt/mirror/file_reference.rb
@@ -23,7 +23,7 @@ class RMT::Mirror::FileReference
     @cache_path = (cache_dir ? File.join(cache_dir, relative_path) : nil)
     @local_path = File.join(base_dir, relative_path.gsub(/\.\./, '__'))
 
-    # INFO: Encode the filename of the URI to make RMT handle not URI RFC3986 complaint filenames. (e.g. containing special characters)
+    # INFO: Encode the filename of the URI to make RMT handle RFC3986-incompliant filenames (e.g. containing special characters)
     encoded_filename = ERB::Util.url_encode(File.basename(relative_path))
     relative_path = File.join(File.dirname(relative_path), encoded_filename)
 

--- a/lib/rmt/mirror/file_reference.rb
+++ b/lib/rmt/mirror/file_reference.rb
@@ -22,6 +22,11 @@ class RMT::Mirror::FileReference
   def initialize(relative_path:, base_dir:, base_url:, cache_dir: nil)
     @cache_path = (cache_dir ? File.join(cache_dir, relative_path) : nil)
     @local_path = File.join(base_dir, relative_path.gsub(/\.\./, '__'))
+
+    # INFO: Encode the filename of the URI to make RMT handle not URI RFC3986 complaint filenames. (e.g. containing special characters)
+    encoded_filename = ERB::Util.url_encode(File.basename(relative_path))
+    relative_path = File.join(File.dirname(relative_path), encoded_filename)
+
     @remote_path = URI.join(base_url, relative_path)
   end
 

--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -3,6 +3,7 @@ Thu Aug 19 10:12:03 UTC 2021 - Felix Schnizlein <fschnizlein@suse.com>
 
 - Version 2.6.12
 - Fix broken rpm package because of a bug in fix for (bsc#1188043)
+- Handle special characters in package names (bsc#1189805)
 
 -------------------------------------------------------------------
 Tue Jun 29 12:41:54 UTC 2021 - Felix Schnizlein <fschnizlein@suse.com>

--- a/spec/lib/rmt/mirror/file_reference_spec.rb
+++ b/spec/lib/rmt/mirror/file_reference_spec.rb
@@ -100,6 +100,14 @@ RSpec.describe RMT::Mirror::FileReference do
     it 'returns the absolute remote path' do
       expect(file_reference.remote_path.to_s).to eq('https://www.repourl.com/dummy_dir/dummy_file.ext')
     end
+
+    context 'URL with special characters' do
+      let(:relative_path) { 'Packages/t/the_silver_searcher-2.2.0^2020704.5a1c8d8-1.el8.x86_64.rpm' }
+
+      it 'returns an encoded remote path' do
+        expect(file_reference.remote_path.to_s).to eq("#{base_url}/Packages/t/the_silver_searcher-2.2.0%5E2020704.5a1c8d8-1.el8.x86_64.rpm")
+      end
+    end
   end
 
   describe 'build_from_metadata' do


### PR DESCRIPTION
## Description

card: https://trello.com/c/L5XhKiBw/2089-rmt-l3-mirroring-packages-with-special-characters-in-the-url-fails
bug: https://bugzilla.suse.com/show_bug.cgi?id=1189805

RMT does not handle non URI RFC3986 characters in package names correctly. By adding URI encoding to the package name RMT is able to handle complex package names as well.

## Change Type

*Please select the correct option.*

- [x] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [x] I have verified that my code follows RMT's coding standards with `rubocop`.
- [x] I have reviewed my own code and believe that it's ready for an external review.
- [x] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [x] RMT's test coverage remains at 100%.
- [x] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## How to test

You need a running development setup of RMT and some disk space to run a mirror on the epel repository.

```
# First get the broken behaviour to see things get fixed:
$ git checkout master
$ bin/rmt-cli repos custom add "http://mirrors.kernel.org/fedora-epel/8/Everything/x86_64/" epel-8-everything

$ bin/rmt-cli mirror repository epel-8-everything
# This command fails mirroring 'the_silver_searcher' package.

# Switch to the fix
$ git checkout handle-special-characters
$ bin/rmt-cli mirror repository epel-8-everything
# Now the command should work mirroring the package