### PR TITLE
Moving the retry logic of failed download requests to the `Downloader` class.

### DIFF
--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -1,5 +1,5 @@
 
-name: RMT Integration tests
+name: RMT unit + engines tests
 
 on:
   pull_request:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -188,7 +188,7 @@ Lint/UnreachableLoop:
 # Offense count: 3
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 164
+  Max: 175
 
 # Offense count: 1
 # Configuration parameters: IgnoredMethods.

--- a/.simplecov
+++ b/.simplecov
@@ -1,5 +1,6 @@
 unless ENV['NO_COVERAGE']
-  if ENV['SIMPLECOV_CMD'] == 'test:core'
+
+  if !ENV['SIMPLECOV_CMD'] || ENV['SIMPLECOV_CMD'] == 'test:core'
     SimpleCov.minimum_coverage 100
     SimpleCov.start do
       SimpleCov.command_name ENV['SIMPLECOV_CMD']
@@ -13,16 +14,16 @@ unless ENV['NO_COVERAGE']
       track_files('lib/**/*.rb')
     end
   end
+
   if ENV['SIMPLECOV_CMD'] == 'test:engines'
-    SimpleCov.minimum_coverage 84
+    SimpleCov.minimum_coverage 100
     SimpleCov.start do
       SimpleCov.command_name ENV['SIMPLECOV_CMD']
       add_filter '/spec/'
       add_filter '/tasks/'
 
-      track_files('engines/**/app/**/*.rb')
-      track_files('engines/**/lib/**/*.rb')
       track_files('engines/**/*.rb')
     end
   end
+
 end

--- a/Gemfile
+++ b/Gemfile
@@ -75,7 +75,7 @@ gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 
 gem 'versionist'
 gem 'responders'
-gem 'typhoeus', '~> 1.1', '>= 1.1.2'
+gem 'typhoeus'
 gem 'active_model_serializers'
 
 # i18n

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,7 +90,7 @@ GEM
       dry-initializer (~> 3.0)
       dry-schema (~> 1.5, >= 1.5.2)
     erubi (1.10.0)
-    ethon (0.14.0)
+    ethon (0.15.0)
       ffi (>= 1.15.0)
     factory_bot (6.2.0)
       activesupport (>= 5.0.0)
@@ -100,7 +100,7 @@ GEM
     fakefs (1.8.0)
     fast_gettext (2.2.0)
     ffaker (2.21.0)
-    ffi (1.15.3)
+    ffi (1.15.5)
     formatador (0.2.5)
     forwardable (1.3.2)
     fuubar (2.5.1)
@@ -356,7 +356,7 @@ DEPENDENCIES
   terminal-table (~> 3.0)
   thor
   timecop
-  typhoeus (~> 1.1, >= 1.1.2)
+  typhoeus
   tzinfo-data
   vcr (~> 6.0)
   versionist

--- a/lib/rmt.rb
+++ b/lib/rmt.rb
@@ -1,5 +1,5 @@
 module RMT
-  VERSION ||= '2.8.0'.freeze
+  VERSION ||= '2.8.1'.freeze
 
   DEFAULT_USER = '_rmt'.freeze
   DEFAULT_GROUP = 'nginx'.freeze

--- a/lib/rmt/cli/base.rb
+++ b/lib/rmt/cli/base.rb
@@ -77,15 +77,13 @@ class RMT::CLI::Base < Thor
         RMT::CLI::Error::ERROR_SCC
       )
     rescue RMT::Lockfile::ExecutionLockedError => e
-      raise RMT::CLI::Error.new(
-        e.message,
-        RMT::CLI::Error::ERROR_OTHER
-      )
+      raise RMT::CLI::Error.new(e.message, RMT::CLI::Error::ERROR_OTHER)
     rescue SUSE::Connect::Api::RequestError => e
       raise RMT::CLI::Error.new(
-        _("SCC API request failed. Error details:\nRequest URL: %{url}\nResponse code: %{code}\nResponse body:\n%{body}") % {
+        _("SCC API request failed. Error details:\nRequest URL: %{url}\nResponse code: %{code}\nReturn code: %{return_code}\nResponse body:\n%{body}") % {
           url: e.response.request.url,
           code: e.response.code,
+          return_code: e.response.return_code,
           body: e.response.body
         },
         RMT::CLI::Error::ERROR_OTHER

--- a/lib/rmt/db.rb
+++ b/lib/rmt/db.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# :nocov: (only used in docker-compose setup)
+
 module RMT
   # The DB module has useful methods for DB purposes. This is largely based on
   # SUSE/Portus.
@@ -60,3 +62,4 @@ module RMT
     class TimeoutReachedError < RuntimeError; end
   end
 end
+# :nocov:

--- a/lib/rmt/downloader/exception.rb
+++ b/lib/rmt/downloader/exception.rb
@@ -10,6 +10,7 @@ class RMT::Downloader::Exception < RuntimeError
   def self.raise_request_error(remote_file, response, logger)
     logger.debug <<~DEBUG.chomp
     #{_('Request error:')}
+      #{_('Request URL')}: #{response.effective_url}
       #{_('Response HTTP status code')}: #{response.code}
       #{_('Response body')}: #{response.body.presence || "''"}
       #{_('Response headers')}: #{flatten_string(response.response_headers.presence)}

--- a/lib/rmt/downloader/exception.rb
+++ b/lib/rmt/downloader/exception.rb
@@ -1,0 +1,32 @@
+class RMT::Downloader::Exception < RuntimeError
+  attr_reader :http_code, :response
+
+  def initialize(message, response: nil)
+    @response = response
+    @http_code = response&.code
+    super(message)
+  end
+
+  def self.raise_request_error(remote_file, response, logger)
+    logger.debug <<~DEBUG.chomp
+    #{_('Request error:')}
+      #{_('Response HTTP status code')}: #{response.code}
+      #{_('Response body')}: #{response.body.presence || "''"}
+      #{_('Response headers')}: #{flatten_string(response.response_headers.presence)}
+      #{_('curl return code')}: #{response.return_code.presence || "''"}
+      #{_('curl return message')}: #{response.return_message.presence || "''"}
+    DEBUG
+
+    message = _("%{file} - request failed with HTTP status code %{code}, return code '%{return_code}'") %
+      { file: remote_file, code: response.code, return_code: response.return_code }
+
+    raise RMT::Downloader::Exception.new(message, response: response)
+  end
+
+  def self.flatten_string(str)
+    return '' if str.blank?
+
+    str.lines.map(&:strip).map(&:presence).compact.join('; ')
+  end
+
+end

--- a/lib/rmt/gpg.rb
+++ b/lib/rmt/gpg.rb
@@ -32,7 +32,7 @@ class RMT::GPG
     out = `#{cmd}`
 
     if $CHILD_STATUS.exitstatus != 0
-      @logger.warn "GPG command: #{cmd}"
+      @logger.warn "GPG command failed with #{$CHILD_STATUS.exitstatus}: #{cmd}"
       @logger.warn "GPG output: #{out}"
       raise RMT::GPG::Exception.new(_('GPG key import failed'))
     end

--- a/lib/rmt/http_request.rb
+++ b/lib/rmt/http_request.rb
@@ -3,6 +3,8 @@ require 'rmt/config'
 
 class RMT::HttpRequest < Typhoeus::Request
 
+  attr_accessor :retries
+
   def set_defaults
     Typhoeus::Config.user_agent = "RMT/#{RMT::VERSION}"
     Typhoeus::Config.verbose = Settings.try(:http_client).try(:verbose)

--- a/lib/rmt/mirror.rb
+++ b/lib/rmt/mirror.rb
@@ -10,8 +10,6 @@ class RMT::Mirror
   include RMT::Deduplicator
   include RMT::FileValidator
 
-  MIRROR_METADATA_RETRIES = 5
-
   def initialize(mirroring_base_dir: RMT::DEFAULT_MIRROR_DIR, logger:, mirror_src: false, airgap_mode: false)
     @mirroring_base_dir = mirroring_base_dir
     @logger = logger
@@ -85,7 +83,7 @@ class RMT::Mirror
     raise RMT::Mirror::Exception.new(_('Could not create a temporary directory: %{error}') % { error: e.message })
   end
 
-  def mirror_metadata(repository_dir, repository_url, temp_metadata_dir, n_retry = MIRROR_METADATA_RETRIES)
+  def mirror_metadata(repository_dir, repository_url, temp_metadata_dir)
     mirroring_paths = {
       base_url: URI.join(repository_url),
       base_dir: temp_metadata_dir,
@@ -111,15 +109,7 @@ class RMT::Mirror
       if (e.http_code == 404)
         logger.info(_('Repository metadata signatures are missing'))
       else
-        if n_retry > 0
-          n_seconds = 2
-          logger.warn _('Mirroring metadata signature/key failed with %{http_code}. Retrying after %{seconds} seconds') % { http_code: e.http_code,
-                                                                                                                            seconds: n_seconds }
-          sleep(n_seconds)
-          mirror_metadata(repository_dir, repository_url, temp_metadata_dir, (n_retry - 1))
-        end
-
-        raise(_('Downloading repo signature/key failed with HTTP code %{http_code}') % { http_code: e.http_code })
+        raise(_('Downloading repo signature/key failed with: %{message}, HTTP code %{http_code}') % { message: e.message, http_code: e.http_code })
       end
     end
 
@@ -130,9 +120,7 @@ class RMT::Mirror
 
     metadata_files
   rescue StandardError => e
-    if n_retry == MIRROR_METADATA_RETRIES
-      raise RMT::Mirror::Exception.new(_('Error while mirroring metadata: %{error}') % { error: e.message })
-    end
+    raise RMT::Mirror::Exception.new(_('Error while mirroring metadata: %{error}') % { error: e.message })
   end
 
   def mirror_license(repository_dir, repository_url, temp_licenses_dir)

--- a/lib/rmt/mirror.rb
+++ b/lib/rmt/mirror.rb
@@ -159,7 +159,7 @@ class RMT::Mirror
 
     raise _('Failed to download %{failed_count} files') % { failed_count: failed_downloads.size } unless failed_downloads.empty?
   rescue StandardError => e
-    raise RMT::Mirror::Exception.new(_('Error while mirroring data: %{error}') % { error: e.message })
+    raise RMT::Mirror::Exception.new(_('Error while mirroring packages: %{error}') % { error: e.message })
   end
 
   def parse_packages_metadata(metadata_references)

--- a/lib/rmt/scc.rb
+++ b/lib/rmt/scc.rb
@@ -144,7 +144,7 @@ class RMT::SCC
 
   def create_product(item, root_product_id = nil, base_product = nil, recommended = false, migration_extra = false)
     ActiveRecord::Base.transaction do
-      @logger.debug _('Adding product %{product}') % { product: "#{item[:identifier]}/#{item[:version]}#{(item[:arch]) ? '/' + item[:arch] : ''}" }
+      @logger.debug _('Adding/Updating product %{product}') % { product: "#{item[:identifier]}/#{item[:version]}#{(item[:arch]) ? '/' + item[:arch] : ''}" }
 
       product = get_product(item[:id])
       product.attributes = item.select { |k, _| product.attributes.keys.member?(k.to_s) }

--- a/lib/suse/connect/api.rb
+++ b/lib/suse/connect/api.rb
@@ -72,12 +72,14 @@ module SUSE
           yield response
         end
       rescue RequestError => e
+        # :nocov: TODO: https://github.com/SUSE/rmt/issues/911
         # change some params here and start the bulk update.
         if e.response.code == 413
           system_limit = e.response.headers['X-Payload-Entities-Max-Limit'].to_i
           return send_bulk_system_update(systems, system_limit)
         end
         raise e
+        # :nocov:
       end
 
       def forward_system_deregistration(scc_system_id)

--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -1,7 +1,13 @@
 -------------------------------------------------------------------
+Fri Jul  1 13:10:01 UTC 2022 - Thomas Schmidt <tschmidt@suse.com>
+
+- Version 2.8.1:
+  Retry failed http requests automatically (bsc#1197405, bsc#1188578, bsc#1198721, bsc#1199961)
+
+-------------------------------------------------------------------
 Mon May  2 13:51:44 UTC 2022 - Thomas Schmidt <tschmidt@suse.com>
 
-- Improved rmt-client-setup-res script for CentOS8.x and RHEL/RES8.x (bsc#1197038) 
+- Improved rmt-client-setup-res script for CentOS8.x and RHEL/RES8.x (bsc#1197038)
 
 -------------------------------------------------------------------
 Mon Mar 14 15:06:48 UTC 2022 - Felix Schnizlein <fschnizlein@suse.com>

--- a/package/obs/rmt-server.spec
+++ b/package/obs/rmt-server.spec
@@ -29,7 +29,7 @@
 %define ruby_version          %{rb_default_ruby_suffix}
 
 Name:           rmt-server
-Version:        2.8.0
+Version:        2.8.1
 Release:        0
 Summary:        Repository mirroring tool and registration proxy for SCC
 License:        GPL-2.0-or-later

--- a/spec/lib/rmt/cli/main_spec.rb
+++ b/spec/lib/rmt/cli/main_spec.rb
@@ -138,7 +138,8 @@ RSpec.describe RMT::CLI::Main, :with_fakefs do
                   url: 'http://example.com/api'
                 ),
                 body: 'A terrible error has occurred!',
-                code: 503
+                code: 503,
+                return_code: 'my_error'
               )
             )
           end
@@ -148,6 +149,7 @@ RSpec.describe RMT::CLI::Main, :with_fakefs do
               "SCC API request failed. Error details:\n" \
               "Request URL: http://example.com/api\n" \
               "Response code: 503\n" \
+              "Return code: my_error\n" \
               "Response body:\n" \
               "A terrible error has occurred!\n"
             ).to_stderr

--- a/spec/lib/rmt/downloader_spec.rb
+++ b/spec/lib/rmt/downloader_spec.rb
@@ -44,7 +44,6 @@ RSpec.describe RMT::Downloader do
       it 'raises an exception' do
         expect_any_instance_of(RMT::Logger).to receive(:debug)
           .with(debug_request_error_regex).once
-
         expect { downloader.download(repomd_xml_file) }.to raise_error(
           RMT::Downloader::Exception,
           "http://example.com/repomd.xml - request failed with HTTP status code 404, return code ''"
@@ -61,7 +60,7 @@ RSpec.describe RMT::Downloader do
 
       it 'raises an exception' do
         expect_any_instance_of(RMT::Logger).to receive(:debug)
-          .with(debug_request_error_regex).once
+          .with(debug_request_error_regex).exactly(5).times
 
         allow_any_instance_of(RMT::FiberRequest).to receive(:read_body) do |instance|
           response = instance_double(Typhoeus::Response, code: 200, body: 'Ok',

--- a/spec/lib/rmt/downloader_spec.rb
+++ b/spec/lib/rmt/downloader_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe RMT::Downloader do
   describe '#download over http://' do
     context 'when HTTP code is not 200' do
       before do
+        allow_any_instance_of(RMT::Logger).to receive(:debug).with(/HTTP request/)
         stub_request(:get, 'http://example.com/repomd.xml')
           .with(headers: headers)
           .to_return(status: 404, body: '', headers: {})
@@ -53,6 +54,7 @@ RSpec.describe RMT::Downloader do
 
     context 'when processing response by Typhoeus failed' do
       before do
+        allow_any_instance_of(RMT::Logger).to receive(:debug).with(/HTTP request/)
         stub_request(:get, 'http://example.com/repomd.xml')
           .with(headers: headers)
           .to_return(status: 200, body: '', headers: {})
@@ -64,6 +66,7 @@ RSpec.describe RMT::Downloader do
 
         allow_any_instance_of(RMT::FiberRequest).to receive(:read_body) do |instance|
           response = instance_double(Typhoeus::Response, code: 200, body: 'Ok',
+                                     effective_url: 'http://example.com/repomd.xml',
                                      return_code: :error, return_message: 'curl error',
                                      response_headers: "HTTP/2 404 \r\ncache-control: max-age=0\r\ncontent-type: text/html")
 
@@ -263,6 +266,7 @@ RSpec.describe RMT::Downloader do
         before do
           File.open(repomd_xml_file.cache_path, 'w') { |file| file.write(cached_content) }
           File.utime(time, time, repomd_xml_file.cache_path)
+          allow_any_instance_of(RMT::Logger).to receive(:debug).with(/HTTP HEAD/)
           stub_request(:head, 'http://example.com/repomd.xml')
             .with(headers: headers)
             .to_return(status: 404)
@@ -369,6 +373,7 @@ RSpec.describe RMT::Downloader do
 
     context 'when download exceptions occur when ignore_errors is true' do
       before do
+        allow_any_instance_of(RMT::Logger).to receive(:debug).with(/HTTP request/)
         files.each do |file|
           stub_request(:get, "http://example.com/#{file}").with(headers: headers)
             .to_return(status: 404, body: file, headers: {})
@@ -418,6 +423,7 @@ RSpec.describe RMT::Downloader do
       end
 
       it 'raises an exception' do
+        allow_any_instance_of(RMT::Logger).to receive(:debug).with(/HTTP request/)
         expect_any_instance_of(RMT::Logger).to receive(:debug)
           .with(debug_request_error_regex).once
 
@@ -442,6 +448,7 @@ RSpec.describe RMT::Downloader do
 
       context 'when a HEAD request fails and the ignore_errors = false' do
         before do
+          allow_any_instance_of(RMT::Logger).to receive(:debug).with(/HTTP HEAD/)
           queue.each do |file|
             FileUtils.touch(file.cache_path)
             stub_request(:head, file.remote_path.to_s).with(headers: headers)
@@ -463,6 +470,7 @@ RSpec.describe RMT::Downloader do
 
       context 'when a HEAD request fails and the ignore_errors = true' do
         before do
+          allow_any_instance_of(RMT::Logger).to receive(:debug).with(/HTTP HEAD/)
           queue.each do |file|
             FileUtils.touch(file.cache_path)
             stub_request(:head, file.remote_path.to_s).with(headers: headers)

--- a/spec/lib/rmt/mirror_spec.rb
+++ b/spec/lib/rmt/mirror_spec.rb
@@ -785,11 +785,10 @@ RSpec.describe RMT::Mirror do
 
       it 'raises RMT::Mirror::Exception' do
         expect(logger).to receive(:info).with(/Mirroring repository/).once
-        expect(logger).to receive(:warn).with('Mirroring metadata signature/key failed with 502. Retrying after 2 seconds').exactly(1).time
         expect(logger).to receive(:info).with(/↓/).at_least(1).times
 
         expect_any_instance_of(described_class).to(
-          receive(:mirror_metadata).exactly(2).times.and_call_original
+          receive(:mirror_metadata).and_call_original
         )
 
         allow_any_instance_of(RMT::Downloader).to receive(:download).and_wrap_original do |klass, *args|
@@ -802,7 +801,7 @@ RSpec.describe RMT::Mirror do
 
         expect { rmt_mirror.mirror(**mirror_params) }.to raise_error(
           RMT::Mirror::Exception,
-           'Error while mirroring metadata: Downloading repo signature/key failed with HTTP code 502'
+           'Error while mirroring metadata: Downloading repo signature/key failed with: HTTP request failed, HTTP code 502'
         )
       end
     end

--- a/spec/lib/rmt/mirror_spec.rb
+++ b/spec/lib/rmt/mirror_spec.rb
@@ -351,7 +351,7 @@ RSpec.describe RMT::Mirror do
             klass.call(*args)
           end
 
-          expect { rmt_mirror.mirror(**mirror_params) }.to raise_error(RMT::Mirror::Exception, 'Error while mirroring data: Failed to download 6 files')
+          expect { rmt_mirror.mirror(**mirror_params) }.to raise_error(RMT::Mirror::Exception, 'Error while mirroring packages: Failed to download 6 files')
         end
 
         it 'handles RMT::ChecksumVerifier::Exception' do
@@ -361,7 +361,7 @@ RSpec.describe RMT::Mirror do
             klass.call(*args)
           end
 
-          expect { rmt_mirror.mirror(**mirror_params) }.to raise_error(RMT::Mirror::Exception, 'Error while mirroring data: Failed to download 6 files')
+          expect { rmt_mirror.mirror(**mirror_params) }.to raise_error(RMT::Mirror::Exception, 'Error while mirroring packages: Failed to download 6 files')
         end
       end
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -26,6 +26,10 @@ Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.maintain_test_schema!
 
+# Speed up tests by shorten wait time to retry failed downloads
+RMT::Downloader.send(:remove_const, :RETRY_DELAY_SECONDS)
+RMT::Downloader.const_set(:RETRY_DELAY_SECONDS, 0.1)
+
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"


### PR DESCRIPTION
## Description

The `Downloader` class is handling the download logic, so it's the logical place 
to own also the retry logic. 

The retries can be tested with: 

```
sudo tc qdisc add dev em1 root netem loss 50%
bin/rmt-cli mirror
sudo tc qdisc del dev em1 root netem loss 50%
```



## Change Type

*Please select the correct option.*

- [ ] **Bug Fix** (a non-breaking change which fixes an issue)
- [x] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)