### PR TITLE
Send last_seen_at column when syncing systems

### DIFF
--- a/lib/suse/connect/api.rb
+++ b/lib/suse/connect/api.rb
@@ -64,7 +64,8 @@ module SUSE
           hostname: system.hostname,
           regcodes: [],
           products: generate_product_listing_for(system),
-          hwinfo: generate_hwinfo_for(system)
+          hwinfo: generate_hwinfo_for(system),
+          last_seen_at: system.last_seen_at
         }
 
         make_single_request(

--- a/spec/lib/suse/connect/api_spec.rb
+++ b/spec/lib/suse/connect/api_spec.rb
@@ -231,7 +231,8 @@ RSpec.describe SUSE::Connect::Api do
             hostname: nil,
             regcodes: [],
             products: [],
-            hwinfo: nil
+            hwinfo: nil,
+            last_seen_at: nil
           }
         end
 
@@ -250,7 +251,8 @@ RSpec.describe SUSE::Connect::Api do
             hostname: nil,
             regcodes: [],
             products: [ %i[id identifier version arch].each_with_object({}) { |k, h| h[k] = product.send(k) } ],
-            hwinfo: %i[cpus sockets hypervisor arch uuid cloud_provider].each_with_object({}) { |k, h| h[k] = hw_info.send(k) }
+            hwinfo: %i[cpus sockets hypervisor arch uuid cloud_provider].each_with_object({}) { |k, h| h[k] = hw_info.send(k) },
+            last_seen_at: nil
           }
         end
 
@@ -279,7 +281,8 @@ RSpec.describe SUSE::Connect::Api do
             hostname: nil,
             regcodes: [],
             products: expected_products,
-            hwinfo: nil
+            hwinfo: nil,
+            last_seen_at: nil
           }
         end
 

--- a/spec/requests/api/connect/v3/systems/activations_controller_spec.rb
+++ b/spec/requests/api/connect/v3/systems/activations_controller_spec.rb
@@ -55,5 +55,19 @@ RSpec.describe Api::Connect::V3::Systems::ActivationsController do
         end
       end
     end
+
+    context 'last_seen_at check' do
+      it 'does not touch scc_synced_at when it simply authenticates' do
+        expect(system.last_seen_at).to be_nil
+
+        get url, headers: authenticated_headers
+        expect(response.code).to eq '200'
+
+        system.reload
+
+        expect(system.last_seen_at).not_to be_nil
+        expect(system.scc_synced_at).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
## Description

This will not happen if, for example, the only change is on the `last_seen_at` column an nothing else.

This change is related to report more consistent data to SCC.

## Change Type

*Please select the correct option.*

- [ ] **Bug Fix** (a non-breaking change which fixes an issue)
- [x] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [ ] I have verified that my code follows RMT's coding standards with `rubocop`.
- [ ] I have reviewed my own code and believe that it's ready for an external review.
- [ ] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] RMT's test coverage remains at 100%.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Other Notes

Please use this space to provide notes or thoughts to the team, such as tips on how to review/demo your changes.
