### PR TITLE
Fail activation when the module requires a root product which is not installed.

### DIFF
--- a/app/controllers/api/connect/v3/systems/products_controller.rb
+++ b/app/controllers/api/connect/v3/systems/products_controller.rb
@@ -108,16 +108,26 @@ class Api::Connect::V3::Systems::ProductsController < Api::Connect::BaseControll
 
   # Check if extension base product is already activated
   def check_base_product_dependencies
-    # TODO: For APIv5 and future. We skip this check for second level extensions. E.g. HA-GEO
-    # To fix bnc#951189 specifically the rollback part of it.
-    return if @product.bases.any?(&:extension?)
-    return if @product.base? || (@system.products & @product.bases).present?
+    # We skip this check for second level extensions (not modules). E.g. HA-GEO
+    # To fix bnc#951189 specifically the rollback part of it (could get dropped in APIv5).
 
-    logger.info("Tried to activate/upgrade to '#{@product.friendly_name}' with unmet base product dependency")
-    raise ActionController::TranslatedError.new(
-      N_('Unmet product dependencies, activate one of these products first: %s'),
-      @product.bases.map(&:friendly_name).join(', ')
-    )
+    return if @product.extension? && @product.bases.any?(&:extension?)
+    return if @product.base?
+
+    # check if required parent(base) product is activated
+    if (@system.products & @product.bases).empty?
+      untranslated = N_('The product you are attempting to activate (%{product}) requires one of these products ' \
+        'to be activated first: %{required_bases}')
+      raise ActionController::TranslatedError.new(untranslated,
+                                                  { product: @product.friendly_name, required_bases: @product.bases.map(&:friendly_name).join(', ') })
+    # check if required root product is activated
+    elsif (@system.products & @product.root_products).empty?
+      untranslated = N_('The product you are attempting to activate (%{product}) is not available on ' \
+        "your system's base product (%{system_base}). %{product} is available on: %{required_bases}.")
+      raise ActionController::TranslatedError.new(untranslated,
+                                                  { product: @product.friendly_name, system_base: @system.products.find(&:base?).friendly_name,
+                                                    required_bases: @product.root_products.map(&:friendly_name).join(', ') })
+    end
   end
 
   def render_service


### PR DESCRIPTION
## Description

Please describe your change and provide as much context as possible.

See https://trello.com/c/0qCebPPp/2134-cnt-api-do-not-allow-to-activate-any-module

## Change Type

*Please select the correct option.*

- [ ] **Bug Fix** (a non-breaking change which fixes an issue)
- [x] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [x] I have verified that my code follows RMT's coding standards with `rubocop`.
- [x] I have reviewed my own code and believe that it's ready for an external review.
- [x] I have provided comments for any hard-to-understand code.
- [x] I have documented the `MANUAL.md` file with any changes to the user experience.
- [x] RMT's test coverage remains at 100%.
- [x] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Other Notes

Please use this space to provide notes or thoughts to the team, such as tips on how to review/demo your changes.