### PR TITLE
sll-release cannot be installed because rhel-release is protected on rhel9.

### DIFF
--- a/public/tools/rmt-client-setup-res
+++ b/public/tools/rmt-client-setup-res
@@ -103,6 +103,11 @@ if [ -f /usr/share/redhat-release ]; then
    rm -f /usr/share/redhat-release;
 fi
 
+# on RHEL9 (not RHEL8) redhat-release is protected and cannot be updated to sll-release
+if [ -f /etc/dnf/protected.d/redhat-release.conf ]; then
+    rm /etc/dnf/protected.d/redhat-release.conf;
+fi
+
 if [ ! -x $SUSECONNECT ]; then
     echo "Downloading SUSEConnect"
 

--- a/public/tools/rmt-client-setup-res
+++ b/public/tools/rmt-client-setup-res
@@ -105,7 +105,7 @@ fi
 
 # on RHEL9 (not RHEL8) redhat-release is protected and cannot be updated to sll-release
 if [ -f /etc/dnf/protected.d/redhat-release.conf ]; then
-    rm /etc/dnf/protected.d/redhat-release.conf;
+    rm -f /etc/dnf/protected.d/redhat-release.conf;
 fi
 
 if [ ! -x $SUSECONNECT ]; then


### PR DESCRIPTION
## Description

On RHEL9 rhel-release is protected, so it cannot be updated to sll-release.
This patch fixes this problem.

## Change Type

*Please select the correct option.*

- [ x ] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [ ] I have verified that my code follows RMT's coding standards with `rubocop`.
- [ x ] I have reviewed my own code and believe that it's ready for an external review.
- [ x ] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ x ] RMT's test coverage remains at 100%.
- [ x ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.
         Change is trivial no need to document it in changelog.
## Other Notes

Please use this space to provide notes or thoughts to the team, such as tips on how to review/demo your changes.
