### PR TITLE
Send system creation date and product activation date.

### DIFF
--- a/lib/suse/connect/api.rb
+++ b/lib/suse/connect/api.rb
@@ -95,7 +95,7 @@ module SUSE
       protected
 
       def prepare_payload_for_bulk_update(systems)
-        mandatory_keys = %i[login password last_seen_at]
+        mandatory_keys = %i[login password last_seen_at created_at]
 
         systems_hash = systems.collect do |system|
           system_hash = system.attributes.symbolize_keys.slice(*mandatory_keys)
@@ -127,6 +127,10 @@ module SUSE
 
         system.activations.map do |activation|
           attributes = activation.product.slice(*product_keys).symbolize_keys
+
+          # Send the activation creation date to determine on SCC
+          # when a system has activated a certain product
+          attributes[:activated_at] = activation.created_at
 
           if activation.subscription
             attributes[:regcode] = activation.subscription.regcode

--- a/lib/suse/connect/system_serializer.rb
+++ b/lib/suse/connect/system_serializer.rb
@@ -1,0 +1,73 @@
+require 'active_model_serializers'
+
+# Serializes a system to be consumed by the SCC Api
+class SUSE::Connect::SystemSerializer < ActiveModel::Serializer
+  # RMT has two modes of sending system information to SCC
+  # 1) Full update mode
+  #    When a system is changed or new RMT will send the full system
+  #    information available to SCC.
+  # 2) Keepalive mode (:needs_full_update?)
+  #    Since the keepalive mechanism has been released in SUSEConnect
+  #    RMT also sends system information to SCC (e.g. last_seen_at).
+  #    This saves resouces since not the full system information needs
+  #    to be processed.
+  attributes :login, :password, :last_seen_at, :created_at
+
+  attribute :system_token, if: :has_system_token?
+
+  attribute :hostname, if: :needs_full_update?
+  attribute :hwinfo, if: :has_hwinfo_and_needs_full_update?
+  attribute :products, if: :needs_full_update?
+
+  # We send the internal system id as system_token if the system (in RMT) is
+  # duplicated (therefore using the system_token mechanism).
+  # SCC needs a stable identifier as system_token to uniquly identify duplicated
+  # systems behind proxies.
+  # More info: https://github.com/SUSE/scc-docs/blob/master/rfc/0031_system_token.md
+  def system_token
+    object.id
+  end
+
+  def products
+    object.activations.map do |activation|
+      product = activation.product
+      payload = {
+        id: product.id,
+        identifier: product.identifier,
+        version: product.version,
+        arch: product.arch,
+        activated_at: activation.created_at
+      }
+
+      if activation.subscription
+        payload[:regcode] = activation.subscription.regcode
+      end
+
+      payload
+    end
+  end
+
+  def hwinfo
+    info = object.hw_info
+    {
+      cpus: info.cpus,
+      sockets: info.sockets,
+      hypervisor: info.hypervisor,
+      arch: info.arch,
+      uuid: info.uuid,
+      cloud_provider: info.cloud_provider
+    }
+  end
+
+  def has_hwinfo_and_needs_full_update?
+    object.hw_info.present? && needs_full_update?
+  end
+
+  def has_system_token?
+    object.system_token.present?
+  end
+
+  def needs_full_update?
+    !object.scc_synced_at
+  end
+end

--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Sep 22 09:30:17 UTC 2022 - Felix Schnizlein <fschnizlein@suse.com>
+
+- Send system creation and product activation dates to SCC for better
+  visibility in SCC.
+
+-------------------------------------------------------------------
 Fri Sep  2 13:33:41 UTC 2022 - Thomas Schmidt <tschmidt@suse.com>
 
 - Release version 2.9: Implement `System-Token` header handling to improve unique system reporting.

--- a/spec/lib/suse/connect/api_spec.rb
+++ b/spec/lib/suse/connect/api_spec.rb
@@ -248,17 +248,22 @@ RSpec.describe SUSE::Connect::Api do
 
       context 'when a single system is bulk updated' do
         let(:systems) { create_list :system, 1, :full }
-        let(:product) { system.products.first }
+        let(:activation) { system.activations.first }
+        let(:product) { activation.product }
         let(:hw_info) { system.hw_info }
 
         let(:expected_body) do
           system_hashes = systems.collect do |system|
-            product = system.products.first.slice(*product_keys)
+            activation = system.activations.first
+            product = activation.product.slice(*product_keys)
+            product[:activated_at] = activation.created_at
+
             hwinfo = system.hw_info.slice(*hwinfo_keys)
             {
               login: system.login,
               password: system.password,
               last_seen_at: system.last_seen_at,
+              created_at: system.created_at,
               hostname: system.hostname,
               hwinfo: hwinfo,
               products: [product]
@@ -279,12 +284,15 @@ RSpec.describe SUSE::Connect::Api do
 
         let(:expected_body) do
           system_hashes = systems.collect do |system|
-            product = system.products.first.slice(*product_keys)
+            activation = system.activations.first
+            product = activation.product.slice(*product_keys)
+            product[:activated_at] = activation.created_at
             hwinfo = system.hw_info.slice(*hwinfo_keys)
             {
               login: system.login,
               password: system.password,
               last_seen_at: system.last_seen_at,
+              created_at: system.created_at,
               hostname: system.hostname,
               hwinfo: hwinfo,
               products: [product]
@@ -311,12 +319,14 @@ RSpec.describe SUSE::Connect::Api do
                 login: system1.login,
                 password: system1.password,
                 last_seen_at: system1.last_seen_at,
+                created_at: system1.created_at,
                 system_token: system1.id
               },
               {
                 login: system2.login,
                 password: system2.password,
-                last_seen_at: system2.last_seen_at
+                last_seen_at: system2.last_seen_at,
+                created_at: system2.created_at
               }
             ]
           }
@@ -408,17 +418,21 @@ RSpec.describe SUSE::Connect::Api do
           {
             login: system_set.login,
             password: system_set.password,
-            last_seen_at: system_set.last_seen_at
+            last_seen_at: system_set.last_seen_at,
+            created_at: system_set.created_at
           }
         end
         let(:expected_body_unset) do
           systems_unset.collect do |system|
-            product = system.products.first.slice(*product_keys)
+            activation = system.activations.first
+            product = activation.product.slice(*product_keys)
+            product[:activated_at] = activation.created_at
             hwinfo = system.hw_info.slice(*hwinfo_keys)
             {
               login: system.login,
               password: system.password,
               last_seen_at: system.last_seen_at,
+              created_at: system.created_at,
               hostname: system.hostname,
               hwinfo: hwinfo,
               products: [product]

--- a/spec/lib/suse/connect/system_serializer_spec.rb
+++ b/spec/lib/suse/connect/system_serializer_spec.rb
@@ -1,0 +1,96 @@
+require 'rails_helper'
+
+describe SUSE::Connect::SystemSerializer do
+  subject(:serializer) { described_class.new(system).to_h }
+
+  let(:system) { create :system, :full }
+
+  context 'not synchronized system' do
+    let(:expected) do
+      info = system.hw_info
+      activation = system.activations.first
+      product = activation.product
+
+      {
+        login: system.login,
+        password: system.password,
+        last_seen_at: system.last_seen_at,
+        created_at: system.created_at,
+        hostname: system.hostname,
+        hwinfo: {
+          cpus: info.cpus,
+          sockets: info.sockets,
+          hypervisor: info.hypervisor,
+          arch: info.arch,
+          uuid: info.uuid,
+          cloud_provider: info.cloud_provider
+        },
+        products: [
+          {
+            id: product.id,
+            identifier: product.identifier,
+            version: product.version,
+            arch: product.arch,
+            activated_at: activation.created_at
+          }
+        ]
+      }
+    end
+
+    it { is_expected.to match(expected) }
+  end
+
+  context 'synchronized system' do
+    let(:system) { create :system, :full, :synced }
+    let(:expected) do
+      {
+        login: system.login,
+        password: system.password,
+        last_seen_at: system.last_seen_at,
+        created_at: system.created_at
+      }
+    end
+
+    it { is_expected.to match(expected) }
+  end
+
+  context 'system with system_token' do
+    let(:system) { create :system, :full, :synced, :with_system_token }
+    let(:expected) do
+      {
+        login: system.login,
+        password: system.password,
+        last_seen_at: system.last_seen_at,
+        created_at: system.created_at,
+        system_token: system.id
+      }
+    end
+
+    it { is_expected.to match(expected) }
+  end
+
+  context 'system with activation and subscriptions' do
+    let(:subscription) { create :subscription }
+    let(:system) { create :system, :full, subscription: subscription }
+
+    it 'does add the subscriptions regcode if associated' do
+      expect(serializer[:products][0][:regcode]).to eq(subscription.regcode)
+    end
+  end
+
+  context 'system without hardware info' do
+    let(:system) { create :system, :synced, hw_info: nil }
+
+    it 'does not add the hwinfo attribute' do
+      expect(serializer.key? :hwinfo).to eq(false)
+    end
+  end
+
+  context 'system without system_token' do
+    let(:system) { create :system, :synced, system_token: nil }
+
+    it 'does not add the system_token attribute' do
+      expect(serializer.key? :system_token).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
## Description

Adding `system.created_at` and `activation.created_at` to the SCC API calls to make possible for SCC to better detect system creation and product activation dates.

part of: https://trello.com/c/7YwvJ3NN/2546-uras-track-actual-system-creation-and-product-activation-times

This pull request is also a refactoring of the `api_spec.rb` test file. It additionally adds `SystemSerializer` to serialize a `system` into the required attributes we send to SCC.

**How to review this pull request?**

Since this a feature + refactoring this pull request is best reviewed in `commits`. I tried to first implement the new behavior (serializer_ and continued to first update the existing tests and made sure the current implementation is still green on the changed tests. Afterwards exchanged the behavior of the business logic.

Check for the new attributes `system > created_at` and `system > products > product > activated_at`:

- Run a catchall `tcp server` with: `nc -l 3000`
- Set your `host` variable in `config/rmt.local.yml` to `http://localhost:3000`
- Make sure you have a system which needs to be update
- Run `bin/rmt-cli systems scc-sync` and check the output from `nc`: I needs to include both attributes!


