### PR TITLE
Remove translations from migration logging because it breaks in ruby 3.x

### DIFF
--- a/db/migrate/20200723124836_add_uniqueness_to_downloaded_files_local_path.rb
+++ b/db/migrate/20200723124836_add_uniqueness_to_downloaded_files_local_path.rb
@@ -2,10 +2,10 @@ class AddUniquenessToDownloadedFilesLocalPath < ActiveRecord::Migration[5.2]
   def change
     logger = RMT::Logger.new(STDOUT)
 
-    logger.info(_('Adding index to `downloaded_files.local_path` before querying duplicates...'))
+    logger.info('Adding index to `downloaded_files.local_path` before querying duplicates...')
     add_index :downloaded_files, :local_path, unique: false
 
-    logger.info(_('Removing duplicated records on `downloaded_files.local_path`...'))
+    logger.info('Removing duplicated records on `downloaded_files.local_path`...')
     ActiveRecord::Base.connection.execute(
       <<~SQL
         DELETE df1 FROM downloaded_files AS df1
@@ -20,7 +20,7 @@ class AddUniquenessToDownloadedFilesLocalPath < ActiveRecord::Migration[5.2]
     )
 
     # Add unique index to `local_path`
-    logger.info(_('Adding an unique index to `downloaded_file.local_path`...'))
+    logger.info('Adding an unique index to `downloaded_file.local_path`...')
     remove_index :downloaded_files, name: :index_downloaded_files_on_local_path, if_exists: true
     add_index :downloaded_files, :local_path, unique: true
   end

--- a/db/migrate/20200916104804_make_scc_id_unique.rb
+++ b/db/migrate/20200916104804_make_scc_id_unique.rb
@@ -2,10 +2,10 @@ class MakeSccIdUnique < ActiveRecord::Migration[6.0]
   def change
     logger = RMT::Logger.new(STDOUT)
 
-    logger.info(_('Adding index to `repositories.scc_id` before querying duplicates...'))
+    logger.info('Adding index to `repositories.scc_id` before querying duplicates...')
     add_index :repositories, :scc_id, unique: false
 
-    logger.info(_('Removing duplicated records on `repositories.scc_id`...'))
+    logger.info('Removing duplicated records on `repositories.scc_id`...')
     ActiveRecord::Base.connection.execute(
       <<~SQL
       UPDATE repositories as r1
@@ -21,7 +21,7 @@ class MakeSccIdUnique < ActiveRecord::Migration[6.0]
     )
 
     # Add unique index to `local_path`
-    logger.info(_('Adding an unique index to `repositories.scc_id`...'))
+    logger.info('Adding an unique index to `repositories.scc_id`...')
     remove_index :repositories, name: :index_repositories_on_scc_id, if_exists: true
     add_index :repositories, :scc_id, unique: true
   end


### PR DESCRIPTION
Our CI is broken due to:
Error: `no implicit conversion of Hash into String`
in: `db/migrate/20200723124836_add_uniqueness_to_downloaded_files_local_path.rb:5`

To fix this I removed the superflous translations using `_()`.

**How to test:**

- Check the code changes!
- Check that ruby 3.x github CI is green
