### PR TITLE
Automate configuration file setup

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -136,6 +136,11 @@ You can install and run this wizard like this:
   * `rmt-cli mirror`:
     In its default configuration, RMT mirrors its enabled product repositories automatically once every night.
     This command starts this mirroring process manually. Changes made to repository mirroring settings while mirroring is in progress are respected by the mirroring process.
+  
+  * `rmt-cli setup`:
+    Automatically add / edit configuration to start RMT Server.
+    This command triggers interactive cli to update default configuration for Database and SUSE credentials to `etc/rmt.conf` file.
+    It provide to restart RMT process using cli.
 
 When all enabled repositories are fully mirrored, you can register your client systems against RMT by running `SUSEConnect --url https://<RMT hostname>` on the client machine.
 After successful registration the repositories from RMT will be used by `zypper` on the client machine.

--- a/lib/rmt/cli/main.rb
+++ b/lib/rmt/cli/main.rb
@@ -34,6 +34,11 @@ class RMT::CLI::Main < RMT::CLI::Base
     puts RMT::VERSION
   end
 
+  desc 'setup', _('Setup configuration file')
+  def setup
+    RMT::CLI::Setup.new.setup_configuration
+  end
+
   map %w[--version -v] => :version
 
   def self.exit_on_failure?

--- a/lib/rmt/cli/setup.rb
+++ b/lib/rmt/cli/setup.rb
@@ -1,0 +1,189 @@
+require 'yaml'
+class RMT::CLI::Setup < RMT::CLI::Base
+  DEFAULT_CONFIG_PATH = 'config/rmt.yml'.freeze
+  CONFIG_PATH = 'etc/rmt.conf'.freeze
+
+  def initialize
+    super
+    @config = {}
+  end
+
+  desc 'setup_configuration', 'Setup RMT configuration file'
+  def setup_configuration
+    puts "\e[2J\e[f" # clean screen
+
+    puts '---------------------------------------'
+    puts '|  Setting up RMT configuration file  |'
+    puts '---------------------------------------'
+
+    load_configuration
+    update_configuration
+    confirm_save_configuration
+    restart_process
+  end
+
+  private
+
+  # Check whether file exist
+  def file_exist?(file_path)
+    File.exist?(file_path)
+  end
+
+  # Copying file
+  def copy_file(source, destination)
+    FileUtils.mkdir_p(File.dirname(destination))
+    FileUtils.cp(source, destination)
+  rescue StandardError
+    abort('Unable to copy the file')
+  end
+
+  # Load File and return its content
+  def load_file_data(file_path)
+    YAML.load_file(file_path)
+  rescue StandardError
+    abort('Unable to load the file')
+  end
+
+  # Write content to file
+  def write_file(file_path, data, mode: 'w')
+    File.open(file_path, mode) { |f| f.write(data) }
+  rescue StandardError
+    abort('Unable to update the config')
+  end
+
+  # Take input from user
+  def user_input(message, default: nil)
+    print "#{message} "
+    print "(#{default}) " unless default.nil?
+
+    input_value = $stdin.gets.chomp
+    input_value.blank? ? default : input_value
+  end
+
+  # Loading configuration
+  def load_configuration
+    # Copy Default config if config file not exist
+    unless file_exist?(CONFIG_PATH)
+      puts "\nNo #{CONFIG_PATH} file found. Copying default config file from #{DEFAULT_CONFIG_PATH}"
+      copy_file(DEFAULT_CONFIG_PATH, CONFIG_PATH)
+    end
+
+    # Loading config data
+    @config.merge!(load_file_data(CONFIG_PATH))
+  end
+
+  # Set Configuration
+  def update_configuration
+    puts "\n"
+    puts 'Enter development database configuration:'
+    update_database_configuration
+    puts "\n"
+    puts 'Enter test database configuration:'
+    update_database_configuration(env: 'test')
+    puts "\n"
+    puts 'Enter SCC Configuration:'
+    puts 'Note: If unable to get username/password, Contact to `https://myaccount.suse.com/help/login#report-security`'
+    update_scc_configuration
+
+    @config.delete('database') # Removing unwanted key
+  end
+
+  # Show Configuration
+  def show_configuration
+    puts "\n"
+    puts 'Development database configuration:'
+    show_database_configuration
+    puts "\n"
+    puts 'Test database configuration:'
+    show_database_configuration(env: 'test')
+    puts "\n"
+    puts 'SCC Configuration:'
+    show_scc_configuration
+  end
+
+  # Set Database Configuration
+  def update_database_configuration(env: 'development')
+    database = @config["database_#{env}"] || @config['database'] || {}
+    @config["database_#{env}"] = {} if @config["database_#{env}"].nil?
+
+    @config["database_#{env}"]['host'] = user_input(' Database Host: ', default: database['host'])
+    @config["database_#{env}"]['database'] = user_input(' Database Name: ', default: database['database'])
+    @config["database_#{env}"]['username'] = user_input(' Database Username: ', default: database['username'])
+    @config["database_#{env}"]['password'] = user_input(' Database Password: ', default: database['password'])
+    @config["database_#{env}"]['adapter'] = user_input(' Database Adapter: ', default: database['adapter'])
+  end
+
+  # Show Database Configuration
+  def show_database_configuration(env: 'development')
+    database = @config["database_#{env}"] || {}
+    puts " Database Host: #{database['host']}"
+    puts " Database Name: #{database['database']}"
+    puts " Database Username: #{database['username']}"
+    puts " Database Password: #{database['password']}"
+    puts " Database Adapter: #{database['adapter']}"
+  end
+
+  # Set SCC Configuration
+  def update_scc_configuration
+    scc = @config['scc'] || {}
+    scc['host'] = user_input(' SCC Host: ', default: scc['host'])
+    scc['username'] = user_input(' SCC Username: ', default: scc['username'])
+    scc['password'] = user_input(' SCC Password: ', default: scc['password'])
+    scc['sync_systems'] = user_input(' SCC System Sync: ', default: scc['sync_systems'])
+  end
+
+  # Show SCC Configuration
+  def show_scc_configuration
+    scc = @config['scc'] || {}
+    puts " SCC Host: #{scc['host']}"
+    puts " SCC Username: #{scc['username']}"
+    puts " SCC Password: #{scc['password']}"
+    puts " SCC System Sync: #{scc['sync_systems']}"
+  end
+
+  # Show configuration and menu
+  def confirm_save_configuration
+    puts "\n"
+    puts "The following key-value pairs will be written to #{CONFIG_PATH}:"
+
+    show_configuration
+
+    loop do
+      puts "\n"
+      choice = user_input('Do you want to save? (y/n):')
+      case choice
+      when 'y'
+        save_configuration
+        break
+      when 'n'
+        abort('Changes are discarded and Exiting')
+      else
+        warn _('Enter valid option')
+      end
+    end
+  end
+
+  # Save New Configuration to file
+  def save_configuration
+    write_file(CONFIG_PATH, @config.to_yaml)
+    puts "Configuration updated to #{CONFIG_PATH}"
+  end
+
+  # Restarting RMT Process
+  def restart_process
+    puts "\n"
+    loop do
+      restart_input = user_input('RMT process need to restart for new configuration. Do you want to continue. (y/n):')
+      case restart_input
+      when 'y'
+        puts 'RMT process restarting...'
+        system('systemctl restart rmt-server')
+        abort('RMT process restarted')
+      when 'n'
+        abort('Please restart the RMT process manually')
+      else
+        warn _('Enter valid option')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description
Automating the configuration file to run RMT server.

New CLI command `bin/rmt-cli setup` is added to generate/update config file etc/rmt.conf.
User can now add/update the development database, test database and SCC credentials using cli interface.

Fixes #987

## Change Type

*Please select the correct option.*

- [ ] **Bug Fix** (a non-breaking change which fixes an issue)
- [X] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have verified that my code follows RMT's coding standards with `rubocop`.
- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [X] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] RMT's test coverage remains at 100%.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Other Notes

Please use this space to provide notes or thoughts to the team, such as tips on how to review/demo your changes.
