### PR TITLE
Send subscriptions associated to a product on system activation to Glue

### DIFF
--- a/spec/lib/suse/connect/api_spec.rb
+++ b/spec/lib/suse/connect/api_spec.rb
@@ -256,6 +256,35 @@ RSpec.describe SUSE::Connect::Api do
 
         it { is_expected.to eq(expected_response) }
       end
+
+      context 'when system has activations with subscriptions' do
+        let(:subscription) { FactoryBot.create :subscription }
+        let(:system) { create :system, :with_activated_product, subscription: subscription }
+        let(:product) { system.products.first }
+        let(:product_keys) { %i[id identifier version arch] }
+
+
+        let(:expected_response) { { login: system.login, password: system.password } }
+
+        let(:expected_products) do
+          attributes = product.slice(*product_keys).symbolize_keys
+          attributes[:regcode] = subscription.regcode
+          [attributes]
+        end
+
+        let(:expected_body) do
+          {
+            login: system.login,
+            password: system.password,
+            hostname: nil,
+            regcodes: [],
+            products: expected_products,
+            hwinfo: nil
+          }
+        end
+
+        it { is_expected.to eq(expected_response) }
+      end
     end
 
     describe '#forward_system_deregistration' do


### PR DESCRIPTION
## Description

This pull request adds the `regcode` attributes to `product` attributes in the
`POST $host/organizations/systems` call.

This allows SCC to consume which product was activated by which subscriptions.

**Note: This is depended on https://github.com/SUSE/rmt/pull/789 which is why all changes from #789 are listed here as well**

## Change Type

*Please select the correct option.*

- [ ] **Bug Fix** (a non-breaking change which fixes an issue)
- [x] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [x] I have verified that my code follows RMT's coding standards with `rubocop`.
- [x] I have reviewed my own code and believe that it's ready for an external review.
- [x] I have provided comments for any hard-to-understand code.
- [x] I have documented the `MANUAL.md` file with any changes to the user experience.
- [x] RMT's test coverage remains at 100%.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.ll

## Other Notes

Please use this space to provide notes or thoughts to the team, such as tips on how to review/demo your changes.

### How to review this pull request

tbd
