### PR TITLE
Do not retry to load non-existing files in "rmt-cli import repos"

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -188,7 +188,7 @@ Lint/UnreachableLoop:
 # Offense count: 3
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 175
+  Max: 177
 
 # Offense count: 1
 # Configuration parameters: IgnoredMethods.

--- a/lib/rmt/downloader.rb
+++ b/lib/rmt/downloader.rb
@@ -235,6 +235,7 @@ class RMT::Downloader
 
     if URI(uri).scheme == 'file' && !File.exist?(uri.path)
       e = RMT::Downloader::Exception.new(_('%{file} - File does not exist') % { file: file.remote_path })
+      # Similar to http download, set 404 when file is not found, to skip retries
       e.http_code = 404
       raise e
     end

--- a/lib/rmt/downloader.rb
+++ b/lib/rmt/downloader.rb
@@ -234,7 +234,9 @@ class RMT::Downloader
     uri.query = @auth_token if (@auth_token && uri.scheme != 'file')
 
     if URI(uri).scheme == 'file' && !File.exist?(uri.path)
-      raise RMT::Downloader::Exception.new(_('%{file} - File does not exist') % { file: file.remote_path })
+      e = RMT::Downloader::Exception.new(_('%{file} - File does not exist') % { file: file.remote_path })
+      e.http_code = 404
+      raise e
     end
 
     uri.to_s

--- a/lib/rmt/downloader/exception.rb
+++ b/lib/rmt/downloader/exception.rb
@@ -1,5 +1,5 @@
 class RMT::Downloader::Exception < RuntimeError
-  attr_reader :http_code, :response
+  attr_accessor :http_code, :response
 
   def initialize(message, response: nil)
     @response = response

--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -3,6 +3,7 @@ Fri Nov 11 17:11:56 UTC 2022 - Thomas Schmidt <tschmidt@suse.com>
 
 - Release version 2.10:
   - Add option to turn off system token support (bsc#1205089)
+  - Do not retry to import non-existing files in air-gapped mode (bsc#1204769)
 
 -------------------------------------------------------------------
 Tue Nov  8 10:30:45 UTC 2022 - Zuzana Petrova <zpetrova@suse.com>

--- a/spec/lib/rmt/downloader_spec.rb
+++ b/spec/lib/rmt/downloader_spec.rb
@@ -353,10 +353,11 @@ RSpec.describe RMT::Downloader do
 
       it 'raises and exception' do
         expect { downloader.download_multi([repomd_xml_file]) }
-          .to raise_error(
-            RMT::Downloader::Exception,
-            %r{/repodata/repomd.xml - File does not exist}
-          )
+          .to raise_error { |error|
+                expect(error).to be_a(RMT::Downloader::Exception)
+                expect(error.message).to match(%r{/repodata/repomd.xml - File does not exist})
+                expect(error.http_code).to eq(404)
+              }
       end
     end
   end


### PR DESCRIPTION
This affected the .license directory that always gets tried to load, but doesn't exist for many repos.

Reproduce by following https://documentation.suse.com/sles/15-SP1/html/SLES-all/cha-rmt-mirroring.html#sec-rmt-mirroring-export-import
and see .license directories immediately marked with: No license directory found for repository ...