### PR TITLE
api: try to also pass the host login information to glue

### DIFF
--- a/bin/rmt-cli
+++ b/bin/rmt-cli
@@ -20,6 +20,10 @@ require_relative '../engines/registration_sharing/lib/registration_sharing' if S
 relative_load_paths = %w[lib lib/rmt app/models app/services app/validators].map { |dir| File.join(rmt_path, dir) }
 ActiveSupport::Dependencies.autoload_paths += relative_load_paths
 
+# Before moving into the default user/group, let's try to fetch the login
+# information for this host.
+RMT::Config.set_host_system!
+
 if RMT::CLI::Base.process_user_name == 'root'
   # set group and then user, otherwise user cannot change group
   Process::Sys.setegid(Etc.getgrnam(RMT::DEFAULT_GROUP).gid)
@@ -32,6 +36,11 @@ if File.exist?(RMT::DEFAULT_MIRROR_DIR) && !File.writable?(RMT::DEFAULT_MIRROR_D
   warn "Mirroring base directory (#{RMT::DEFAULT_MIRROR_DIR}) is not writable by user '#{RMT::CLI::Base.process_user_name}'"
   warn 'Run as root or adjust the permissions.'
   exit RMT::CLI::Error::ERROR_OTHER
+end
+
+if Settings.try(:host_system).blank? && File.exist?(RMT::CREDENTIALS_FILE_LOCATION) && !File.readable?(RMT::CREDENTIALS_FILE_LOCATION)
+  warn "Credentials file (#{RMT::CREDENTIALS_FILE_LOCATION}) is not readable by user '#{RMT::CLI::Base.process_user_name}'"
+  warn "Run as root or adjust the permissions."
 end
 
 db_config = RMT::Config.db_config

--- a/lib/rmt.rb
+++ b/lib/rmt.rb
@@ -5,4 +5,5 @@ module RMT
   DEFAULT_GROUP = 'nginx'.freeze
   DEFAULT_MIRROR_DIR = File.expand_path(File.join(__dir__, '../public/repo/')).freeze
   DEFAULT_MIRROR_URL_PREFIX = '/repo/'.freeze
+  CREDENTIALS_FILE_LOCATION = '/etc/zypp/credentials.d/SCCcredentials'.freeze
 end

--- a/lib/rmt/config.rb
+++ b/lib/rmt/config.rb
@@ -50,7 +50,23 @@ module RMT::Config
       )
     end
 
+    def set_host_system!
+      Settings[:host_system] = host_system
+    end
+
     private
+
+    def host_system
+      return '' if !File.exist?(RMT::CREDENTIALS_FILE_LOCATION) ||
+                   !File.readable?(RMT::CREDENTIALS_FILE_LOCATION)
+
+      File.foreach(RMT::CREDENTIALS_FILE_LOCATION) do |line|
+        m = line.match(/username=(.+)/)
+        return m[1] if m
+      end
+
+      ''
+    end
 
     def validate_int(value)
       converted_value = Integer(value) rescue nil

--- a/lib/suse/connect/api.rb
+++ b/lib/suse/connect/api.rb
@@ -102,6 +102,7 @@ module SUSE
         options[:accept_encoding] = 'gzip, deflate'
         options[:headers] = {
           'RMT' => system_uuid.strip,
+          'HOST-SYSTEM' => host_system.to_s.strip,
           'Accept' => 'application/vnd.scc.suse.com.v4+json',
           'Content-Type' => 'application/json'
         }
@@ -138,6 +139,10 @@ module SUSE
       end
 
       private
+
+      def host_system
+        Settings.try(:host_system) || ''
+      end
 
       def system_uuid
         @system_uuid ||= if File.exist?(UUID_FILE_LOCATION) && !File.empty?(UUID_FILE_LOCATION)

--- a/spec/lib/rmt/config_spec.rb
+++ b/spec/lib/rmt/config_spec.rb
@@ -135,4 +135,37 @@ RSpec.describe RMT::Config do
       }
     end
   end
+
+  describe '#host_system' do
+    subject(:method_call) { described_class.send(:host_system) }
+
+    it 'returns an empty string when the credentials file does not exist' do
+      allow(File).to receive(:exist?).with(RMT::CREDENTIALS_FILE_LOCATION).and_return(false)
+
+      expect(method_call).to be_empty
+    end
+
+    it 'returns an empty string when the credentials file is not readable' do
+      allow(File).to receive(:exist?).with(RMT::CREDENTIALS_FILE_LOCATION).and_return(true)
+      allow(File).to receive(:readable?).with(RMT::CREDENTIALS_FILE_LOCATION).and_return(false)
+
+      expect(method_call).to be_empty
+    end
+
+    it 'returns the proper string when the credentials file is readable and the contents are as expected' do
+      allow(File).to receive(:exist?).with(RMT::CREDENTIALS_FILE_LOCATION).and_return(true)
+      allow(File).to receive(:readable?).with(RMT::CREDENTIALS_FILE_LOCATION).and_return(true)
+      allow(File).to receive(:foreach).with(RMT::CREDENTIALS_FILE_LOCATION).and_yield('username=12341234')
+
+      expect(method_call).to eq('12341234')
+    end
+
+    it 'returns an empty string when the credentials file is readable but the contents are not as expected' do
+      allow(File).to receive(:exist?).with(RMT::CREDENTIALS_FILE_LOCATION).and_return(true)
+      allow(File).to receive(:readable?).with(RMT::CREDENTIALS_FILE_LOCATION).and_return(true)
+      allow(File).to receive(:foreach).with(RMT::CREDENTIALS_FILE_LOCATION).and_yield('whatever=12341234')
+
+      expect(method_call).to be_empty
+    end
+  end
 end

--- a/spec/suse/connect/api_spec.rb
+++ b/spec/suse/connect/api_spec.rb
@@ -158,6 +158,7 @@ RSpec.describe SUSE::Connect::Api do
         'Authorization' => 'Basic ' + Base64.encode64("#{username}:#{password}").strip,
         'User-Agent' => "RMT/#{RMT::VERSION}",
         'RMT' => uuid,
+        'HOST-SYSTEM' => '',
         'Accept' => 'application/vnd.scc.suse.com.v4+json'
       }
     end
@@ -298,6 +299,7 @@ RSpec.describe SUSE::Connect::Api do
       {
         'Authorization' => 'Basic ' + Base64.encode64("#{username}:#{password}").strip,
         'User-Agent' => "RMT/#{RMT::VERSION}",
+        'HOST-SYSTEM' => '',
         'RMT' => uuid
       }
     end


### PR DESCRIPTION
## Description

If possible, try to pass the host's login information into a new header. This header will be handled by glue so to link this registration proxy with the its registered host.

If the host is not registered into SCC, nothing will happen and it will work as usual. If the host is registered but the credentials file is not readable by the running user, a warning will be printed, but everything will run as usual.

**To be done**: add tests. I've been told to first have a discussion on the implementation details.

## Change Type

*Please select the correct option.*

- [ ] **Bug Fix** (a non-breaking change which fixes an issue)
- [x] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [ ] I have verified that my code follows RMT's coding standards with `rubocop`.
- [ ] I have reviewed my own code and believe that it's ready for an external review.
- [ ] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] RMT's test coverage remains at 100%.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Other Notes

Please use this space to provide notes or thoughts to the team, such as tips on how to review/demo your changes.
