### PR TITLE
Adding -f to the file move command

### DIFF
--- a/lib/rmt/mirror.rb
+++ b/lib/rmt/mirror.rb
@@ -191,7 +191,7 @@ class RMT::Mirror
 
     FileUtils.remove_entry(old_directory) if Dir.exist?(old_directory)
     FileUtils.mv(destination_dir, old_directory) if Dir.exist?(destination_dir)
-    FileUtils.mv(source_dir, destination_dir, force: '-f')
+    FileUtils.mv(source_dir, destination_dir, force: true)
     FileUtils.chmod(0o755, destination_dir)
   rescue StandardError => e
     raise RMT::Mirror::Exception.new(_('Error while moving directory %{src} to %{dest}: %{error}') % {

--- a/lib/rmt/mirror.rb
+++ b/lib/rmt/mirror.rb
@@ -191,7 +191,7 @@ class RMT::Mirror
 
     FileUtils.remove_entry(old_directory) if Dir.exist?(old_directory)
     FileUtils.mv(destination_dir, old_directory) if Dir.exist?(destination_dir)
-    FileUtils.mv(source_dir, destination_dir)
+    FileUtils.mv(source_dir, destination_dir, force: '-f')
     FileUtils.chmod(0o755, destination_dir)
   rescue StandardError => e
     raise RMT::Mirror::Exception.new(_('Error while moving directory %{src} to %{dest}: %{error}') % {

--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Jan 24 22:03:53 UTC 2023 - Thomas Schmidt <tschmidt@suse.com>
+
+- Adding -f to the file move command when moving the mirrored directory to its final location (bsc#1203171) 
+
+-------------------------------------------------------------------
 Wed Dec 21 14:07:21 UTC 2022 - Thomas Schmidt <tschmidt@suse.com>
 
 - Fix %post install of pubcloud subpackage reload of nginx (bsc#1206593)

--- a/spec/lib/rmt/mirror_spec.rb
+++ b/spec/lib/rmt/mirror_spec.rb
@@ -702,7 +702,7 @@ RSpec.describe RMT::Mirror do
 
       it 'removes it, moves src to dst and sets permissions' do
         expect(FileUtils).to receive(:remove_entry).with(old_dir)
-        expect(FileUtils).to receive(:mv).with(source_dir, destination_dir, { force: '-f' })
+        expect(FileUtils).to receive(:mv).with(source_dir, destination_dir, { force: true })
         expect(FileUtils).to receive(:chmod).with(0o755, destination_dir)
         replace_directory
       end
@@ -716,7 +716,7 @@ RSpec.describe RMT::Mirror do
 
       it 'renames it as .old, moves src to dst and sets permissions' do
         expect(FileUtils).to receive(:mv).with(destination_dir, old_dir)
-        expect(FileUtils).to receive(:mv).with(source_dir, destination_dir, { force: '-f' })
+        expect(FileUtils).to receive(:mv).with(source_dir, destination_dir, { force: true })
         expect(FileUtils).to receive(:chmod).with(0o755, destination_dir)
         replace_directory
       end

--- a/spec/lib/rmt/mirror_spec.rb
+++ b/spec/lib/rmt/mirror_spec.rb
@@ -702,7 +702,7 @@ RSpec.describe RMT::Mirror do
 
       it 'removes it, moves src to dst and sets permissions' do
         expect(FileUtils).to receive(:remove_entry).with(old_dir)
-        expect(FileUtils).to receive(:mv).with(source_dir, destination_dir)
+        expect(FileUtils).to receive(:mv).with(source_dir, destination_dir, { force: '-f' })
         expect(FileUtils).to receive(:chmod).with(0o755, destination_dir)
         replace_directory
       end
@@ -716,7 +716,7 @@ RSpec.describe RMT::Mirror do
 
       it 'renames it as .old, moves src to dst and sets permissions' do
         expect(FileUtils).to receive(:mv).with(destination_dir, old_dir)
-        expect(FileUtils).to receive(:mv).with(source_dir, destination_dir)
+        expect(FileUtils).to receive(:mv).with(source_dir, destination_dir, { force: '-f' })
         expect(FileUtils).to receive(:chmod).with(0o755, destination_dir)
         replace_directory
       end


### PR DESCRIPTION
Adding -f to the file move command when moving the mirrored directory to its final location.

This fixes a problem with some filesystem setups, see bsc#1203171