### PR TITLE
Use bulk send api for system sync

### DIFF
--- a/lib/rmt.rb
+++ b/lib/rmt.rb
@@ -1,5 +1,5 @@
 module RMT
-  VERSION ||= '2.7.1'.freeze
+  VERSION ||= '2.8.0'.freeze
 
   DEFAULT_USER = '_rmt'.freeze
   DEFAULT_GROUP = 'nginx'.freeze

--- a/lib/rmt/scc.rb
+++ b/lib/rmt/scc.rb
@@ -84,10 +84,9 @@ class RMT::SCC
     scc_api_client = SUSE::Connect::Api.new(Settings.scc.username, Settings.scc.password)
 
     # do not sync BYOS proxy systems to SCC
-    updatable_systems = System.where('scc_registered_at IS NULL OR last_seen_at > scc_registered_at', proxy_byos: false)
-
+    systems = System.where('scc_registered_at IS NULL OR last_seen_at > scc_registered_at', proxy_byos: false)
     @logger.info(_('Syncing systems to SCC'))
-    scc_api_client.send_bulk_system_update(updatable_systems) do |successful_response|
+    scc_api_client.send_bulk_system_update(systems) do |successful_response|
       next if successful_response[:systems].count == 0
 
       successful_response[:systems].each do |system_hash|
@@ -95,7 +94,7 @@ class RMT::SCC
         System.find_by(login: system_hash[:login])
            .update_columns(scc_system_id: system_hash[:id], scc_synced_at: Time.current)
       rescue StandardError => e
-        @logger.error(_('Failed to sync systems: %{error}') % { login: system_hash[:login], error: e.to_s })
+        @logger.error(_('Failed to sync systems: %{error}') % { error: e.to_s })
       end
     end
 

--- a/lib/rmt/scc.rb
+++ b/lib/rmt/scc.rb
@@ -84,14 +84,19 @@ class RMT::SCC
     scc_api_client = SUSE::Connect::Api.new(Settings.scc.username, Settings.scc.password)
 
     # do not sync BYOS proxy systems to SCC
-    System.where(scc_synced_at: nil, proxy_byos: false).find_in_batches(batch_size: 20) do |batch|
-      batch.each do |system|
-        @logger.info(_('Syncing system %{login} to SCC') % { login: system.login })
-        response = scc_api_client.forward_system_activations(system)
+    updatable_systems = System.where(scc_synced_at: nil, proxy_byos: false)
+
+    @logger.info(_('Syncing systems to SCC'))
+    scc_api_client.send_bulk_system_update(updatable_systems) do |successful_response|
+      next if successful_response[:systems].count == 0
+
+      successfully_updated_systems = successful_response[:systems]
+      successfully_updated_systems.each do |system_hash|
         # Update attributes without triggering after_update callback (which resets scc_synced_at to nil)
-        system.update_columns(scc_system_id: response[:id], scc_synced_at: Time.current)
-      rescue SUSE::Connect::Api::RequestError => e
-        @logger.error(_('Failed to sync system %{login}: %{error}') % { login: system.login, error: e.to_s })
+        System.find_by(login: system_hash[:login])
+           .update_columns(scc_system_id: system_hash[:id], scc_synced_at: Time.current)
+      rescue StandardError => e
+        @logger.error(_('Failed to sync systems: %{error}') % { login: system_hash[:login], error: e.to_s })
       end
     end
 

--- a/lib/rmt/scc.rb
+++ b/lib/rmt/scc.rb
@@ -84,7 +84,7 @@ class RMT::SCC
     scc_api_client = SUSE::Connect::Api.new(Settings.scc.username, Settings.scc.password)
 
     # do not sync BYOS proxy systems to SCC
-    updatable_systems = System.where(scc_synced_at: nil, proxy_byos: false)
+    updatable_systems = System.where('scc_registered_at IS NULL OR scc_synced_at > scc_registered_at', proxy_byos: false)
 
     @logger.info(_('Syncing systems to SCC'))
     scc_api_client.send_bulk_system_update(updatable_systems) do |successful_response|

--- a/lib/suse/connect/api.rb
+++ b/lib/suse/connect/api.rb
@@ -62,7 +62,7 @@ module SUSE
 
       def send_bulk_system_update(systems, system_limit = nil)
         system_limit ||= BULK_SYSTEM_REQUEST_LIMIT
-        systems.each_slice(system_limit) do |batched_systems|
+        systems.in_batches(of: system_limit) do |batched_systems|
           params = prepare_payload_for_bulk_update(batched_systems)
           response = make_single_request(
             :put,

--- a/lib/suse/connect/api.rb
+++ b/lib/suse/connect/api.rb
@@ -94,8 +94,12 @@ module SUSE
 
         systems_hash = systems.collect do |system|
           system_hash = system.attributes.symbolize_keys.slice(*mandatory_keys)
+
+          # If an system is updated, scc_synced_at is set to nil to
+          # indicate a full sync
+          next system_hash unless system.scc_synced_at.nil?
+
           system_hash[:hostname] = system.hostname
-          system_hash[:regcodes] = []
           system_hash[:hwinfo] = generate_hwinfo_for(system)
           system_hash[:products] = generate_product_listing_for(system)
           system_hash

--- a/lib/suse/connect/api.rb
+++ b/lib/suse/connect/api.rb
@@ -60,24 +60,6 @@ module SUSE
         make_paginated_request(:get, "#{connect_api}/organizations/subscriptions")
       end
 
-      def forward_system_activations(system)
-        params = {
-          login: system.login,
-          password: system.password,
-          hostname: system.hostname,
-          regcodes: [],
-          products: generate_product_listing_for(system),
-          hwinfo: generate_hwinfo_for(system),
-          last_seen_at: system.last_seen_at
-        }
-
-        make_single_request(
-          :post,
-          "#{connect_api}/organizations/systems",
-          { body: params.to_json }
-        )
-      end
-
       def send_bulk_system_update(systems, system_limit = nil)
         system_limit ||= BULK_SYSTEM_REQUEST_LIMIT
         systems.each_slice(system_limit) do |batched_systems|

--- a/lib/suse/connect/api.rb
+++ b/lib/suse/connect/api.rb
@@ -80,16 +80,15 @@ module SUSE
 
       def send_bulk_system_update(systems, system_limit = nil)
         system_limit ||= BULK_SYSTEM_REQUEST_LIMIT
-        last_response = nil
         systems.each_slice(system_limit) do |batched_systems|
           params = prepare_payload_for_bulk_update(batched_systems)
-          last_response = make_single_request(
+          response = make_single_request(
             :put,
             "#{connect_api}/organizations/systems",
             { body: params.to_json }
           )
+          yield response
         end
-        last_response
       rescue RequestError => e
         # change some params here and start the bulk update.
         if e.response.code == 413

--- a/package/files/systemd/rmt-server-mirror.timer
+++ b/package/files/systemd/rmt-server-mirror.timer
@@ -3,7 +3,7 @@ Description=RMT Mirror timer
 
 [Timer]
 OnCalendar=*-*-* 02:00:00
-RandomizedDelaySec=3h
+RandomizedDelaySec=9h
 Unit=rmt-server-mirror.service
 
 [Install]

--- a/package/files/systemd/rmt-server-sync.timer
+++ b/package/files/systemd/rmt-server-sync.timer
@@ -3,7 +3,7 @@ Description=RMT Sync timer
 
 [Timer]
 OnCalendar=*-*-* 01:00:00
-RandomizedDelaySec=3h
+RandomizedDelaySec=9h
 Unit=rmt-server-sync.service
 
 [Install]

--- a/package/files/systemd/rmt-server-systems-scc-sync.timer
+++ b/package/files/systemd/rmt-server-systems-scc-sync.timer
@@ -3,7 +3,7 @@ Description=Sync RMT systems to SCC timer
 
 [Timer]
 OnCalendar=*-*-* 04:00:00
-RandomizedDelaySec=3h
+RandomizedDelaySec=9h
 Unit=rmt-server-systems-scc-sync.service
 
 [Install]

--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Mar 14 15:06:48 UTC 2022 - Felix Schnizlein <fschnizlein@suse.com>
+
+- Version 2.8.0
+- Add sending bulk system information to SCC if needed. Send up to date
+  last seen information to SCC
+
+-------------------------------------------------------------------
 Thu Mar  7 16:38:12 UTC 2022 - Felix Schnizlein <fschnizlein@suse.com>
 
 - Add switch to disable user confirmation when cleaning repository data

--- a/package/obs/rmt-server.spec
+++ b/package/obs/rmt-server.spec
@@ -29,7 +29,7 @@
 %define ruby_version          %{rb_default_ruby_suffix}
 
 Name:           rmt-server
-Version:        2.7.1
+Version:        2.8.0
 Release:        0
 Summary:        Repository mirroring tool and registration proxy for SCC
 License:        GPL-2.0-or-later

--- a/spec/factories/systems.rb
+++ b/spec/factories/systems.rb
@@ -3,9 +3,19 @@ FactoryBot.define do
     sequence(:login) { |n| "login#{n}" }
     sequence(:password) { |n| "password#{n}" }
 
+    scc_synced_at { nil }
+
     transient do
       virtual { false }
       instance_data { nil }
+    end
+
+    trait :synced do
+      sequence(:scc_system_id) { |n| n }
+
+      after :create do |system, _|
+        system.touch(:scc_synced_at)
+      end
     end
 
     trait :byos do

--- a/spec/lib/rmt/scc_spec.rb
+++ b/spec/lib/rmt/scc_spec.rb
@@ -382,13 +382,13 @@ describe RMT::SCC do
 
       context 'when syncing succeeds' do
         before do
-          expect(api_double).to receive(:forward_system_activations).with(system).and_return(
-            {
+          expect(api_double).to receive(:send_bulk_system_update).with([system]).and_yield({
+            systems: [{
               id: scc_system_id,
-              login: 'test',
-              password: 'test'
-            }
-          )
+              login: system.login,
+              password: system.password
+            }]
+          })
           expect(api_double).to receive(:forward_system_deregistration).with(deregistered_system.scc_system_id)
 
           expect(logger).to receive(:info).with(/Syncing system/)
@@ -413,7 +413,13 @@ describe RMT::SCC do
 
       context 'when syncing fails' do
         before do
-          expect(api_double).to receive(:forward_system_activations).with(system).and_raise(SUSE::Connect::Api::RequestError, 'Sync error')
+          expect(api_double).to receive(:send_bulk_system_update).with([system]).and_yield({
+            systems: [{
+              id: 3000,
+              login: 'foo',
+              password: 'bar'
+            }]
+          })
           expect(logger).to receive(:info).with(/Syncing system/)
           expect(logger).to receive(:error).with(/Failed to sync system/)
           described_class.new.sync_systems

--- a/spec/lib/rmt/scc_spec.rb
+++ b/spec/lib/rmt/scc_spec.rb
@@ -361,7 +361,7 @@ describe RMT::SCC do
       end
 
       it "doesn't sync systems" do
-        expect(api_double).not_to receive(:forward_system_activations)
+        expect(api_double).not_to receive(:send_bulk_system_update)
         described_class.new.sync_systems
       end
 

--- a/spec/lib/suse/connect/api_spec.rb
+++ b/spec/lib/suse/connect/api_spec.rb
@@ -205,7 +205,7 @@ RSpec.describe SUSE::Connect::Api do
       it { is_expected.to eq([ { endpoint: 'organizations/subscriptions' } ]) }
     end
 
-    describe '#forward_system_activations' do
+    xdescribe '#forward_system_activations' do
       subject { api_client.forward_system_activations(system) }
 
       before do

--- a/spec/lib/suse/connect/api_spec.rb
+++ b/spec/lib/suse/connect/api_spec.rb
@@ -267,7 +267,8 @@ RSpec.describe SUSE::Connect::Api do
 
         it 'yields results' do
           expect do |block|
-            api_client.send_bulk_system_update(systems, &block)
+            relation = System.where(id: systems.pluck(:id))
+            api_client.send_bulk_system_update(relation, &block)
           end.to yield_with_args(expected_response)
         end
       end
@@ -295,7 +296,8 @@ RSpec.describe SUSE::Connect::Api do
 
         it 'yields successful results' do
           expect do |block|
-            api_client.send_bulk_system_update(systems, &block)
+            relation = System.where(id: systems.pluck(:id))
+            api_client.send_bulk_system_update(relation, &block)
           end.to yield_with_args(expected_response)
         end
       end
@@ -367,7 +369,10 @@ RSpec.describe SUSE::Connect::Api do
         end
 
         it 'yields successful results' do
-          expect { |b| api_client.send_bulk_system_update(systems, &b) }.to yield_with_args(expected_response)
+          expect do |block|
+            relation = System.where(id: systems.pluck(:id))
+            api_client.send_bulk_system_update(relation, &block)
+          end.to yield_with_args(expected_response)
         end
       end
 
@@ -402,7 +407,8 @@ RSpec.describe SUSE::Connect::Api do
 
         it 'yields successful results' do
           expect do |block|
-            api_client.send_bulk_system_update(systems, &block)
+            relation = System.where(id: systems.pluck(:id))
+            api_client.send_bulk_system_update(relation, &block)
           end.to yield_with_args(expected_response)
         end
       end

--- a/spec/lib/suse/connect/api_spec.rb
+++ b/spec/lib/suse/connect/api_spec.rb
@@ -338,7 +338,9 @@ RSpec.describe SUSE::Connect::Api do
           { systems: system_hashes }
         end
 
-        it { is_expected.to eq(expected_response) }
+        it 'yields results' do
+          expect { |b| api_client.send_bulk_system_update(systems, &b) }.to yield_with_args(expected_response)
+        end
       end
 
       context 'when sending in bulk' do
@@ -373,10 +375,11 @@ RSpec.describe SUSE::Connect::Api do
           { systems: system_hashes }
         end
 
-        it { is_expected.to eq(expected_response) }
+        it 'yields successful results' do
+          expect { |b| api_client.send_bulk_system_update(systems, &b) }.to yield_with_args(expected_response)
+        end
       end
 
-      # Spec needs to be fixed.
       context 'when sending in bulk and encounter 413 http error code' do
         subject { api_client.send_bulk_system_update(systems) }
 
@@ -453,7 +456,9 @@ RSpec.describe SUSE::Connect::Api do
           { systems: system_hashes }
         end
 
-        it { is_expected.to eq(expected_response) }
+        it 'yields successful results' do
+          expect { |b| api_client.send_bulk_system_update(systems, &b) }.to yield_with_args(expected_response)
+        end
       end
     end
 


### PR DESCRIPTION
# description
- Refactor API call function to yield results
- Use bulk send API for SCC system update
- Remove system forwarding logic

# How to review this pull request:

### Requirements
- Running RMT checkout out to `use_bulk_send_api_for_system_sync` branch
- Connection to SCC working (e.g. `rmt-cli sync` works)
- Mirroring at least one SLES and HA (in this howto it is 15.3)
- A running 15.3 container (e.g. from SUSEConnect repository)

### Acceptance
```bash
$  = rmt host terminal
>  = SLES docker container
% = rmt host rails console
#  = comment
!  = expectation

! Make sure RMT is running (assuming http://localhost:4224)
```
---

**Show that a newly registered system behind RMT gets fully synced to SCC in the daily sync process**
```bash
$ docker run --rm --network=host -h review-1 --network=host -ti connect.15sp3 /bin/bash
> SUSEConnect -r <slesregcode> --url http://localhost:4224

$ rmt-cli systems scc-sync

! You should be able to find the newly registered system under you proxy system tab (hint: its hostname should be `review-1`)
```
---

**Show that a previously synced system that activated a new product gets fully synced to SCC in the daily sync process**
```bash
# Make sure to reuse the container from first test step or recreate a new container

> SUSEConnect -p sle-ha/15.3/x86_64

$ rmt-cli systems scc-sync
! Check that the system you created now has also HA enabled
```
---
**Show that a previously synced system that has changes in `hw_info` gets fully synced to SCC in the daily sync process**
```bash
# You need to create 2 systems to make this work
# 1. Create a normal container, without system privileged
$ docker run --rm --network=host -h review-2 --network=host -ti connect.15sp3 /bin/bash
> SUSEConnect -r <slesregcode> --url http://localhost:4224

$ bin/rmt-cli systems scc-sync
! Get the newly created system and check it does **not** have a uuid set

> cat /etc/zypp/credentials.d/SCCcredentials
> cat /etc/SUSEConnect

$ docker run --privileged --rm --network=host -h review-3 --network=host -ti connect.15sp3 /bin/bash
> vim /etc/zypp/credentials.d/SCCcredentials # Copy content from SCCcredentials to newly created container
> vim /etc/SUSEConnect                                # Copy content from SUSEConnect to newly created container
> SUSEConnect -p sle-ha/15.3/x86_64         # This will fail since server-apps is not correctly activated but works regarding sending new information

$ bin/rmt-cli systems scc-sync
! Check that the system now has uuid available
```
---

**Show that a system that updated its `last_seen_at` timestamp in RMT by running `SUSEConnect --keepalive` or `zypper refs` gets that `last_seen_at` timestamp forwarded to SCC in the daily sync process over the new [bulk API](https://trello.com/c/g3vEUfZs/2289-uras-bulk-system-update-endpoint) without syncing unchanged attributes (activations, hw_info).**
and
**Show that systems that have no change to activations, `hw_info` and last_seen_at are not included in the daily sync**
are more or less the same acceptance ;)
```bash
$ docker run --rm --network=host -h review-4 --network=host -ti connect.15sp3 /bin/bash
> SUSEConnect -r <slesregcode> --url http://localhost:4224
> zypper refs

$ bin/rmt-cli systems scc-sync
! Find the system you just created

> zypper refs
$ killall rmt-server rails  # stop the rmt rails server ;)
$ vim $RMT_DIR/config/rmt.local.yml
! Set your `scc >> host:` variable to `host: http://localhost:8000/connect`

$ nc -l 8000
$ bin/rmt-cli systems scc-sync
! Check the request send by rmt to SCC in your `nc` output! It should only include login, password and last_seen_at
```
---

**Show that BYOS systems are not included in the daily sync.**
A tough one! Check this: https://github.com/SUSE/rmt/pull/864/files#diff-2d45d1d7af6dd13cb171709edb7a8e4eaa135578414047fd70e2f83ce46eb61bR87


**As always, if you having trouble with instruction or something is unclear, feel free to approach us to help you make reviewing a nice activity!**

