### PR TITLE
Do not encode file that are imported from the filesystem (bsc#1195201)

### DIFF
--- a/lib/rmt/mirror/file_reference.rb
+++ b/lib/rmt/mirror/file_reference.rb
@@ -24,7 +24,8 @@ class RMT::Mirror::FileReference
     @local_path = File.join(base_dir, relative_path.gsub(/\.\./, '__'))
 
     # INFO: Encode the filename of the URI to make RMT handle RFC3986-incompliant filenames (e.g. containing special characters)
-    encoded_filename = ERB::Util.url_encode(File.basename(relative_path))
+    encoded_filename = File.basename(relative_path)
+    encoded_filename = ERB::Util.url_encode(encoded_filename) unless base_url.to_s.starts_with? 'file://'
     relative_path = File.join(File.dirname(relative_path), encoded_filename)
 
     @remote_path = URI.join(base_url, relative_path)


### PR DESCRIPTION
## Description

Commit 8f68994ca6a352031261199a1dead5f27ddffe10 added encoding of file names so that special characters are properly escaped when handled over network. However, it does so also for files stored locally on the filesystem, which leads to `rmt-cli import` failing due to the expected (encoded) file names not existing. This patch prevents encoding for files that are handled through the `file://` scheme.

Fixes bsc#1195201

## Change Type

*Please select the correct option.*

- [x] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [ ] I have verified that my code follows RMT's coding standards with `rubocop`.
- [ ] I have reviewed my own code and believe that it's ready for an external review.
- [ ] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] RMT's test coverage remains at 100%.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Other Notes

Please use this space to provide notes or thoughts to the team, such as tips on how to review/demo your changes.
