### PR TITLE
Update changelog wording for 2.6.12 release

### DIFF
--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -2,7 +2,9 @@
 Thu Aug 19 10:12:03 UTC 2021 - Felix Schnizlein <fschnizlein@suse.com>
 
 - Version 2.6.12
-- Fix broken rpm package because of a bug in fix for (bsc#1188043)
+- Re-fix broken symlinks: This version fixes the bug-fix 
+deployed with version 2.6.11. Reference bug (bsc#1188043)
+
 - Handle special characters in package names (bsc#1189805)
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## Description

This PR attempts to fix the wording on our changelog. It further clarifies what is being deployed with version`2.6.12`.

*Please select the correct option.*

- [ ] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [x] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [x] I have verified that my code follows RMT's coding standards with `rubocop`.
- [x] I have reviewed my own code and believe that it's ready for an external review.
- [ ] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [x] RMT's test coverage remains at 100%.
- [x] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Other Notes

Please use this space to provide notes or thoughts to the team, such as tips on how to review/demo your changes.
