### PR TITLE
Explicitely install OBS CLI

### DIFF
--- a/integration/install.sh
+++ b/integration/install.sh
@@ -9,5 +9,5 @@ zypper --non-interactive up
 zypper --non-interactive in -t pattern devel_osc_build
 zypper --non-interactive install --no-recommends wget curl timezone \
   gcc-c++ libffi-devel git-core zlib-devel libxml2-devel libxslt-devel libmariadb-devel \
-  mariadb-client mariadb ruby2.5-rubygem-bundler make build sudo ruby-devel nginx obs-service-format_spec_file
+  mariadb-client mariadb ruby2.5-rubygem-bundler make build sudo ruby-devel nginx osc obs-service-format_spec_file
 SUSEConnect -d


### PR DESCRIPTION
## Description

Since osc is not installed on some nodes, we explicitely add it to `install.sh`
Fixes failing integration tests

## Change Type

*Please select the correct option.*

- [ ] **Bug Fix** (a non-breaking change which fixes an issue)

## Checklist

*Please check off each item if the requirement is met.*

- [ ] I have verified that my code follows RMT's coding standards with `rubocop`.
- [ ] I have reviewed my own code and believe that it's ready for an external review.
- [ ] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] RMT's test coverage remains at 100%.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Other Notes

Please use this space to provide notes or thoughts to the team, such as tips on how to review/demo your changes.
