### PR TITLE
Force https in rmt-client-setup-res script

### DIFF
--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Fri Mar 31 17:10:41 UTC 2023 - Zuzana Petrova <zpetrova@suse.com>
+
+- Force rmt-client-setup-res script to use https (bsc#1209825)
+
+-------------------------------------------------------------------
 Tue Mar 21 09:20:19 UTC 2023 - Thomas Schmidt <tschmidt@suse.com>
 
 - Download repomd.xml.asc before repomd.xml.key, because there are repos that only have repomd.xml.asc

--- a/public/tools/rmt-client-setup-res
+++ b/public/tools/rmt-client-setup-res
@@ -51,7 +51,7 @@ while true ; do
         "") break ;;
         -h|--help) usage;;
         https://*) RMTNAME=${1:8};
-                   REGURL="http://${RMTNAME}";;
+                   REGURL=$1;;
         http://*) REGURL=$1;
                   RMTNAME=${REGURL:7};;
         *) usage "Unknown option $1";;
@@ -123,7 +123,7 @@ if [ ! -x $SUSECONNECT ]; then
     $DNF config-manager --set-disabled "${RMTNAME}_repo_SUSE_Updates_${SLL_name}-AS_${SLL_version}_x86_64_update"
 fi
 
-$CURL -s -S $REGURL/tools/rmt-client-setup --output rmt-client-setup
+$CURL --silent --show-error --insecure $REGURL/tools/rmt-client-setup --output rmt-client-setup
 echo "Running rmt-client-setup $PARAMS"
 sh rmt-client-setup $PARAMS
 


### PR DESCRIPTION
## Description
Always use https in rmt-client-setup-res script

Fixes # (issue)
https://bugzilla.suse.com/show_bug.cgi?id=1209825

## Change Type

*Please select the correct option.*

- [ x] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [ ] I have verified that my code follows RMT's coding standards with `rubocop`. - not written in ruby...
- [ x] I have reviewed my own code and believe that it's ready for an external review.
- [ ] I have provided comments for any hard-to-understand code. - change is simple - no comments.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience. 
- [ x] RMT's test coverage remains at 100%.
- [ x] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Other Notes

Please use this space to provide notes or thoughts to the team, such as tips on how to review/demo your changes.
I've tested the script on SLL9, RES8. 
