### PR TITLE
Instance id as system token

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,8 +22,7 @@ class ApplicationController < ActionController::API
         # If SYSTEM_TOKEN_HEADER is present, RMT assumes the client uses a SUSEConnect version
         # that supports this feature. In this case, refresh the token and include it in the response.
         if system_tokens_enabled? && request.headers.key?(SYSTEM_TOKEN_HEADER)
-          @system.update(last_seen_at: Time.zone.now, system_token: SecureRandom.uuid) unless @system.proxy_byos
-          @system.update(last_seen_at: Time.zone.now) if @system.proxy_byos
+          @system.update(last_seen_at: Time.zone.now, system_token: SecureRandom.uuid)
           headers[SYSTEM_TOKEN_HEADER] = @system.system_token
         # only update last_seen_at each 3 minutes,
         # so that a system that calls SCC every second doesn't write + lock the database row
@@ -56,10 +55,7 @@ class ApplicationController < ActionController::API
     return nil if systems.blank?
 
     # 1st case
-    # check if BYOS systems have system_token
-    # as those will not have the token in the header
-    byos_system_with_system_token = systems.find{|system| system.proxy_byos && system.system_token }
-    unless request.headers.key?(SYSTEM_TOKEN_HEADER) || !byos_system_with_system_token.nil?
+    unless request.headers.key?(SYSTEM_TOKEN_HEADER)
       logger.info _('System with login \"%{login}\" authenticated without token header') %
         { login: systems.first.login }
       return systems.first

--- a/engines/instance_verification/lib/instance_verification/providers/example.rb
+++ b/engines/instance_verification/lib/instance_verification/providers/example.rb
@@ -25,4 +25,8 @@ class InstanceVerification::Providers::Example < InstanceVerification::ProviderB
 
     return '6789_SUSE_SAP' if @product_hash[:identifier].casecmp('sles_sap').zero?
   end
+
+  def parse_instance_data(_instance_data)
+    return {'instance_data' => 'parsed_instance_data'}
+  end
 end

--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -29,10 +29,11 @@ NET_HTTP_ERRORS = [
 module SccProxy
   class << self
 
-    def headers(auth, params)
+    def headers(auth, params, logger)
       if params && params.class != String
         @instance_id = get_instance_id(params, logger)
       else
+        # if it is not JSON, it is the system_token already
         @instance_id = params
       end
 
@@ -44,10 +45,7 @@ module SccProxy
       }
     end
 
-    def get_instance_id(params)
-      # if it is not JSON, it is the system_token already
-      return params if params.class == String
-
+    def get_instance_id(params, logger)
       verification_provider = InstanceVerification.provider.new(
         logger,
         nil,
@@ -64,8 +62,8 @@ module SccProxy
       iid[instance_id_key]
     end
 
-    def prepare_scc_announce_request(uri_path, auth, params)
-      scc_request = Net::HTTP::Post.new(uri_path, headers(auth, params))
+    def prepare_scc_announce_request(uri_path, auth, params, logger)
+      scc_request = Net::HTTP::Post.new(uri_path, headers(auth, params, logger))
       hw_info_keys = %i[cpus sockets hypervisor arch uuid cloud_provider]
       hw_info = params['hwinfo'].symbolize_keys.slice(*hw_info_keys)
       scc_request.body = {
@@ -76,43 +74,44 @@ module SccProxy
       scc_request
     end
 
-    def prepare_scc_request(uri_path, product, auth, token, email, system_token)
-      scc_request = Net::HTTP::Post.new(uri_path, headers(auth, system_token))
+    def prepare_scc_request(uri_path, product, auth, token, email, system_token, logger)
+      scc_request = Net::HTTP::Post.new(uri_path, headers(auth, nil, logger))
       scc_request.body = {
         token: token,
         identifier: product.identifier,
         version: product.version,
         arch: product.arch,
         release_type: product.release_type,
-        email: email || nil
+        email: email || nil,
+        byos: system_token
       }.to_json
       scc_request
     end
 
-    def announce_system_scc(auth, params)
+    def announce_system_scc(auth, params, logger)
       uri = URI.parse(ANNOUNCE_URL)
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true
-      scc_request = prepare_scc_announce_request(uri.path, auth, params)
+      scc_request = prepare_scc_announce_request(uri.path, auth, params, logger)
       response = http.request(scc_request)
       response.error! unless response.code_type == Net::HTTPCreated
 
       JSON.parse(response.body)
     end
 
-    def scc_activate_product(product, auth, token, email, system_token)
+    def scc_activate_product(product, auth, token, email, system_token, logger)
       uri = URI.parse(ACTIVATE_PRODUCT_URL)
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true
-      scc_request = prepare_scc_request(uri.path, product, auth, token, email, system_token)
+      scc_request = prepare_scc_request(uri.path, product, auth, token, email, system_token, logger)
       http.request(scc_request)
     end
 
-    def deactivate_product_scc(auth, product, params)
+    def deactivate_product_scc(auth, product, params, logger)
       uri = URI.parse(DEREGISTER_PRODUCT_URL)
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true
-      scc_request = Net::HTTP::Delete.new(uri.path, headers(auth, params))
+      scc_request = Net::HTTP::Delete.new(uri.path, headers(auth, params, logger))
       scc_request.body = {
         identifier: product.identifier,
         version: product.version,
@@ -121,11 +120,11 @@ module SccProxy
       http.request(scc_request)
     end
 
-    def deregister_system_scc(auth, params)
+    def deregister_system_scc(auth, params, logger)
       uri = URI.parse(DEREGISTER_SYSTEM_URL)
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true
-      scc_request = Net::HTTP::Delete.new(uri.path, headers(auth))
+      scc_request = Net::HTTP::Delete.new(uri.path, headers(auth, params, logger))
       http.request(scc_request)
     end
 
@@ -138,12 +137,12 @@ module SccProxy
 
     # rubocop:disable Metrics/CyclomaticComplexity
     # rubocop:disable Metrics/PerceivedComplexity
-    def scc_check_subscription_expiration(headers, login, logger)
+    def scc_check_subscription_expiration(headers, login, params, logger)
       auth = headers['HTTP_AUTHORIZATION'] if headers.include?('HTTP_AUTHORIZATION')
       uri = URI.parse(SYSTEMS_ACTIVATIONS_URL)
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true
-      scc_request = Net::HTTP::Get.new(uri.path, headers(auth))
+      scc_request = Net::HTTP::Get.new(uri.path, headers(auth, params, logger))
       response = http.request(scc_request)
       unless response.code_type == Net::HTTPOK
         logger.info "Could not get the system (#{login}) activations, error: #{response.message} #{response.code}"
@@ -208,7 +207,7 @@ module SccProxy
             # standard announce case
             @system = System.create!(hostname: params[:hostname], hw_info: HwInfo.new(hw_info_params))
           else
-            response = SccProxy.announce_system_scc(auth_header, request.request_parameters)
+            response = SccProxy.announce_system_scc(auth_header, request.request_parameters, logger)
             @system = System.create!(
               login: response['login'],
               password: response['password'],
@@ -249,7 +248,16 @@ module SccProxy
           logger.info "Activating product #{@product.product_string} to SCC"
           auth = request.headers['HTTP_AUTHORIZATION']
           if @system.proxy_byos
-            response = SccProxy.scc_activate_product(@product, auth, params[:token], params[:email], nil)
+            iid = @system.hw_info.instance_data.match(%r{<document>(.*?)</document>}m)
+            iid = iid.captures
+            instance_id_keys = {
+              'Amazon': 'instanceId',
+              'Google': 'instance_id',
+              'Microsoft': 'vmId'
+            }
+            iid_key = instance_id_keys[@system.hw_info.cloud_provider]
+            iid  = JSON.parse(iid[0])[iid_key]
+            response = SccProxy.scc_activate_product(@product, auth, params[:token], params[:email], iid, logger)
             unless response.code_type == Net::HTTPCreated
               error = JSON.parse(response.body)
               logger.info "Could not activate #{@product.product_string}, error: #{error['error']} #{response.code}"
@@ -270,7 +278,7 @@ module SccProxy
         def scc_deactivate_product
           auth = request.headers['HTTP_AUTHORIZATION']
           if @system.proxy_byos && @product[:product_type] != 'base'
-            response = SccProxy.deactivate_product_scc(auth, @product, request.request_parameters)
+            response = SccProxy.deactivate_product_scc(auth, @product, request.request_parameters, logger)
             unless response.code_type == Net::HTTPOK
               error = JSON.parse(response.body)
               error['error'] = SccProxy.parse_error(error['error'], params[:token], params[:email]) if error['error'].include? 'json'
@@ -290,7 +298,7 @@ module SccProxy
         def scc_deregistration
           if @system.proxy_byos
             auth = request.headers['HTTP_AUTHORIZATION']
-            response = SccProxy.deregister_system_scc(auth, @system.system_token)
+            response = SccProxy.deregister_system_scc(auth, @system.system_token, logger)
             unless response.code_type == Net::HTTPNoContent
               error = JSON.parse(response.body)
               logger.info "Could not de-activate system #{@system.login}, error: #{error['error']} #{response.code}"

--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -70,7 +70,8 @@ module SccProxy
       hw_info = params['hwinfo'].symbolize_keys.slice(*hw_info_keys)
       scc_request.body = {
         hostname: params['hostname'],
-        hwinfo: hw_info
+        hwinfo: hw_info,
+        byos: @instance_id
       }.to_json
       scc_request
     end

--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -35,6 +35,8 @@ INSTANCE_ID_KEYS = {
 module SccProxy
   class << self
 
+    attr_accessor :instance_id
+
     def headers(auth, params, logger)
       if params && params.class != String
         @instance_id = get_instance_id(params, logger)
@@ -210,6 +212,7 @@ module SccProxy
           else
             response = SccProxy.announce_system_scc(auth_header, request.request_parameters, logger)
             @system = System.create!(
+              system_token: SccProxy.instance_id,
               login: response['login'],
               password: response['password'],
               hostname: params[:hostname],

--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -25,6 +25,12 @@ NET_HTTP_ERRORS = [
   Net::HTTPRetriableError
 ].freeze
 
+INSTANCE_ID_KEYS = {
+  'Amazon': 'instanceId',
+  'Google': 'instance_id',
+  'Microsoft': 'vmId'
+}.freeze
+
 # rubocop:disable Metrics/ModuleLength
 module SccProxy
   class << self
@@ -52,12 +58,7 @@ module SccProxy
         nil,
         nil,
       )
-      instance_id_keys = {
-        'Amazon': 'instanceId',
-        'Google': 'instance_id',
-        'Microsoft': 'vmId'
-      }
-      instance_id_key = instance_id_keys[params['cloud_provider']]
+      instance_id_key = INSTANCE_ID_KEYS[params['cloud_provider']]
       iid = verification_provider.parse_instance_data(params['instance_data'])
       iid[instance_id_key]
     end
@@ -250,12 +251,7 @@ module SccProxy
           if @system.proxy_byos
             iid = @system.hw_info.instance_data.match(%r{<document>(.*?)</document>}m)
             iid = iid.captures
-            instance_id_keys = {
-              'Amazon': 'instanceId',
-              'Google': 'instance_id',
-              'Microsoft': 'vmId'
-            }
-            iid_key = instance_id_keys[@system.hw_info.cloud_provider]
+            iid_key = INSTANCE_ID_KEYS[@system.hw_info.cloud_provider]
             iid  = JSON.parse(iid[0])[iid_key]
             response = SccProxy.scc_activate_product(@product, auth, params[:token], params[:email], iid, logger)
             unless response.code_type == Net::HTTPCreated

--- a/engines/scc_proxy/spec/requests/api/connect/v3/systems/products_controller_spec.rb
+++ b/engines/scc_proxy/spec/requests/api/connect/v3/systems/products_controller_spec.rb
@@ -33,7 +33,7 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
 
 
     context 'when system has hw_info' do
-      let(:instance_data) { 'dummy_instance_data' }
+      let(:instance_data) { '<document>{"instanceId": "dummy_instance_data"}</document>' }
       let(:system) { FactoryBot.create(:system, :with_hw_info, instance_data: instance_data) }
       let(:serialized_service_json) do
         V3::ServiceSerializer.new(

--- a/engines/scc_proxy/spec/requests/api/connect/v3/systems/products_controller_spec.rb
+++ b/engines/scc_proxy/spec/requests/api/connect/v3/systems/products_controller_spec.rb
@@ -34,6 +34,7 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
 
     context 'when system has hw_info' do
       let(:instance_data) { '<document>{"instanceId": "dummy_instance_data"}</document>' }
+      let(:new_system_token) { 'BBBBBBBB-BBBB-4BBB-9BBB-BBBBBBBBBBBB' }
       let(:system) { FactoryBot.create(:system, :with_hw_info, instance_data: instance_data) }
       let(:serialized_service_json) do
         V3::ServiceSerializer.new(
@@ -50,7 +51,10 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
       end
 
       context 'when system is connected to SCC' do
-        let(:system) { FactoryBot.create(:system, :byos, :with_hw_info, instance_data: instance_data) }
+        let(:system) do
+          FactoryBot.create(:system, :byos, :with_hw_info, instance_data: instance_data,
+            system_token: new_system_token)
+        end
         let(:scc_activate_url) { 'https://scc.suse.com/connect/systems/products' }
         let(:subscription_response) do
           {
@@ -92,8 +96,6 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
         end
 
         before do
-          allow(InstanceVerification::Providers::Example).to receive(:new)
-              .with(be_a(ActiveSupport::Logger), be_a(ActionDispatch::Request), payload, instance_data).and_return(plugin_double)
           allow(plugin_double).to(
             receive(:instance_valid?)
               .and_raise(InstanceVerification::Exception, 'Custom plugin error')
@@ -131,6 +133,58 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
             data = JSON.parse(response.body)
             expect(data['error']).to include('No product found on SCC')
             expect(data['error']).not_to include('json api')
+          end
+        end
+
+        context 'with different system_tokens' do
+          let(:system2) do
+            FactoryBot.create(:system, :byos, :with_hw_info, instance_data: instance_data,
+              system_token: 'foo')
+          end
+          before do
+            allow(System).to receive(:get_by_credentials).and_return([system, system2])
+            allow(plugin_double).to(
+              receive(:instance_valid?)
+                .and_raise(InstanceVerification::Exception, 'Custom plugin error')
+            )
+            stub_request(:post, scc_activate_url)
+              .to_return(
+                status: 201,
+                body: '{"id": "bar"}',
+                headers: {}
+              )
+            post url, params: payload_byos, headers: headers
+          end
+
+          it 'renders service JSON' do
+            expect(response.body).to eq(serialized_service_json)
+          end
+        end
+
+        context 'with duplicated system_tokens' do
+          let(:system2) do
+            FactoryBot.create(:system, :byos, :with_hw_info, instance_data: instance_data,
+              system_token: 'foo')
+          end
+          before do
+            system2 = system
+            system2.save!
+            allow(System).to receive(:get_by_credentials).and_return([system, system2])
+            allow(plugin_double).to(
+              receive(:instance_valid?)
+                .and_raise(InstanceVerification::Exception, 'Custom plugin error')
+            )
+            stub_request(:post, scc_activate_url)
+              .to_return(
+                status: 201,
+                body: '{"id": "bar"}',
+                headers: {}
+              )
+            post url, params: payload_byos, headers: headers
+          end
+
+          it 'renders service JSON' do
+            expect(response.body).to eq(serialized_service_json)
           end
         end
       end

--- a/engines/strict_authentication/lib/strict_authentication/engine.rb
+++ b/engines/strict_authentication/lib/strict_authentication/engine.rb
@@ -15,7 +15,14 @@ module StrictAuthentication
         prepend_before_action :authenticate_system
 
         def verify_service_access
-          @system.services.find(params[:id])
+          service = Service.find(params[:id])
+          activation = @systems.includes(activations: %i[service]).map(&:activations).flatten
+                         .select { |a| a.service == service }
+
+          raise ActiveRecord::RecordNotFound unless activation.length > 0
+
+          system_id = activation[0].system_id
+          @system = System.find(system_id)
         rescue ActiveRecord::RecordNotFound
           render plain: 'Product is not registered', status: :forbidden
         end

--- a/engines/zypper_auth/lib/zypper_auth/engine.rb
+++ b/engines/zypper_auth/lib/zypper_auth/engine.rb
@@ -29,7 +29,12 @@ module ZypperAuth
     rescue InstanceVerification::Exception => e
       message = ''
       if system.proxy_byos
-        result = SccProxy.scc_check_subscription_expiration(request.headers, system.login, logger) if system.proxy_byos
+        params = {
+          'cloud_provider' => system.hw_info.cloud_provider,
+          'instance_data' => instance_data
+        }
+
+        result = SccProxy.scc_check_subscription_expiration(request.headers, system.login, params, logger)
         if result[:is_active]
           InstanceVerification.update_cache(request.remote_ip, system.login, base_product.id)
           return true

--- a/engines/zypper_auth/spec/requests/strict_authentication/authentication_controller_spec.rb
+++ b/engines/zypper_auth/spec/requests/strict_authentication/authentication_controller_spec.rb
@@ -113,7 +113,7 @@ describe StrictAuthentication::AuthenticationController, type: :request do
             }
           }
         end
-        let(:system_byos) { FactoryBot.create(:system, :byos, :with_activated_product) }
+        let(:system_byos) { FactoryBot.create(:system, :byos, :with_activated_product, :with_hw_info) }
         let(:scc_systems_activations_url) { 'https://scc.suse.com/connect/systems/activations' }
 
         include_context 'auth header', :system_byos, :login, :password


### PR DESCRIPTION
## Description

Add `system_token` handling to `SccProxy` engine for BYOS cloud instances 

## Change Type

*Please select the correct option.*

- [ ] **Bug Fix** (a non-breaking change which fixes an issue)
- [X] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have verified that my code follows RMT's coding standards with `rubocop`.
- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [X] RMT's test coverage remains at 100%.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Other Notes

I had a previous approach without overwriting the method, I think it's better to keep the cases as isolated as possible,
in this case belonging to `SccProxy` engine but if you think it should go in the main `authenticate_system` and there should
not be an overwrite, please let me know

Code has been tested for BYOS and PAYG, both registration succeds 