### PR TITLE
Release 2.12 - Bump activesupport to fix CVE-2023-28120

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,12 +10,12 @@ gem 'mysql2', '~> 0.5.3'
 
 gem 'nokogiri', '< 1.13' # Locked because of Ruby >= 2.6 dependency
 gem 'thor'
-gem 'activesupport', '~> 6.1.6'
-gem 'actionpack', '~> 6.1.6'
-gem 'actionview', '~> 6.1.6'
-gem 'activemodel', '~> 6.1.6'
-gem 'activerecord', '~> 6.1.6'
-gem 'railties', '~> 6.1.6'
+gem 'activesupport', '~> 6.1.7.3'
+gem 'actionpack', '~> 6.1.7.3'
+gem 'actionview', '~> 6.1.7.3'
+gem 'activemodel', '~> 6.1.7.3'
+gem 'activerecord', '~> 6.1.7.3'
+gem 'railties', '~> 6.1.7.3'
 gem 'repomd_parser', '~> 0.1.4'
 
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -313,12 +313,12 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  actionpack (~> 6.1.6)
-  actionview (~> 6.1.6)
+  actionpack (~> 6.1.7.3)
+  actionview (~> 6.1.7.3)
   active_model_serializers
-  activemodel (~> 6.1.6)
-  activerecord (~> 6.1.6)
-  activesupport (~> 6.1.6)
+  activemodel (~> 6.1.7.3)
+  activerecord (~> 6.1.7.3)
+  activesupport (~> 6.1.7.3)
   awesome_print
   byebug
   config (~> 3.0, >= 2.2.1)
@@ -340,7 +340,7 @@ DEPENDENCIES
   nokogiri (< 1.13)
   public_suffix (< 5)
   puma (~> 5.6.2)
-  railties (~> 6.1.6)
+  railties (~> 6.1.7.3)
   repomd_parser (~> 0.1.4)
   responders
   ronn

--- a/lib/rmt.rb
+++ b/lib/rmt.rb
@@ -1,5 +1,5 @@
 module RMT
-  VERSION ||= '2.11'.freeze
+  VERSION ||= '2.12'.freeze
 
   DEFAULT_USER = '_rmt'.freeze
   DEFAULT_GROUP = 'nginx'.freeze

--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Apr 12 15:27:18 UTC 2023 - Felix Schnizlein <fschnizlein@suse.com>
+
+- Version 2.12
+  * Update translations
+  * Fix CVE-2023-28120: Update active support to fix possible XSS Security Vulnerability
+    in bytesliced strings for html_safe. (bsc#1209507)
+
+-------------------------------------------------------------------
 Fri Mar 31 17:10:41 UTC 2023 - Zuzana Petrova <zpetrova@suse.com>
 
 - Force rmt-client-setup-res script to use https (bsc#1209825)

--- a/package/obs/rmt-server.spec
+++ b/package/obs/rmt-server.spec
@@ -30,7 +30,7 @@
 %define ruby_version          %{rb_default_ruby_suffix}
 
 Name:           rmt-server
-Version:        2.11
+Version:        2.12
 Release:        0
 Summary:        Repository mirroring tool and registration proxy for SCC
 License:        GPL-2.0-or-later


### PR DESCRIPTION
## Description

Activesupport has fixed a XSS in their code base due to missing detected for new string behavior in ruby 3.2. We are actually not affected by this. But to make sure we safe :rocket:

**How to test this code**:
- Grab the branch and make a `make dist`
- Copy the files to your obs repo for RMT and build the package. Make sure everything is fine