### PR TITLE
Adding setup command for rmt-cli to update database and scc configs [Issue#987]

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -22,6 +22,9 @@ You can install and run this wizard like this:
 
 ## USAGE
 
+  * `rmt-cli setup`:
+    This command is responsibile for creating and updating the user configurations for RMT. If the user has defined configurations previously and wishes to update them, it interactively suggests these previously set values for user to review before updating them.
+
   * `rmt-cli sync`:
     RMT comes with a preconfigured systemd timer to automatically get the latest product and repository data from the SUSE Customer Center over night.
     This command triggers the same synchronization instantly.

--- a/lib/rmt/cli/main.rb
+++ b/lib/rmt/cli/main.rb
@@ -14,6 +14,11 @@ class RMT::CLI::Main < RMT::CLI::Base
   desc 'products', _('List and modify products')
   subcommand 'products', RMT::CLI::Products
 
+  desc 'setup', _('Configure RMT')
+  def setup
+    RMT::CLI::Setup.start
+  end
+
   desc 'repos', _('List and modify repositories')
   subcommand 'repos', RMT::CLI::Repos
 

--- a/lib/rmt/cli/setup.rb
+++ b/lib/rmt/cli/setup.rb
@@ -1,0 +1,128 @@
+class RMT::CLI::Setup < RMT::CLI::Base
+  CONFIG_FILE = '/etc/rmt.conf'.freeze
+  DEVELOPMENT_CONFIG_FILE = './config/rmt.yml'.freeze
+  DB_CONFIG = 'database'.freeze
+  SCC_CONFIG = 'scc'.freeze
+
+  desc 'setup', _('Update user configurations required for RMT setup')
+  def setup
+    puts _('-------- Starting RMT server setup ---------')
+    copy_to_config_file unless File.exist?(CONFIG_FILE)
+    update_config
+    confirm_details_and_save
+  end
+
+  private
+
+  # Copies the development config file to the main config file for RMT
+  def copy_to_config_file
+    puts "\n" + (_('Could not find config at %{config_file}') % { config_file: CONFIG_FILE })
+    puts _('Copying config from %{development_config_file} to %{config_file}') % { development_config_file: DEVELOPMENT_CONFIG_FILE,
+                                                                                   config_file: CONFIG_FILE }
+    begin
+      FileUtils.cp(DEVELOPMENT_CONFIG_FILE, CONFIG_FILE)
+      puts _('Config copied successfully!')
+    rescue StandardError => e
+      puts _('Failed to copy configuration. Error : %{error_message}') % { error_message: e.message }
+      abort _('Aborting.')
+    end
+  end
+
+  # Prompts user to specify new configs or uses previously set config
+  def update_config
+    @config = YAML.load_file(CONFIG_FILE)
+
+    @new_config = {}
+    puts "\n" + _('Please enter the following database configurations: ')
+    @new_config[DB_CONFIG] = {}
+    @new_config[DB_CONFIG]['database'] = input_prompt_generator('database', @config[DB_CONFIG]['database'])
+    @new_config[DB_CONFIG]['username'] = input_prompt_generator('username', @config[DB_CONFIG]['username'])
+    @new_config[DB_CONFIG]['password'] = input_prompt_generator('password', @config[DB_CONFIG]['password'], sensitive_data: true)
+
+    puts "\n\n" + _('Please enter your SCC credentials: ')
+    puts _('NOTE: You can find them in https://scc.suse.com under the Proxies tab.')
+    @new_config[SCC_CONFIG] ||= {}
+    @new_config[SCC_CONFIG]['username'] = input_prompt_generator('username', @config[SCC_CONFIG]['username'])
+    @new_config[SCC_CONFIG]['password'] = input_prompt_generator('password', @config[SCC_CONFIG]['password'], sensitive_data: true)
+  end
+
+  def confirm_details_and_save
+    loop do
+      input = ask("\n\n" + _('Would you like to save the updated configuration? (y/n/exit) : ')).downcase
+
+      case input
+      when 'y'
+        # Merging updated configs with the older config for updation and saving result to CONFIG_FILE
+        @config = @config.deep_merge(@new_config)
+        begin
+          File.write(CONFIG_FILE, @config.to_yaml)
+        rescue StandardError
+          puts _('Failed to save config. Please retry.')
+        end
+        puts _('Successfully updated the configuration!')
+        restart_rmt
+        break
+      when 'n'
+        update_config
+      when 'exit'
+        confirmation = ask(_('You are attempting to exit before saving the configuration. Are you sure? (y/n) : ')).downcase
+        if confirmation == 'y'
+          puts _('Aborted')
+          break
+        elsif confirmation == 'n'
+          next
+        else
+          puts _('Invalid input. Please try again.')
+        end
+      else
+        puts _('Invalid input. Please try again.')
+
+      end
+    end
+
+  end
+
+  # Constructs the prompt message to be displayed to users to fetch config field data
+  # Displays the existing default value to the user, if present
+  # Example => username (Press enter for John ) :
+  def input_prompt_generator(config_field, default_value, sensitive_data: false)
+    prompt = config_field.to_s
+
+    # Show default_value as "*****" for sensitive fields
+    unless default_value.empty?
+      prompt << ' ('
+      prompt << _('Press enter for ')
+      prompt << "#{sensitive_data ? '*****' : default_value} "
+      prompt << ')'
+    end
+    prompt << ' : '
+
+    input = ask(prompt, echo: !sensitive_data)
+    input.empty? ? default_value : input
+  end
+
+  # Restarts the RMT process
+  def restart_rmt
+    loop do
+      puts "\n" + _('RMT must be restarted with the updated configuration.')
+      input = ask(_('Restart RMT automatically? (y/n) : ')).downcase
+      case input
+      when 'y'
+        begin
+          puts _('Restarting RMT server. Please wait.')
+          `systemctl restart rmt-server`
+          puts _('Successfully restarted RMT server.')
+        rescue StandardError => e
+          puts _('Failed to restart RMT server. Error : %{error_message}') % { error_message: e.message }
+        end
+        break
+      when 'n'
+        puts _('Please restart the RMT server manually.')
+        break
+      else
+        puts _('Invalid input. Please try again.')
+      end
+    end
+  end
+
+end


### PR DESCRIPTION


## Description

Adding the "setup" command for the rmt-cli : `rmt-cli setup`

Currently users must manually create or alter the /etc/rmt.conf file to update certain configs like database values and scc credentials. This `rmt-cli setup` command aims to automate this process. 

It performs the following actions:
*  Copies `./config/rmt.yml` to `etc/rmt.conf` file, if `etc/rmt.conf` is not present 
*  Interactively prompts users to provide the database and scc cofigurations. If any configs have been defined previously, it displays the existing value to the user so they can review it before updating it. They can simply hit enter to retain the previous value as is. ( Example => username (Press enter for John ) : )
* Provides the option to restart the RMT server automatically with the updated configurations. Users can chose to manually restart RMT as well. 


Fixes issue  : https://github.com/SUSE/rmt/issues/987

## Change Type

*Please select the correct option.*

- [ ] **Bug Fix** (a non-breaking change which fixes an issue)
- [x] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [x] I have verified that my code follows RMT's coding standards with `rubocop`.
- [x] I have reviewed my own code and believe that it's ready for an external review.
- [x] I have provided comments for any hard-to-understand code.
- [x] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] RMT's test coverage remains at 100%.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Other Notes

Run `bin/rmt-cli setup` command to start the setup.

**Note:**  
If a previously configured value for any config exists, it will be displayed in the prompt to preview. ( Example => username (Press enter for John ) : ) . If you wish to alter it, enter a new value. If you do not wish to alter it,  just hit enter.

