### PR TITLE
Handle missing X-Original-URI header

### DIFF
--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -172,7 +172,7 @@ module SccProxy
       active_products_ids = scc_systems_activations.map { |act| act['service']['product']['id'] if act['status'].casecmp('active').zero? }.flatten
       products = Product.where(id: active_products_ids)
       product_paths = products.map { |prod| prod.repositories.pluck(:local_path) }.flatten
-      active_subscription = product_paths.any? { |path| headers['X-Original-URI'].include?(path) }
+      active_subscription = product_paths.any? { |path| headers['X-Original-URI'].to_s.include?(path) }
       if active_subscription
         { is_active: true }
       else
@@ -186,7 +186,7 @@ module SccProxy
         end
         products = Product.where(id: expired_products_ids)
         product_paths = products.map { |prod| prod.repositories.pluck(:local_path) }.flatten
-        expired_subscription = product_paths.any? { |path| headers['X-Original-URI'].include?(path) }
+        expired_subscription = product_paths.any? { |path| headers['X-Original-URI'].to_s.include?(path) }
         if expired_subscription
           {
             is_active: false,


### PR DESCRIPTION
## Description

In SLE-Micro 5.4 instance in GCE fails to update running the command `transactional-update dup`

One of the issues is header not being present, which IMHO is not the roo/core issue but it needs fixing

When the header is not present, it produces a 500 error due to `undefined include? method for nil class`

This is part of the fix for bsc#1211398


## Change Type

*Please select the correct option.*

- [X] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have verified that my code follows RMT's coding standards with `rubocop`.
- [X] I have reviewed my own code and believe that it's ready for an external review.
- [ ] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [X] RMT's test coverage remains at 100%.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Other Notes

Please use this space to provide notes or thoughts to the team, such as tips on how to review/demo your changes.
