### PR TITLE
cli: standardize the naming for --non-interactive

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -100,10 +100,10 @@ You can install and run this wizard like this:
 
   	`rmt-cli products show SLES/15/x86_64`
 
-  * `rmt-cli repos clean [-y|--no-confirm]`:
+  * `rmt-cli repos clean [-n|--non-interactive]`:
     Removes locally mirrored files of repositories which are not marked to be mirrored.
 
-	Use the `-y` or `--no-confirm` to avoid user interaction
+	Use the `-n` or `--non-interactive` to avoid user interaction
 
   * `rmt-cli repos list [--all] [--csv]`:
     Lists the repositories that are enabled for mirroring.

--- a/lib/rmt/cli/repos.rb
+++ b/lib/rmt/cli/repos.rb
@@ -14,7 +14,7 @@ class RMT::CLI::Repos < RMT::CLI::ReposBase
   map 'ls' => :list
 
   desc 'clean', _('Removes locally mirrored files of repositories which are not marked to be mirrored')
-  option :no_confirm, aliases: '-y', type: :boolean, desc: _(' Don\'t require user interaction. Default: Auto accept confirmation dialog.')
+  option :non_interactive, aliases: '-n', type: :boolean, desc: _(' Don\'t require user interaction. Default: Auto accept confirmation dialog.')
 
   def clean
     base_directory = RMT::DEFAULT_MIRROR_DIR
@@ -42,7 +42,7 @@ class RMT::CLI::Repos < RMT::CLI::ReposBase
     print _('Enter a value:')
     print "\e[22m\s\s"
 
-    unless options[:no_confirm]
+    unless options[:non_interactive]
       input = $stdin.gets.to_s.strip
       if input != 'yes'
         puts "\n" + _('Clean cancelled.')

--- a/spec/lib/rmt/cli/repos_spec.rb
+++ b/spec/lib/rmt/cli/repos_spec.rb
@@ -135,8 +135,8 @@ RMT only found locally mirrored files of repositories that are marked to be mirr
       end
     end
 
-    context 'with -y' do
-      let(:argv) { ['clean', '-y'] }
+    context 'with -n' do
+      let(:argv) { ['clean', '-n'] }
       let(:input) { 'no' }
 
       it 'delete downloaded files for non-mirrored repositories' do
@@ -147,8 +147,8 @@ RMT only found locally mirrored files of repositories that are marked to be mirr
       end
     end
 
-    context 'with --no-confirm' do
-      let(:argv) { ['clean', '--no-confirm'] }
+    context 'with --non-interactive' do
+      let(:argv) { ['clean', '--non-interactive'] }
       let(:input) { 'no' }
 
       it 'delete downloaded files for non-mirrored repositories' do


### PR DESCRIPTION
## Description

In other places we are using `-n | --non-interactive`, and this is consistent with other SUSE tools such as zypper. Let's use these strings everywhere.
