### PR TITLE
Send system_token (actually the system id) if available

### DIFF
--- a/lib/suse/connect/api.rb
+++ b/lib/suse/connect/api.rb
@@ -97,6 +97,15 @@ module SUSE
         systems_hash = systems.collect do |system|
           system_hash = system.attributes.symbolize_keys.slice(*mandatory_keys)
 
+          # Instead of the actual system token we send the system id which is
+          # stable per RMT host.
+          # This is required since SCC does not have access to up to date token
+          # information. If we would send the actual token, SCC would create a
+          # duplicate each time the token changed.
+          if system.system_token
+            system_hash[:system_token] = system.id
+          end
+
           # If a system has updated attributes other than `last_seen_at`,
           # scc_synced_at is reset to nil, to require a full sync.
           next system_hash unless system.scc_synced_at.nil?


### PR DESCRIPTION
## Description

Send the `system.id` if the system is using a `system_token` in RMT. This ensures we get a unique system on SCC even if we do not send the *actual* `system_token`.


## How to test this changes:

**Preparation**:
You need:
   - A running SCC instance (glue)
   - A RMT environment configured to use the local SCC instance (rmt.conf + mirroring credentials)
   - RMT has SLES15SP3 and SLES15GA products enabled and mirrored
   - Docker to run multiple SLES15SP3 and SLES15GA containers
   - A regcode from the organization you configured RMT (aka <regcode>)

**Review:**
legend:
```
# = comment
$ = host system
> = docker container
>> = RMT rails console (bin/rails c)
#! = expectation
```

```
# To verify your setup run (which should suceed)
$ bin/rmt-cli sync

# Run rmt server
$ bin/rails s

# 1. A systems token is updated and syncing does not duplicate the system on SCC side
$ docker run --privileged --rm -h forward-id-1 --network=host -ti connect.15sp3 /bin/bash
> SUSEConnect -r <regcode> --url http://localhost:4224

# Sync to local SCC
$ bin/rmt-cli systems scc-sync

# Search for the system in your local SCC and open up the admin page of the system
# Tip: http://localhost:3000/systems/<id> -> http://localhost:3000/admin/systems/<id>
#! The system should show the id which is used by RMT as system_token
>> System.find(<id from system_token in SCC>)
...
#!  Should find the system in question

# Update the system and change the token
> cat /etc/zypp/credentials.d/SCCcredentials | grep token
> SUSEConnect --keepalive
> cat /etc/zypp/credentials.d/SCCcredentials | grep token
#! Token has changed
$ bin/rmt-cli systems scc-sync
#! There is no new system in SCC and the only the last seen at has changed (of the system)

# 2. Show multiple systems **with** and **without** `system_token` are forwarded.
$ docker run --privileged --rm -h forward-id-ga --network=host -ti connect.15sp0 /bin/bash
# I assume you use a GA container which does not yet have token support!
GA> SUSEConnect -r <regcode> --url http://localhost:4224
$ docker run --privileged --rm -h forward-id-sp3 --network=host -ti connect.15sp3 /bin/bash
SP3> SUSEConnect -r <regcode> --url http://localhost:4224
$ bin/rmt-cli systems scc-sync
#! Find the your proxy and both systems should show up
#! Validate that both systems have correct setup (token + products)

# Optional:
# Upgrade the GA system to support tokens
GA> zypper in https://download.opensuse.org/repositories/systemsmanagement:/SCC/SLE_15/x86_64/SUSEConnect-0.4-1.1.x86_64.rpm
GA> SUSEConnect --keepalive
$ bin/rmt-cli system scc-sync
#! Check that your GA system now has a id set as system token (in SCC)

voila!

```

Thank you very much for reviewing! :rocket: 
