### PR TITLE
Update the last_seen_at column on service refresh

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,10 +9,14 @@ class ApplicationController < ActionController::API
 
   protected
 
-  def authenticate_system
+  def authenticate_system(skip_on_duplicated: false)
     authenticate_or_request_with_http_basic('RMT API') do |login, password|
       @systems = System.get_by_credentials(login, password)
       if @systems.present?
+        # Return now if we just detected duplicates and we were told to skip on
+        # this situation.
+        return true if skip_on_duplicated && @systems.size > 1
+
         @system = find_system_by_token_header(@systems)
 
         # If SYSTEM_TOKEN_HEADER is present, RMT assumes the client uses a SUSEConnect version

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -8,6 +8,20 @@ class ServicesController < ApplicationController
 
   before_action :authenticate_system, only: %w[legacy_service]
 
+  # The #show method was historically not being put behind an authentication
+  # wall, but we have detected that Zypper follows the HTTP Basic authentication
+  # mechanism whenever requested (even in this case). Thus, we can try to
+  # authenticate requests on this method for Zypper so we have a better picture
+  # which systems are still being active (even if not using SUSEConnect).
+  before_action only: %w[show] do
+    ua = request.headers['HTTP_USER_AGENT']
+
+    # Zypper will never provide the `system_token` credentials for the system.
+    # Hence, if there are duplicates, we will not be able to deterministically
+    # tell which system is to be updated. Just skip it altogether on this case.
+    authenticate_system(skip_on_duplicated: true) if ua && ua.downcase.starts_with?('zypp')
+  end
+
   ZYPPER_SERVICE_TTL = 86400
 
   def show


### PR DESCRIPTION
## Description

Some systems might not use SUSEConnect ever again but still be active. Before this commit, we only assumed that systems using SUSEConnect from time to time were active, and we made sure about this with the optional service that runs `SUSEConnect --keepalive`.

That being said, refreshing services from zypper also contact RMT, and that's another point where `last_seen_at` can be updated as well. However, this was not going through the existing authentication workflow, and thus we could not figure out the system performing the action. But, as it turns out, Zypper will actually be able to follow the mechanism even if we add it now. This commit only adds this for Zypper, since we know that it already works and we want to keep backwards compatibility.

- [Trello card](https://trello.com/c/e5YiTC1A/2610-uras-rmt-to-update-lastseenat-on-service-refresh)

## How to test

1. Set up a local RMT and a client (make sure that the SUSEConnect installed on the client knows how to handle `system_token`).
2. Make sure that the client is registered and that it has some services (i.e. `ls /etc/zypp/services.d/` has multiple files and the `url` in them point to your local RMT installation).
3. Run `zypper refs --force` (or `zypper ref -s --force`) on the client (I have tried with the zypper on SLES12 SP3 and on SLES15 SP3, but go wild 😉 ).
4. Run `./bin/rmt-cli systems list` and notice that the `last_seen_at` attribute has been updated (notice that this column is only updated every 3 minutes, though)
5. Create a clone out of the client you were using and make sure that RMT has detected it as such (i.e. check a duplicated output for `./bin/rmt-cli systems list`)
6. Make sure that from now on you can no longer update the `last_seen_at` column with this method (we cannot guarantee which system is to be updated anymore).