### PR TITLE
Append to 1.12: Explicitly mark updated rack for CVE-2023-27530

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,12 +10,12 @@ gem 'mysql2', '~> 0.5.3'
 
 gem 'nokogiri', '< 1.13' # Locked because of Ruby >= 2.6 dependency
 gem 'thor'
-gem 'activesupport', '~> 6.1.7.3'
-gem 'actionpack', '~> 6.1.7.3'
-gem 'actionview', '~> 6.1.7.3'
-gem 'activemodel', '~> 6.1.7.3'
-gem 'activerecord', '~> 6.1.7.3'
-gem 'railties', '~> 6.1.7.3'
+gem 'activesupport', '~> 6.1.7'
+gem 'actionpack', '~> 6.1.7'
+gem 'actionview', '~> 6.1.7'
+gem 'activemodel', '~> 6.1.7'
+gem 'activerecord', '~> 6.1.7'
+gem 'railties', '~> 6.1.7'
 gem 'repomd_parser', '~> 0.1.4'
 
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -313,12 +313,12 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  actionpack (~> 6.1.7.3)
-  actionview (~> 6.1.7.3)
+  actionpack (~> 6.1.7)
+  actionview (~> 6.1.7)
   active_model_serializers
-  activemodel (~> 6.1.7.3)
-  activerecord (~> 6.1.7.3)
-  activesupport (~> 6.1.7.3)
+  activemodel (~> 6.1.7)
+  activerecord (~> 6.1.7)
+  activesupport (~> 6.1.7)
   awesome_print
   byebug
   config (~> 3.0, >= 2.2.1)
@@ -340,7 +340,7 @@ DEPENDENCIES
   nokogiri (< 1.13)
   public_suffix (< 5)
   puma (~> 5.6.2)
-  railties (~> 6.1.7.3)
+  railties (~> 6.1.7)
   repomd_parser (~> 0.1.4)
   responders
   ronn

--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -3,8 +3,9 @@ Wed Apr 12 15:27:18 UTC 2023 - Felix Schnizlein <fschnizlein@suse.com>
 
 - Version 2.12
   * Update translations
-  * Fix CVE-2023-28120: Update active support to fix possible XSS Security Vulnerability
+  * CVE-2023-28120: Update active support to fix possible XSS Security Vulnerability
     in bytesliced strings for html_safe. (bsc#1209507)
+  * CVE-2023-27530: Update rack to mitigate possible DoS in multipart mime parsing (bsc#1209096)
 
 -------------------------------------------------------------------
 Fri Mar 31 17:10:41 UTC 2023 - Zuzana Petrova <zpetrova@suse.com>


### PR DESCRIPTION
... we updated the gem a while ago, now we have an official bug open for this. Here is the paperwork!