### PR TITLE
Move to --no-confirmation for all non interactive modes in rmt-cli

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -41,7 +41,7 @@ You can install and run this wizard like this:
 
     `rmt-cli systems remove SCC_e740f34145b84523a184ace764d0d597`
     
-  * `rmt-cli systems purge [--non-confirmation] [--before date]`:
+  * `rmt-cli systems purge [--no-confirmation] [--before date]`:
     Removes inactive systems.
     
     Use the `--non-confirmation` flag so the command does not ask you for

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -44,7 +44,7 @@ You can install and run this wizard like this:
   * `rmt-cli systems purge [--no-confirmation] [--before date]`:
     Removes inactive systems.
     
-    Use the `--non-confirmation` flag so the command does not ask you for
+    Use the `--no-confirmation` flag so the command does not ask you for
     confirmation.
     
     Use the `--before date` flag to define that systems before the given date

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -41,10 +41,10 @@ You can install and run this wizard like this:
 
     `rmt-cli systems remove SCC_e740f34145b84523a184ace764d0d597`
     
-  * `rmt-cli systems purge [--non-interactive] [--before date]`:
+  * `rmt-cli systems purge [--non-confirmation] [--before date]`:
     Removes inactive systems.
     
-    Use the `--non-interactive` flag so the command does not ask you for
+    Use the `--non-confirmation` flag so the command does not ask you for
     confirmation.
     
     Use the `--before date` flag to define that systems before the given date
@@ -100,10 +100,11 @@ You can install and run this wizard like this:
 
   	`rmt-cli products show SLES/15/x86_64`
 
-  * `rmt-cli repos clean [-y|--no-confirm]`:
+  * `rmt-cli repos clean [--no-confirmation]`:
     Removes locally mirrored files of repositories which are not marked to be mirrored.
 
-	Use the `-y` or `--no-confirm` to avoid user interaction
+    Use the `--no-confirmation` to avoid user interaction and auto accept confirmation
+    dialogs.
 
   * `rmt-cli repos list [--all] [--csv]`:
     Lists the repositories that are enabled for mirroring.

--- a/lib/rmt/cli/repos.rb
+++ b/lib/rmt/cli/repos.rb
@@ -14,7 +14,7 @@ class RMT::CLI::Repos < RMT::CLI::ReposBase
   map 'ls' => :list
 
   desc 'clean', _('Removes locally mirrored files of repositories which are not marked to be mirrored')
-  option :no_confirm, aliases: '-y', type: :boolean, desc: _(' Don\'t require user interaction. Default: Auto accept confirmation dialog.')
+  option :confirmation, type: :boolean, default: true, desc: _('Ask for confirmation or do not ask for confirmation and require no user interaction')
 
   def clean
     base_directory = RMT::DEFAULT_MIRROR_DIR
@@ -42,7 +42,7 @@ class RMT::CLI::Repos < RMT::CLI::ReposBase
     print _('Enter a value:')
     print "\e[22m\s\s"
 
-    unless options[:no_confirm]
+    if options.confirmation
       input = $stdin.gets.to_s.strip
       if input != 'yes'
         puts "\n" + _('Clean cancelled.')

--- a/lib/rmt/cli/systems.rb
+++ b/lib/rmt/cli/systems.rb
@@ -65,17 +65,17 @@ class RMT::CLI::Systems < RMT::CLI::Base
 
   desc 'purge', _('Removes inactive systems')
   option :before, aliases: '-b', type: :string, desc: _('Remove systems before the given date (format: "<year>-<month>-<day>")')
-  option :non_interactive, aliases: '-n', type: :boolean, default: false, desc: _("Don't ask for anything")
+  option :confirmation, type: :boolean, default: true, desc: _('Ask for confirmation or do not ask for confirmation and require no user interaction')
   long_desc <<~PURGE
     #{_('Removes old systems and their activations if they are inactive.')}
 
     #{_('By default, inactive systems are those that have not contacted in any way with RMT for the past 3 months. You can override this with the \'-b / --before\' flag.')}
 
-    #{_('The command will list you the candidates for removal and will ask for confirmation. You can tell this subcommand to go ahead without asking with the \'-n / --non-interactive\' flag.')}
+    #{_('The command will list you the candidates for removal and will ask for confirmation. You can tell this subcommand to go ahead without asking with the \'--no-confirmation\' flag.')}
 
     #{_('Examples')}:
 
-    $ rmt-cli systems purge --non-interactive --before 2022-02-28
+    $ rmt-cli systems purge --no-confirmation --before 2022-02-28
   PURGE
   def purge
     ask, before = purge_options
@@ -114,11 +114,9 @@ class RMT::CLI::Systems < RMT::CLI::Base
 
   # Returns the validated options expected by the `purge` subcommand.
   def purge_options
-    ask = options.non_interactive.nil? ? true : !options.non_interactive
-
     dt = options.before.to_s.to_datetime || INACTIVE.ago
 
-    [ask, dt.strftime('%F')]
+    [options.confirmation, dt.strftime('%F')]
   rescue ArgumentError
     raise RMT::CLI::Error.new(_("The given date does not follow a proper format. Ensure it follows this format '<year>-<month>-<day>'."))
   end

--- a/spec/lib/rmt/cli/repos_spec.rb
+++ b/spec/lib/rmt/cli/repos_spec.rb
@@ -135,20 +135,8 @@ RMT only found locally mirrored files of repositories that are marked to be mirr
       end
     end
 
-    context 'with -y' do
-      let(:argv) { ['clean', '-y'] }
-      let(:input) { 'no' }
-
-      it 'delete downloaded files for non-mirrored repositories' do
-        expect { command }.to output(expected_output).to_stdout.and output('').to_stderr
-        expect(DownloadedFile.where('local_path LIKE ?', "#{repo_1_path}%").count).to eq(0)
-        expect(DownloadedFile.where('local_path LIKE ?', "#{repo_2_path}%").count).to eq(0)
-        expect(DownloadedFile.where('local_path LIKE ?', "#{repo_3_path}%").count).to eq(1)
-      end
-    end
-
-    context 'with --no-confirm' do
-      let(:argv) { ['clean', '--no-confirm'] }
+    context 'with --no-confirmation' do
+      let(:argv) { ['clean', '--no-confirmation'] }
       let(:input) { 'no' }
 
       it 'delete downloaded files for non-mirrored repositories' do

--- a/spec/lib/rmt/cli/systems_spec.rb
+++ b/spec/lib/rmt/cli/systems_spec.rb
@@ -211,7 +211,7 @@ RSpec.describe RMT::CLI::Systems do
     context 'argument error' do
       it 'raises a CLI error when given a wrong date' do
         msg = "The given date does not follow a proper format. Ensure it follows this format '<year>-<month>-<day>'.\n"
-        expect { described_class.start(['purge', '--non-interactive', '--before', 'whatever']) }
+        expect { described_class.start(['purge', '--no-confirmation', '--before', 'whatever']) }
           .to raise_error(SystemExit)
                 .and output(msg).to_stderr
       end
@@ -239,7 +239,7 @@ RSpec.describe RMT::CLI::Systems do
       it 'removes systems by following the default definition of inactive' do
         expect(System.count).to eq 2
 
-        expect { described_class.start(['purge', '--non-interactive']) }
+        expect { described_class.start(['purge', '--no-confirmation']) }
           .to output(/#{s2.login}/).to_stdout
 
         expect(System.count).to eq 1
@@ -249,7 +249,7 @@ RSpec.describe RMT::CLI::Systems do
       it 'removes systems by the given date' do
         expect(System.count).to eq 2
 
-        argv = ['purge', '--non-interactive', '--before', Time.zone.now.strftime('%F')]
+        argv = ['purge', '--no-confirmation', '--before', Time.zone.now.strftime('%F')]
         expect { described_class.start(argv) }
           .to output(/#{s1.login}/).to_stdout
 


### PR DESCRIPTION
## Description
Instead of using multiple switches for `non interactive`/`no confirmation` in `rmt-cli`, streamline them to `-no-confirmation`.

Note: Since thor is automatically adding positive and negative switches when using a `boolean` switch all these commands
come now with: `--confirmation` and `--no-confirmation`.
Before they where like `--non-interactive` and `-no-non-interactive`.

# How to test this fixes:

```bash
$ = rmt host terminal
# = comment
!  = expectation
```

### Systems
```bash
$ rmt-cli systems purge --help
! --no-confirmation should be available and described

$ rmt-cli systems purge --before 2022-02-02
! Should ask you if you want to delete systems
# cancel purging command (ctrl+c)

$ rmt-cli systems purge --no-confirmation --before 2022-02-02
! Should purge the systems without user interaction
```
---

### Repos
```bash
$ rmt-cli repos clean --help
! --no-confirmation should be available and described

# If the following command does not show any data to be clean, disable a product (pro tip: Take something light to disable like SLES root product to not have to remirror lots of data later)
$ rmt-cli repos clean
! Should ask you if you want to continue with cleaning
# cancel cleaning command (ctrl+c)

$ rmt-cli repos clean --no-confirmation
! Should clean the repository data
```

