### PR TITLE
set suseconnect.timers for sll version >= 9

### DIFF
--- a/public/tools/rmt-client-setup-res
+++ b/public/tools/rmt-client-setup-res
@@ -23,7 +23,7 @@ function usage()
 
   Usage: $0 <registration URL> [--regcert <url>] [--regdata <filename>] [--de-register]
   Usage: $0 --host <hostname of the RMT server> [--regcert <url>] [--regdata <filename>] [--de-register]
-  Usage: $0 --host <hostname of the RMT server> [--fingerprint <fingerprint of server cert>] [--yes] [--regdata <filename>] [--de-register]
+  Usage: $0 --host <hostname of the RMT server> [--fingerprint <fingerprint of server cert>] [--regdata <filename>] [--de-register]
          configures a SLE client to register against a different registration server
 
   Example: $0 https://rmt.example.com/
@@ -37,7 +37,6 @@ EOT
 # We need only REGURL and RMTNAME, all other parameters are just passed to rmt-client-setup script
 REGURL=""
 RMTNAME=""
-AUTOACCEPT=""
 
 while true ; do
     case "$1" in
@@ -49,7 +48,6 @@ while true ; do
              REGURL="http://${RMTNAME}";
              shift;;
         --de-register) DE_REGISTER="Y";;
-        --yes) AUTOACCEPT="--assumeyes";;
         "") break ;;
         -h|--help) usage;;
         https://*) RMTNAME=${1:8};
@@ -128,5 +126,8 @@ fi
 $CURL -s -S $REGURL/tools/rmt-client-setup --output rmt-client-setup
 echo "Running rmt-client-setup $PARAMS"
 sh rmt-client-setup $PARAMS
-systemctl start suseconnect-keepalive.timer
-systemctl enable suseconnect-keepalive.timer
+
+if [[ ${SLL_version} > 8 ]]; then 
+    systemctl start suseconnect-keepalive.timer
+    systemctl enable suseconnect-keepalive.timer
+fi

--- a/public/tools/rmt-client-setup-res
+++ b/public/tools/rmt-client-setup-res
@@ -117,8 +117,8 @@ if [ ! -x $SUSECONNECT ]; then
 
     $DNF config-manager --add-repo ${REGURL}/repo/SUSE/Updates/${SLL_name}/${SLL_version}/x86_64/update
     $DNF config-manager --add-repo ${REGURL}/repo/SUSE/Updates/${SLL_name}-AS/${SLL_version}/x86_64/update
-    $DNF install ${AUTOACCEPT} --allowerasing ${SLL_release_package}
-    $DNF install ${AUTOACCEPT} SUSEConnect librepo
+    $DNF install --allowerasing ${SLL_release_package}
+    $DNF install SUSEConnect librepo
     $DNF config-manager --set-disabled "${RMTNAME}_repo_SUSE_Updates_${SLL_name}_${SLL_version}_x86_64_update"
     $DNF config-manager --set-disabled "${RMTNAME}_repo_SUSE_Updates_${SLL_name}-AS_${SLL_version}_x86_64_update"
 fi

--- a/public/tools/rmt-client-setup-res
+++ b/public/tools/rmt-client-setup-res
@@ -95,7 +95,8 @@ echo "Importing repomd.xml.key"
 $RPM --import ${REGURL}/repo/SUSE/Updates/${SLL_name}/${SLL_version}/x86_64/update/repodata/repomd.xml.key
 
 echo "Disabling all repositories"
-sed -i 's/^enabled=1/enabled=0/' /etc/yum.repos.d/*                                                                  
+dnf config-manager --disable $(dnf repolist -q | awk '{ print $1 }' | grep -v repo)
+#sed -i 's/^enabled=1/enabled=0/' /etc/yum.repos.d/*           
 
 # on Centos /usr/share/redhat-release is a file, on RHEL and RES it is a directory
 # so this is CentOS only workaround
@@ -127,3 +128,5 @@ fi
 $CURL -s -S $REGURL/tools/rmt-client-setup --output rmt-client-setup
 echo "Running rmt-client-setup $PARAMS"
 sh rmt-client-setup $PARAMS
+systemctl start suseconnect-keepalive.timer
+systemctl enable suseconnect-keepalive.timer


### PR DESCRIPTION
## Description

Please describe your change and provide as much context as possible.

add suseconnect.timer for sll9 and higher.
remove --yes switch, because it is not supported with rmt-client-setup script.
Script fails with --yes, so I guess noone use it. 
I consider these changes trivial, so I do not document them in changes file.

Fixes # (issue)

## Change Type

*Please select the correct option.*

- [ x ] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [ ] I have verified that my code follows RMT's coding standards with `rubocop`.
- [ x ] I have reviewed my own code and believe that it's ready for an external review.
- [ x ] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ x ] RMT's test coverage remains at 100%.
- [ x ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.
         changes are trivial, no need to document them in rmt-server.changes

## Other Notes

Please use this space to provide notes or thoughts to the team, such as tips on how to review/demo your changes.
