### PR TITLE
sync: purge products with a negative id

### DIFF
--- a/db/migrate/20220113074644_remove_products_negative_id.rb
+++ b/db/migrate/20220113074644_remove_products_negative_id.rb
@@ -1,0 +1,9 @@
+# This migration gets rid off a bug introduced in SCC where some non-SUSE
+# products with negative IDs were visible. This should never have happened since
+# they are managed elsewhere. Purge them now if this is the case for this
+# registration proxy.
+class RemoveProductsNegativeId < ActiveRecord::Migration[6.1]
+  def change
+    Product.where('id < ?', 0).destroy_all
+  end
+end

--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Tue Jan 11 16:52:16 UTC 2022 - Miquel Sabate Sola <msabate@suse.com>
 
-- Remove products with a negative ID on sync
+- Remove products with a negative ID during migration
 
 -------------------------------------------------------------------
 Tue Jan 11 15:03:58 UTC 2022 - Luís Caparroz <luis.caparroz@suse.com>

--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -1,10 +1,15 @@
 -------------------------------------------------------------------
+Tue Jan 11 16:52:16 UTC 2022 - Miquel Sabate Sola <msabate@suse.com>
+
+- Remove products with a negative ID on sync
+
+-------------------------------------------------------------------
 Tue Jan 11 15:03:58 UTC 2022 - Luís Caparroz <luis.caparroz@suse.com>
 
 - Version 2.7.1
 - Changes to RMT/connect API: RMT returns HTTP status code 422 whenever a system
   tries to register/activate a product with an expired subscription.
-  
+
 -------------------------------------------------------------------
 Tue Jan  4 17:25:07 UTC 2022 - Jesús Bermúdez Velázquez <jesus.bv@suse.com>
 


### PR DESCRIPTION
## Description

Purge products with a negative ID if they are on the database.

In order to test it, make sure that you have products with a negative ID (e.g. by calling `sync` before applying this patch). After applying this, you should be able to call `sync` and check that there are no products with a negative ID.

## Change Type

*Please select the correct option.*

- [x] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [x] I have verified that my code follows RMT's coding standards with `rubocop`.
- [x] I have reviewed my own code and believe that it's ready for an external review.
- [x] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [x] RMT's test coverage remains at 100%.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Other Notes

Please use this space to provide notes or thoughts to the team, such as tips on how to review/demo your changes.
