### PR TITLE
cli: added the 'systems purge' command

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -40,6 +40,19 @@ You can install and run this wizard like this:
     Example:
 
     `rmt-cli systems remove SCC_e740f34145b84523a184ace764d0d597`
+    
+  * `rmt-cli systems purge [--non-interactive] [--before date]`:
+    Removes inactive systems.
+    
+    Use the `--non-interactive` flag so the command does not ask you for
+    confirmation.
+    
+    Use the `--before date` flag to define that systems before the given date
+    should be viewed as inactive.
+    
+    Example:
+    
+    `rmt-cli systems purge --non-interactive --before 2022-02-28`
 
   * `rmt-cli products list [--all] [--csv] [--name name] [--version version] [--arch arch]`:
     Lists the products that are enabled for mirroring.

--- a/spec/lib/rmt/cli/systems_spec.rb
+++ b/spec/lib/rmt/cli/systems_spec.rb
@@ -184,4 +184,53 @@ RSpec.describe RMT::CLI::Systems do
       end
     end
   end
+
+  describe '#purge' do
+    context 'argument error' do
+      it 'raises a CLI error when given a wrong date' do
+        msg = "The given date does not follow a proper format. Ensure it follows this format '<year>-<month>-<day>'.\n"
+        expect { described_class.start(['purge', '--non-interactive', '--before', 'whatever']) }
+          .to raise_error(SystemExit)
+                .and output(msg).to_stderr
+      end
+    end
+
+    context 'no systems to be purged' do
+      let(:argv) { ['purge'] }
+
+      before do
+        create :system, :with_activated_product, last_seen_at: 1.month.ago
+      end
+
+      it 'shows a warning if there are no systems matching the query' do
+        expect { described_class.start(argv) }.to output('').to_stdout.and \
+          output("No systems to be purged on this RMT instance.\n").to_stderr
+      end
+    end
+
+    context 'there are systems to be purged' do
+      let!(:s1) { create :system, :with_activated_product, last_seen_at: 2.months.ago }
+      let!(:s2) { create :system, :with_activated_product, last_seen_at: 4.months.ago }
+
+      it 'removes systems by following the default definition of inactive' do
+        expect(System.count).to eq 2
+
+        expect { described_class.start(['purge', '--non-interactive']) }
+          .to output(/#{s2.login}/).to_stdout
+
+        expect(System.count).to eq 1
+        expect(System.first.id).to eq s1.id
+      end
+
+      it 'removes systems by the given date' do
+        expect(System.count).to eq 2
+
+        argv = ['purge', '--non-interactive', '--before', Time.zone.now.strftime('%F')]
+        expect { described_class.start(argv) }
+          .to output(/#{s1.login}/).to_stdout
+
+        expect(System.count).to eq 0
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Description

This command allows users to delete inactive systems. By default, inactive systems are those which have not contacted RMT for at least 3 months.

### How to test

Setup an RMT instance with a variety of systems on it. Tweak the `last_seen_at` attribute of these systems according to your testing purposes. Then, check that `rmt-cli systems purge` lists you first the systems that will get deleted and that you need to confirm for this to actually happen. Check that you can bypass this question by calling this command with the `--non-interactive` flag. Finally, check that you can change which systems are to be picked with the `--before` flag, which expects a string with the format `<year>-<month>-<day>` (even though any date format would actually work).

## Change Type

*Please select the correct option.*

- [ ] **Bug Fix** (a non-breaking change which fixes an issue)
- [x] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [x] I have verified that my code follows RMT's coding standards with `rubocop`.
- [x] I have reviewed my own code and believe that it's ready for an external review.
- [x] I have provided comments for any hard-to-understand code.
- [x] I have documented the `MANUAL.md` file with any changes to the user experience.
- [x] RMT's test coverage remains at 100%.
~~- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.~~

## Other Notes

Please use this space to provide notes or thoughts to the team, such as tips on how to review/demo your changes.
