### PR TITLE
Fix `systems list` CSV output

### DIFF
--- a/lib/rmt/cli/decorators/system_decorator.rb
+++ b/lib/rmt/cli/decorators/system_decorator.rb
@@ -8,34 +8,44 @@ class RMT::CLI::Decorators::SystemDecorator < RMT::CLI::Decorators::Base
     end
   end
 
+  def initialize(systems)
+    @data = systems
+  end
+
+  def to_csv(batch: false)
+    systems = systems_to_arrays
+    array_to_csv(systems, HEADERS, batch: batch)
+  end
+
+  def to_table
+    systems = systems_to_arrays(join_new_line: true)
+    array_to_table(systems, HEADERS)
+  end
+
+  private
+
   attr_reader :data
 
-  def initialize(systems)
-    @data = systems.map do |system|
+  def systems_to_arrays(join_new_line: false)
+    data.map do |system|
       [
         system.login,
         system.hostname,
         system.registered_at,
         system.last_seen_at,
-        products_and_subscriptions(system).join("\n")
+        products_and_subscriptions(system, join_new_line: join_new_line)
       ]
     end
   end
 
-  def products_and_subscriptions(system)
-    system.activations.map do |a|
+  def products_and_subscriptions(system, join_new_line: false)
+    products = system.activations.map do |a|
       product_name = a.service.product.product_string
 
       a.subscription ? "#{product_name} (Regcode: #{a.subscription.regcode})" : product_name
     end
-  end
 
-  def to_csv(batch: false)
-    array_to_csv(@data, HEADERS, batch: batch)
-  end
-
-  def to_table
-    array_to_table(@data, HEADERS)
+    join_new_line ? products.join("\n") : products.join(' ')
   end
 
 end


### PR DESCRIPTION
## Description

The command `rmt-cli systems list --csv` had an issue with its output, where the value in the column "Products" was presented as a list of items separated by new line characters. This is counter-intuitive since one expects a CSV file to have just one entry per line.

This commit fix the behavior by separating the items in the "Products" columns by spaces.

Fixes # (issue)

## Change Type

*Please select the correct option.*

- [ ] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [x] I have verified that my code follows RMT's coding standards with `rubocop`.
- [x] I have reviewed my own code and believe that it's ready for an external review.
- [x] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [x] RMT's test coverage remains at 100%.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Other Notes

Please use this space to provide notes or thoughts to the team, such as tips on how to review/demo your changes.
