### PR TITLE
Command for cleaning stales packages

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -103,8 +103,8 @@ You can install and run this wizard like this:
     `rmt-cli products show SLES/15/x86_64`
 
   * `rmt-cli clean packages`:
-    Removes locally mirrored stale files and their database entries.
-    A file is considered *stale* if it matches all the following characteristics:
+    Removes locally mirrored dangling files and their database entries.
+    A file is considered *dangling* if it matches all the following characteristics:
 
       * It exists in a repository directory with primary and deltainfo metadata files;
       * It is not referenced in those metadata files;

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -104,15 +104,15 @@ You can install and run this wizard like this:
 
   * `rmt-cli clean packages`:
     Removes locally mirrored dangling files and their database entries.
-    A file is considered *dangling* if it matches all the following characteristics:
+    A file is considered to be *dangling* if it matches all the following characteristics:
 
-      * It exists in a repository directory with primary and deltainfo metadata files;
-      * It is not referenced in those metadata files;
+      * It exists in a repository directory with primary and deltainfo metadata `repomd.xml` files;
+      * It is no longer referenced to in those metadata files;
       * It is at least *2-days-old*.
 
     Use the `--dry-run` flag to generate a report of all files without actually cleaning files or database entries.
 
-    Use the `--verbose` flag to print information detailed information of each cleaned file.
+    Use the `--verbose` flag to print detailed information of each cleaned file.
 
     Use the `--non-interactive` flag to skip confirmation before proceeding with the cleaning process.
 

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -96,11 +96,25 @@ You can install and run this wizard like this:
     `rmt-cli products disable SLES/15/x86_64 1743`
 
   * `rmt-cli products show <id | string>`:
-  	Displays product with all its repositories and their attributes.
+    Displays product with all its repositories and their attributes.
 
-  	Examples:
+    Examples:
 
-  	`rmt-cli products show SLES/15/x86_64`
+    `rmt-cli products show SLES/15/x86_64`
+
+  * `rmt-cli clean packages`:
+    Removes locally mirrored stale files and their database entries.
+    A file is considered *stale* if it matches all the following characteristics:
+
+      * It exists in a repository directory with primary and deltainfo metadata files;
+      * It is not referenced in those metadata files;
+      * It is at least *2-days-old*.
+
+    Use the `--dry-run` flag to generate a report of all files without actually cleaning files or database entries.
+
+    Use the `--verbose` flag to print information detailed information of each cleaned file.
+
+    Use the `--non-interactive` flag to skip confirmation before proceeding with the cleaning process.
 
   * `rmt-cli repos clean [--no-confirmation]`:
     Removes locally mirrored files of repositories which are not marked to be mirrored.

--- a/lib/rmt.rb
+++ b/lib/rmt.rb
@@ -1,5 +1,5 @@
 module RMT
-  VERSION ||= '2.13'.freeze
+  VERSION ||= '2.14'.freeze
 
   DEFAULT_USER = '_rmt'.freeze
   DEFAULT_GROUP = 'nginx'.freeze

--- a/lib/rmt/cli/clean.rb
+++ b/lib/rmt/cli/clean.rb
@@ -108,7 +108,7 @@ class RMT::CLI::Clean < RMT::CLI::Base
       next nil if stale_packages.empty?
 
       [repo_base_dir, stale_packages]
-    end.reject(&:nil?)
+    end.compact_blank
   end
 
   def stale_packages_list(repo_base_dir, repomd_file)
@@ -139,7 +139,7 @@ class RMT::CLI::Clean < RMT::CLI::Base
 
       CleanedFile.new(path: file, file_size: file_size, db_entries: db_entries,
                       db_entries_count: db_entries.count, hardlink: hardlink)
-    end.reject(&:nil?)
+    end.compact
   end
 
   def parse_packages_data(repomd_file, repo_base_dir)

--- a/lib/rmt/cli/clean.rb
+++ b/lib/rmt/cli/clean.rb
@@ -27,7 +27,7 @@ class RMT::CLI::Clean < RMT::CLI::Base
     print _("Scanning the mirror directory for 'repomd.xml' files...")
     print "\e[0m\n"
 
-    repomd_files = Dir.glob(File.join(RMT::DEFAULT_MIRROR_DIR, '**', 'repomd.xml'))
+    repomd_files = Dir.glob(File.join(RMT::DEFAULT_MIRROR_DIR, '**', 'repomd.xml')).sort
 
     repomd_count = repomd_files.count
     if repomd_count == 0

--- a/lib/rmt/cli/clean.rb
+++ b/lib/rmt/cli/clean.rb
@@ -1,0 +1,184 @@
+class RMT::CLI::Clean < RMT::CLI::Base
+
+  desc 'packages', _('Clean stale package files, based on current repository data.')
+  option :non_interactive, aliases: '-n', type: :boolean,
+    desc: _('Do not ask anything, use default answers automatically. Default: false')
+  option :dry_run, type: :boolean,
+    desc: _('Run the clean process without actually removing files.')
+  option :verbose, aliases: '-v', type: :boolean,
+    desc: _('List files during the cleaning process.')
+  long_desc _(
+    <<~PACKAGES
+    Clean stale package files, based on current repository metadata.
+
+    This command scans the mirror directory for 'repomd.xml' files, parse the
+    metadata files, and compare their content with files on disk. Files not
+    listed in the metadata are considered stale.
+
+    Then, it removes all stale files from disk and any associated database entries.
+    PACKAGES
+  )
+
+  def packages
+    print "\n\e[1m"
+    print _("Scanning the mirror directory for 'repomd.xml' files...")
+    print "\e[0m\n"
+
+    repomd_files = Dir.glob(File.join(RMT::DEFAULT_MIRROR_DIR, '**', 'repomd.xml'))
+
+    repomd_count = repomd_files.count
+    if repomd_count == 0
+      print "\e[31;1m"
+      print _('RMT found no repomd.xml files. Check if RMT is properly configured.')
+      print "\e[0m\n"
+
+      return
+    end
+
+    repomd_count_text = file_count_text(repomd_count)
+    puts _('RMT found repomd.xml files: %{repomd_count}.') % { repomd_count: repomd_count_text }
+    puts _('Now, it will parse all repomd.xml files, search for stale packages on disk and clean them.')
+
+    unless options.non_interactive
+      print "\n\e[1m"
+      print _('This can take several minutes. Would you like to continue and clean stale packages?')
+      print "\e[0m\n\s\s"
+      print _("Only '%{input}' will be accepted.") % { input: _('yes') }
+      print "\n\s\s\e[1m"
+      print _('Enter a value:')
+      print "\e[0m\s"
+
+      input = $stdin.gets.to_s.strip
+      if input != _('yes')
+        puts "\n" + _('Clean cancelled.')
+        return
+      end
+    end
+
+    report = run_package_clean(repomd_files)
+
+    if report[:total_cleaned_count] == 0
+      print "\n\e[32;1m"
+      print _('No stale packages have been found!')
+      print "\e[0m\n"
+
+      return
+    end
+
+    puts "\n#{'-' * 80}"
+    print "\e[32;1m"
+    print _('Total: cleaned %{total_count} (%{total_size}), %{total_db_entries}.') % {
+      total_count: file_count_text(report[:total_cleaned_count]),
+      total_size: ActiveSupport::NumberHelper.number_to_human_size(report[:total_cleaned_size]),
+      total_db_entries: db_entries_text(report[:total_cleaned_db_entries])
+    }
+    print "\e[0m\n"
+  end
+
+  private
+
+  def run_package_clean(repomd_files)
+    dirs_with_stale_files = repomd_files.lazy.map do |repomd_file|
+      repo_base_dir = File.absolute_path(File.join(File.dirname(repomd_file), '..'))
+      stale_packages = stale_packages_list(repo_base_dir, repomd_file)
+
+      next nil if stale_packages.empty?
+
+      [repo_base_dir, stale_packages]
+    end.reject(&:nil?)
+
+    stats = dirs_with_stale_files.map do |(repo_base_dir, stale_packages)|
+      print "\n\e[1m"
+      print _('Directory: %{dir}') % { dir: repo_base_dir }
+      print "\e[0m\n"
+
+      partial_stats = clean_stale_packages(stale_packages, repo_base_dir)
+
+      cleaned_files_count = partial_stats.count
+      cleaned_files_size, cleaned_db_entries =
+        partial_stats.transpose.map(&:sum)
+
+      puts _('Cleaned %{file_count_text} (%{total_size}), %{db_entries}.') % {
+        file_count_text: file_count_text(cleaned_files_count),
+        total_size: ActiveSupport::NumberHelper.number_to_human_size(cleaned_files_size),
+        db_entries: db_entries_text(cleaned_db_entries)
+      }
+
+      [cleaned_files_count, cleaned_files_size, cleaned_db_entries]
+    end
+
+    total_cleaned_count, total_cleaned_size, total_cleaned_db_entries =
+      stats.force.transpose.map(&:sum)
+
+    {
+      total_cleaned_size: total_cleaned_size.to_i,
+      total_cleaned_count: total_cleaned_count.to_i,
+      total_cleaned_db_entries: total_cleaned_db_entries.to_i
+    }
+  end
+
+  def stale_packages_list(repo_base_dir, repomd_file)
+    expected_packages = parse_packages_data(repomd_file, repo_base_dir)
+      .map { |file| File.join(repo_base_dir, file.location) }.sort
+
+    actual_packages = Dir.glob(File.join(repo_base_dir, '**', '*.{rpm,drpm}')).sort
+
+    (actual_packages - expected_packages).sort
+  end
+
+  def parse_packages_data(repomd_file, repo_base_dir)
+    metadata_files = RepomdParser::RepomdXmlParser.new(repomd_file).parse
+
+    xml_parsers = { deltainfo: RepomdParser::DeltainfoXmlParser,
+                    primary: RepomdParser::PrimaryXmlParser }
+
+    metadata_files.reduce([]) do |acc, metadata|
+      next acc unless xml_parsers.key?(metadata.type)
+
+      metadata_path = File.join(repo_base_dir, metadata.location)
+      acc << xml_parsers[metadata.type].new(metadata_path).parse
+    end.flatten
+  end
+
+  def clean_stale_packages(packages, repo_base_dir)
+    quoted_repo_base_dir = Regexp.quote(repo_base_dir)
+
+    packages.map do |file|
+      next nil unless File.exist?(file)
+
+      file_size, db_entries = clean_package(file)
+
+      if options.verbose
+        puts "\s\s" + (
+          _("Cleaned '%{file_name}' (%{file_size}), %{db_entries}.") % {
+            file_name: file.gsub(%r{^#{quoted_repo_base_dir}/?}, ''),
+            file_size: ActiveSupport::NumberHelper.number_to_human_size(file_size),
+            db_entries: db_entries_text(db_entries)
+          }
+        )
+      end
+
+      [file_size, db_entries]
+    end.reject(&:nil?)
+  end
+
+  def clean_package(file)
+    file_size = File.size(file)
+    db_entries = DownloadedFile.where(local_path: file)
+
+    unless options.dry_run
+      FileUtils.rm(file)
+      db_entries = db_entries.destroy_all
+    end
+
+    [file_size, db_entries.count]
+  end
+
+  def file_count_text(count)
+    n_('%{count} file', '%{count} files', count) % { count: count }
+  end
+
+  def db_entries_text(count)
+    n_('%{db_entries} database entry', '%{db_entries} database entries', count) % { db_entries: count }
+  end
+end

--- a/lib/rmt/cli/main.rb
+++ b/lib/rmt/cli/main.rb
@@ -29,6 +29,9 @@ class RMT::CLI::Main < RMT::CLI::Base
   desc 'systems', _('List and manipulate registered systems')
   subcommand 'systems', RMT::CLI::Systems
 
+  desc 'clean', _('Clean files')
+  subcommand 'clean', RMT::CLI::Clean
+
   desc 'version', _('Show RMT version')
   def version
     puts RMT::VERSION

--- a/lib/rmt/cli/main.rb
+++ b/lib/rmt/cli/main.rb
@@ -29,7 +29,7 @@ class RMT::CLI::Main < RMT::CLI::Base
   desc 'systems', _('List and manipulate registered systems')
   subcommand 'systems', RMT::CLI::Systems
 
-  desc 'clean', _('Clean files')
+  desc 'clean', _('Clean stale files and their database entries')
   subcommand 'clean', RMT::CLI::Clean
 
   desc 'version', _('Show RMT version')

--- a/lib/rmt/cli/main.rb
+++ b/lib/rmt/cli/main.rb
@@ -29,7 +29,7 @@ class RMT::CLI::Main < RMT::CLI::Base
   desc 'systems', _('List and manipulate registered systems')
   subcommand 'systems', RMT::CLI::Systems
 
-  desc 'clean', _('Clean stale files and their database entries')
+  desc 'clean', _('Clean dangling files and their database entries')
   subcommand 'clean', RMT::CLI::Clean
 
   desc 'version', _('Show RMT version')

--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jun 06 15:44:00 UTC 2023 - Luís Caparroz <lcaparroz@suse.com>
+
+- Version 2.14
+- Add command 'rmt-cli clean packages', which remove stale packages no longer
+  referenced in the available metadata files and their database entries.
+
+-------------------------------------------------------------------
 Fri May 19 12:05:44 UTC 2023 - Jesús Bermúdez Velázquez <jesus.bv@suse.com>
 
 - Version 2.13
@@ -7,7 +14,6 @@ Fri May 19 12:05:44 UTC 2023 - Jesús Bermúdez Velázquez <jesus.bv@suse.com>
   * Additional API paths for SUMa PAYG for RMT
   * Allow access to SUMa Client Tools and Proxy channels if product is SUMA_Server
   * Handle system token for BYOS instances in the cloud
-
 
 -------------------------------------------------------------------
 Wed Apr 12 15:27:18 UTC 2023 - Felix Schnizlein <fschnizlein@suse.com>

--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -2,7 +2,7 @@
 Thu Jun 06 15:44:00 UTC 2023 - Luís Caparroz <lcaparroz@suse.com>
 
 - Version 2.14
-- Add command 'rmt-cli clean packages', which remove stale packages no longer
+- Add command 'rmt-cli clean packages', which remove dangling packages no longer
   referenced in the available metadata files and their database entries.
 
 -------------------------------------------------------------------

--- a/package/obs/rmt-server.spec
+++ b/package/obs/rmt-server.spec
@@ -30,7 +30,7 @@
 %define ruby_version          %{rb_default_ruby_suffix}
 
 Name:           rmt-server
-Version:        2.13
+Version:        2.14
 Release:        0
 Summary:        Repository mirroring tool and registration proxy for SCC
 License:        GPL-2.0-or-later

--- a/spec/lib/rmt/cli/clean_spec.rb
+++ b/spec/lib/rmt/cli/clean_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-class StaleList
+class DanglingList
   attr_reader :files, :db_entries, :hardlinks
 
   def initialize(files: [], db_entries: [], hardlinks: [])
@@ -26,7 +26,7 @@ RSpec.describe RMT::CLI::Clean do
       { fixture: 'dummy_repo_with_src', dir: File.join(mirror_dir, 'dummy_repo_with_src') }
     end
     let(:mirrored_repos) { [dummy_repo, dummy_repo_with_src] }
-    let(:stale_files) do
+    let(:dangling_files) do
       {
         rpm1: {
           fixture: 'dummy_repo_with_src/x86_64/apples-0.0.2-lp151.2.1.x86_64.rpm',
@@ -68,25 +68,25 @@ RSpec.describe RMT::CLI::Clean do
       <<~OUTPUT
         \n\e[1mScanning the mirror directory for 'repomd.xml' files...\e[0m
         RMT found repomd.xml files: 2 files.
-        Now, it will parse all repomd.xml files, search for stale packages on disk and clean them.
+        Now, it will parse all repomd.xml files, search for dangling packages on disk and clean them.
 
         #{confirmation_prompt}#{expected_result_output}
       OUTPUT
     end
     let(:confirmation_prompt) do
       <<~OUTPUT
-        \e[1mThis can take several minutes. Would you like to continue and clean stale packages?\e[0m
+        \e[1mThis can take several minutes. Would you like to continue and clean dangling packages?\e[0m
           Only 'yes' will be accepted.
           \e[1mEnter a value:\e[0m\s
       OUTPUT
     end
-    let(:stale_list)       { StaleList.new }
-    let(:fresh_stale_list) { StaleList.new }
+    let(:dangling_list)       { DanglingList.new }
+    let(:fresh_dangling_list) { DanglingList.new }
 
-    shared_context 'default stale files setup' do
-      let(:stale_list) do
-        StaleList.new(files: stale_files.values_at(:rpm1, :drpm1, :rpm2, :drpm2),
-                      db_entries: stale_files.values_at(:rpm1, :rpm2, :drpm2))
+    shared_context 'default dangling files setup' do
+      let(:dangling_list) do
+        DanglingList.new(files: dangling_files.values_at(:rpm1, :drpm1, :rpm2, :drpm2),
+                         db_entries: dangling_files.values_at(:rpm1, :rpm2, :drpm2))
       end
 
       let(:expected_result_output) do
@@ -136,8 +136,8 @@ RSpec.describe RMT::CLI::Clean do
       include_examples 'prints to stdout'
     end
 
-    context 'when no stale packages have been found' do
-      let(:expected_result_output) { "\e[32;1mNo stale packages have been found!\e[0m" }
+    context 'when no dangling packages have been found' do
+      let(:expected_result_output) { "\e[32;1mNo dangling packages have been found!\e[0m" }
 
       include_context 'mirror repositories'
 
@@ -168,9 +168,9 @@ RSpec.describe RMT::CLI::Clean do
       end
     end
 
-    context 'when there are stale packages and no options have been passed' do
-      include_context 'default stale files setup'
-      include_context 'mirror repositories with stale files'
+    context 'when there are dangling packages and no options have been passed' do
+      include_context 'default dangling files setup'
+      include_context 'mirror repositories with dangling files'
       include_context 'command without options'
 
       include_examples 'prints to stdout'
@@ -178,9 +178,9 @@ RSpec.describe RMT::CLI::Clean do
       include_examples 'removes database entries'
     end
 
-    context 'when there are stale packages and --dry-run option is set' do
-      include_context 'default stale files setup'
-      include_context 'mirror repositories with stale files'
+    context 'when there are dangling packages and --dry-run option is set' do
+      include_context 'default dangling files setup'
+      include_context 'mirror repositories with dangling files'
       include_context 'command with dry run option'
 
       include_examples 'prints to stdout'
@@ -188,9 +188,9 @@ RSpec.describe RMT::CLI::Clean do
       include_examples 'does not remove database entries'
     end
 
-    context 'when there are stale packages and --non-interactive option is set' do
-      include_context 'default stale files setup'
-      include_context 'mirror repositories with stale files'
+    context 'when there are dangling packages and --non-interactive option is set' do
+      include_context 'default dangling files setup'
+      include_context 'mirror repositories with dangling files'
       include_context 'command with non-interactive mode'
 
       include_examples 'prints to stdout'
@@ -198,10 +198,10 @@ RSpec.describe RMT::CLI::Clean do
       include_examples 'removes database entries'
     end
 
-    context 'when there are stale packages and --verbose option is set' do
-      let(:stale_list) do
-        StaleList.new(files: stale_files.values_at(:rpm1, :drpm1, :rpm2, :drpm2),
-                      db_entries: stale_files.values_at(:rpm1, :rpm2, :drpm2))
+    context 'when there are dangling packages and --verbose option is set' do
+      let(:dangling_list) do
+        DanglingList.new(files: dangling_files.values_at(:rpm1, :drpm1, :rpm2, :drpm2),
+                         db_entries: dangling_files.values_at(:rpm1, :rpm2, :drpm2))
       end
       let(:expected_result_output) do
         <<~OUTPUT.chomp
@@ -220,7 +220,7 @@ RSpec.describe RMT::CLI::Clean do
         OUTPUT
       end
 
-      include_context 'mirror repositories with stale files'
+      include_context 'mirror repositories with dangling files'
       include_context 'command with verbose mode'
 
       include_examples 'prints to stdout'
@@ -228,10 +228,10 @@ RSpec.describe RMT::CLI::Clean do
       include_examples 'removes database entries'
     end
 
-    context 'when there are stale packages and some are source packages' do
-      let(:stale_list) do
-        StaleList.new(db_entries: stale_files.values_at(:rpm1, :rpm2, :drpm2, :src2),
-                      files: stale_files.values_at(:src1, :src2, :rpm1, :drpm1, :rpm2, :drpm2))
+    context 'when there are dangling packages and some are source packages' do
+      let(:dangling_list) do
+        DanglingList.new(db_entries: dangling_files.values_at(:rpm1, :rpm2, :drpm2, :src2),
+                         files: dangling_files.values_at(:src1, :src2, :rpm1, :drpm1, :rpm2, :drpm2))
       end
       let(:expected_result_output) do
         <<~OUTPUT.chomp
@@ -252,7 +252,7 @@ RSpec.describe RMT::CLI::Clean do
         OUTPUT
       end
 
-      include_context 'mirror repositories with stale files'
+      include_context 'mirror repositories with dangling files'
       include_context 'command with verbose mode'
 
       include_examples 'prints to stdout'
@@ -260,14 +260,14 @@ RSpec.describe RMT::CLI::Clean do
       include_examples 'removes database entries'
     end
 
-    context 'when there are stale packages and some are less than 2-days-old' do
-      let(:stale_list) do
-        StaleList.new(files: stale_files.values_at(:rpm2, :drpm2),
-                      db_entries: stale_files.values_at(:rpm2))
+    context 'when there are dangling packages and some are less than 2-days-old' do
+      let(:dangling_list) do
+        DanglingList.new(files: dangling_files.values_at(:rpm2, :drpm2),
+                         db_entries: dangling_files.values_at(:rpm2))
       end
-      let(:fresh_stale_list) do
-        StaleList.new(files: stale_files.values_at(:rpm1, :drpm1),
-                      db_entries: stale_files.values_at(:rpm1))
+      let(:fresh_dangling_list) do
+        DanglingList.new(files: dangling_files.values_at(:rpm1, :drpm1),
+                         db_entries: dangling_files.values_at(:rpm1))
       end
       let(:expected_result_output) do
         <<~OUTPUT.chomp
@@ -281,20 +281,20 @@ RSpec.describe RMT::CLI::Clean do
         OUTPUT
       end
 
-      include_context 'mirror repositories with stale files'
+      include_context 'mirror repositories with dangling files'
       include_context 'command with verbose mode'
 
       include_examples 'prints to stdout'
       include_examples 'removes files'
       include_examples 'removes database entries'
-      include_examples 'does not remove fresh stale files'
-      include_examples 'does not remove database entries of fresh stale files'
+      include_examples 'does not remove fresh dangling files'
+      include_examples 'does not remove database entries of fresh dangling files'
     end
 
-    context 'when there are stale packages and all of them are hardlinks' do
-      let(:stale_list) do
-        StaleList.new(db_entries: stale_files.values_at(:rpm1, :rpm2, :drpm2, :src2),
-                      hardlinks: stale_files.values_at(:src1, :src2, :rpm1, :drpm1, :rpm2, :drpm2))
+    context 'when there are dangling packages and all of them are hardlinks' do
+      let(:dangling_list) do
+        DanglingList.new(db_entries: dangling_files.values_at(:rpm1, :rpm2, :drpm2, :src2),
+                         hardlinks: dangling_files.values_at(:src1, :src2, :rpm1, :drpm1, :rpm2, :drpm2))
       end
       let(:expected_result_output) do
         <<~OUTPUT.chomp
@@ -315,7 +315,7 @@ RSpec.describe RMT::CLI::Clean do
         OUTPUT
       end
 
-      include_context 'mirror repositories with stale files'
+      include_context 'mirror repositories with dangling files'
       include_context 'command with verbose mode'
 
       include_examples 'prints to stdout'
@@ -323,16 +323,16 @@ RSpec.describe RMT::CLI::Clean do
       include_examples 'removes database entries'
     end
 
-    context 'when there are stale packages and some hardlinks points to them' do
-      let(:stale_list) do
-        StaleList.new(files: stale_files.values_at(:drpm1, :rpm2),
-                      hardlinks: stale_files.values_at(:src1, :drpm2, :rpm3, :rpm4),
-                      db_entries: stale_files.values_at(:rpm2, :drpm2, :rpm4))
+    context 'when there are dangling packages and some hardlinks points to them' do
+      let(:dangling_list) do
+        DanglingList.new(files: dangling_files.values_at(:drpm1, :rpm2),
+                         hardlinks: dangling_files.values_at(:src1, :drpm2, :rpm3, :rpm4),
+                         db_entries: dangling_files.values_at(:rpm2, :drpm2, :rpm4))
       end
       let(:fresh_state_files) do
-        StaleList.new(files: stale_files.values_at(:rpm1),
-                      hardlinks: stale_files.values_at(:src2),
-                      db_entries: stale_files.values_at(:rpm1, :src2))
+        DanglingList.new(files: dangling_files.values_at(:rpm1),
+                         hardlinks: dangling_files.values_at(:src2),
+                         db_entries: dangling_files.values_at(:rpm1, :src2))
       end
       let(:expected_result_output) do
         <<~OUTPUT.chomp
@@ -353,14 +353,14 @@ RSpec.describe RMT::CLI::Clean do
         OUTPUT
       end
 
-      include_context 'mirror repositories with stale files'
+      include_context 'mirror repositories with dangling files'
       include_context 'command with verbose mode'
 
       include_examples 'prints to stdout'
       include_examples 'removes files'
       include_examples 'removes database entries'
-      include_examples 'does not remove fresh stale files'
-      include_examples 'does not remove database entries of fresh stale files'
+      include_examples 'does not remove fresh dangling files'
+      include_examples 'does not remove database entries of fresh dangling files'
 
       context '--dry-run options is set' do
         include_context 'command with dry run and verbose options'
@@ -368,8 +368,8 @@ RSpec.describe RMT::CLI::Clean do
         include_examples 'prints to stdout'
         include_examples 'does not remove files'
         include_examples 'does not remove database entries'
-        include_examples 'does not remove fresh stale files'
-        include_examples 'does not remove database entries of fresh stale files'
+        include_examples 'does not remove fresh dangling files'
+        include_examples 'does not remove database entries of fresh dangling files'
       end
     end
   end

--- a/spec/lib/rmt/cli/clean_spec.rb
+++ b/spec/lib/rmt/cli/clean_spec.rb
@@ -91,11 +91,11 @@ RSpec.describe RMT::CLI::Clean do
 
       let(:expected_result_output) do
         <<~OUTPUT.chomp
-          \e[1mDirectory: #{dummy_repo_with_src[:dir]}\e[0m
-          Cleaned 2 files (#{file_human_size(10824)}), 1 database entry.
-
           \e[1mDirectory: #{dummy_repo[:dir]}\e[0m
           Cleaned 2 files (#{file_human_size(4038)}), 2 database entries.
+
+          \e[1mDirectory: #{dummy_repo_with_src[:dir]}\e[0m
+          Cleaned 2 files (#{file_human_size(10824)}), 1 database entry.
 
           #{'-' * 80}
           \e[32;1mTotal: cleaned 4 files (#{file_human_size(14862)}), 3 database entries.\e[0m
@@ -205,15 +205,15 @@ RSpec.describe RMT::CLI::Clean do
       end
       let(:expected_result_output) do
         <<~OUTPUT.chomp
-          \e[1mDirectory: #{dummy_repo_with_src[:dir]}\e[0m
-            Cleaned 'x86_64/lemon-0.0.1_0.0.2-lp151.2.1.x86_64.drpm' (#{file_human_size(3544)}), 0 database entries.
-            Cleaned 'x86_64/lemon-0.0.2-lp151.2.1.x86_64.rpm' (#{file_human_size(7280)}), 1 database entry.
-          Cleaned 2 files (#{file_human_size(10824)}), 1 database entry.
-
           \e[1mDirectory: #{dummy_repo[:dir]}\e[0m
             Cleaned 'blueberry-0.1-0.x86_64.drpm' (#{file_human_size(2088)}), 1 database entry.
             Cleaned 'blueberry-0.2-0.x86_64.rpm' (#{file_human_size(1950)}), 1 database entry.
           Cleaned 2 files (#{file_human_size(4038)}), 2 database entries.
+
+          \e[1mDirectory: #{dummy_repo_with_src[:dir]}\e[0m
+            Cleaned 'x86_64/lemon-0.0.1_0.0.2-lp151.2.1.x86_64.drpm' (#{file_human_size(3544)}), 0 database entries.
+            Cleaned 'x86_64/lemon-0.0.2-lp151.2.1.x86_64.rpm' (#{file_human_size(7280)}), 1 database entry.
+          Cleaned 2 files (#{file_human_size(10824)}), 1 database entry.
 
           #{'-' * 80}
           \e[32;1mTotal: cleaned 4 files (#{file_human_size(14862)}), 3 database entries.\e[0m
@@ -235,17 +235,17 @@ RSpec.describe RMT::CLI::Clean do
       end
       let(:expected_result_output) do
         <<~OUTPUT.chomp
+          \e[1mDirectory: #{dummy_repo[:dir]}\e[0m
+            Cleaned 'blueberry-0.1-0.x86_64.drpm' (#{file_human_size(2088)}), 1 database entry.
+            Cleaned 'blueberry-0.2-0.x86_64.rpm' (#{file_human_size(1950)}), 1 database entry.
+          Cleaned 2 files (#{file_human_size(4038)}), 2 database entries.
+
           \e[1mDirectory: #{dummy_repo_with_src[:dir]}\e[0m
             Cleaned 'src/lemon-0.0.1-lp151.1.1.src.rpm' (#{file_human_size(7518)}), 0 database entries.
             Cleaned 'src/lemon-0.0.2-lp151.2.1.src.rpm' (#{file_human_size(7528)}), 1 database entry.
             Cleaned 'x86_64/lemon-0.0.1_0.0.2-lp151.2.1.x86_64.drpm' (#{file_human_size(3544)}), 0 database entries.
             Cleaned 'x86_64/lemon-0.0.2-lp151.2.1.x86_64.rpm' (#{file_human_size(7280)}), 1 database entry.
           Cleaned 4 files (#{file_human_size(25870)}), 2 database entries.
-
-          \e[1mDirectory: #{dummy_repo[:dir]}\e[0m
-            Cleaned 'blueberry-0.1-0.x86_64.drpm' (#{file_human_size(2088)}), 1 database entry.
-            Cleaned 'blueberry-0.2-0.x86_64.rpm' (#{file_human_size(1950)}), 1 database entry.
-          Cleaned 2 files (#{file_human_size(4038)}), 2 database entries.
 
           #{'-' * 80}
           \e[32;1mTotal: cleaned 6 files (#{file_human_size(29908)}), 4 database entries.\e[0m
@@ -298,17 +298,17 @@ RSpec.describe RMT::CLI::Clean do
       end
       let(:expected_result_output) do
         <<~OUTPUT.chomp
+        \e[1mDirectory: #{dummy_repo[:dir]}\e[0m
+          Cleaned 'blueberry-0.1-0.x86_64.drpm' (#{file_human_size(0)}, hardlink), 1 database entry.
+          Cleaned 'blueberry-0.2-0.x86_64.rpm' (#{file_human_size(0)}, hardlink), 1 database entry.
+        Cleaned 2 files (#{file_human_size(0)}), 2 database entries.
+
         \e[1mDirectory: #{dummy_repo_with_src[:dir]}\e[0m
           Cleaned 'src/lemon-0.0.1-lp151.1.1.src.rpm' (#{file_human_size(0)}, hardlink), 0 database entries.
           Cleaned 'src/lemon-0.0.2-lp151.2.1.src.rpm' (#{file_human_size(0)}, hardlink), 1 database entry.
           Cleaned 'x86_64/lemon-0.0.1_0.0.2-lp151.2.1.x86_64.drpm' (#{file_human_size(0)}, hardlink), 0 database entries.
           Cleaned 'x86_64/lemon-0.0.2-lp151.2.1.x86_64.rpm' (#{file_human_size(0)}, hardlink), 1 database entry.
         Cleaned 4 files (#{file_human_size(0)}), 2 database entries.
-
-        \e[1mDirectory: #{dummy_repo[:dir]}\e[0m
-          Cleaned 'blueberry-0.1-0.x86_64.drpm' (#{file_human_size(0)}, hardlink), 1 database entry.
-          Cleaned 'blueberry-0.2-0.x86_64.rpm' (#{file_human_size(0)}, hardlink), 1 database entry.
-        Cleaned 2 files (#{file_human_size(0)}), 2 database entries.
 
         #{'-' * 80}
         \e[32;1mTotal: cleaned 6 files (#{file_human_size(0)}), 4 database entries.\e[0m
@@ -336,17 +336,17 @@ RSpec.describe RMT::CLI::Clean do
       end
       let(:expected_result_output) do
         <<~OUTPUT.chomp
-          \e[1mDirectory: #{dummy_repo_with_src[:dir]}\e[0m
-            Cleaned 'src/lemon-0.0.1-lp151.1.1.src.rpm' (#{file_human_size(0)}, hardlink), 0 database entries.
-            Cleaned 'x86_64/lemon-0.0.1_0.0.2-lp151.2.1.x86_64.drpm' (#{file_human_size(3544)}), 0 database entries.
-          Cleaned 2 files (#{file_human_size(3544)}), 0 database entries.
-
           \e[1mDirectory: #{dummy_repo[:dir]}\e[0m
             Cleaned 'blueberry-0.1-0.x86_64.drpm' (#{file_human_size(0)}, hardlink), 1 database entry.
             Cleaned 'blueberry-0.2-0.x86_64.rpm' (#{file_human_size(0)}, hardlink), 1 database entry.
             Cleaned 'cranberry-0.4-0.x86_64.rpm' (#{file_human_size(0)}, hardlink), 1 database entry.
             Cleaned 'strawberry-0.3-0.x86_64.rpm' (#{file_human_size(1950)}), 0 database entries.
           Cleaned 4 files (#{file_human_size(1950)}), 3 database entries.
+
+          \e[1mDirectory: #{dummy_repo_with_src[:dir]}\e[0m
+            Cleaned 'src/lemon-0.0.1-lp151.1.1.src.rpm' (#{file_human_size(0)}, hardlink), 0 database entries.
+            Cleaned 'x86_64/lemon-0.0.1_0.0.2-lp151.2.1.x86_64.drpm' (#{file_human_size(3544)}), 0 database entries.
+          Cleaned 2 files (#{file_human_size(3544)}), 0 database entries.
 
           #{'-' * 80}
           \e[32;1mTotal: cleaned 6 files (#{file_human_size(5494)}), 3 database entries.\e[0m

--- a/spec/lib/rmt/cli/clean_spec.rb
+++ b/spec/lib/rmt/cli/clean_spec.rb
@@ -1,0 +1,236 @@
+require 'rails_helper'
+
+RSpec.describe RMT::CLI::Clean do
+  describe '#packages' do
+    let(:command) { described_class.start(argv) }
+
+    let(:tmp_dir) { Dir.mktmpdir }
+    let(:mirror_dir) { File.join(tmp_dir, 'public', 'repo') }
+
+    let(:dummy_repo) do
+      { fixture: 'dummy_repo', dir: File.join(mirror_dir, 'dummy_repo') }
+    end
+    let(:dummy_repo_with_src) do
+      { fixture: 'dummy_repo_with_src', dir: File.join(mirror_dir, 'dummy_repo_with_src') }
+    end
+    let(:stale_rpm1) do
+      { fixture: 'dummy_repo_with_src/x86_64/apples-0.0.2-lp151.2.1.x86_64.rpm',
+        file: File.join(dummy_repo_with_src[:dir], 'x86_64', 'lemon-0.0.2-lp151.2.1.x86_64.rpm'),
+        size: 7280 }
+    end
+    let(:stale_drpm1) do
+      { fixture: 'dummy_repo_with_src/x86_64/apples-0.0.1_0.0.2-lp151.2.1.x86_64.drpm',
+        file: File.join(dummy_repo_with_src[:dir], 'x86_64', 'lemon-0.0.1_0.0.2-lp151.2.1.x86_64.drpm'),
+        size: 3544 }
+    end
+    let(:stale_rpm2) do
+      { fixture: 'dummy_repo/apples-0.2-0.x86_64.rpm',
+        file: File.join(dummy_repo[:dir], 'blueberry-0.2-0.x86_64.rpm'),
+        size: 1950 }
+    end
+    let(:stale_drpm2) do
+      { fixture: 'dummy_repo/apples-0.1-0.x86_64.drpm',
+        file: File.join(dummy_repo[:dir], 'blueberry-0.1-0.x86_64.drpm'),
+        size: 2088 }
+    end
+    let(:stale_src1) do
+      { fixture: 'dummy_repo_with_src/src/oranges-0.0.1-lp151.1.1.src.rpm',
+        file: File.join(dummy_repo_with_src[:dir], 'src', 'lemon-0.0.1-lp151.1.1.src.rpm'),
+        size: 7518 }
+    end
+    let(:stale_src2) do
+      { fixture: 'dummy_repo_with_src/src/apples-0.0.2-lp151.2.1.src.rpm',
+        file: File.join(dummy_repo_with_src[:dir], 'src', 'lemon-0.0.2-lp151.2.1.src.rpm'),
+        size: 7528 }
+    end
+
+    let(:input) { 'yes' }
+    let(:expected_output) do
+      <<~OUTPUT
+        \n\e[1mScanning the mirror directory for 'repomd.xml' files...\e[0m
+        RMT found repomd.xml files: 2 files.
+        Now, it will parse all repomd.xml files, search for stale packages on disk and clean them.
+
+        #{confirmation_prompt}#{expected_result_output}
+      OUTPUT
+    end
+    let(:confirmation_prompt) do
+      <<~OUTPUT
+        \e[1mThis can take several minutes. Would you like to continue and clean stale packages?\e[0m
+          Only 'yes' will be accepted.
+          \e[1mEnter a value:\e[0m\s
+      OUTPUT
+    end
+
+    around do |example|
+      RMT.send(:remove_const, 'DEFAULT_MIRROR_DIR')
+      RMT.const_set('DEFAULT_MIRROR_DIR', mirror_dir)
+      FileUtils.mkdir_p(mirror_dir)
+      example.run
+      FileUtils.rm_r(tmp_dir, secure: false)
+    end
+
+    context 'when no repomd files have been found' do
+      let(:argv) { ['packages'] }
+      let(:expected_output) do
+        <<~OUTPUT
+          \n\e[1mScanning the mirror directory for 'repomd.xml' files...\e[0m
+          \e[31;1mRMT found no repomd.xml files. Check if RMT is properly configured.\e[0m
+        OUTPUT
+      end
+
+      include_examples 'prints to stdout'
+    end
+
+    context "when RMT asks for confirmation and user inputs text other than 'yes'" do
+      let(:mirrored_repos) { [dummy_repo, dummy_repo_with_src] }
+      let(:expected_result_output) { 'Clean cancelled.' }
+      let(:input) { 'no' }
+
+      include_context 'command without options'
+      include_context 'mirror directory without stale files'
+
+      include_examples 'prints to stdout'
+    end
+
+    context 'when no stale packages have been found' do
+      let(:mirrored_repos) { [dummy_repo, dummy_repo_with_src] }
+      let(:expected_result_output) { "\e[32;1mNo stale packages have been found!\e[0m" }
+
+      include_context 'mirror directory without stale files'
+
+      context 'and no options have been passed' do
+        include_context 'command without options'
+
+        include_examples 'prints to stdout'
+        include_examples 'does not remove files'
+        include_examples 'does not remove database entries'
+      end
+
+      context 'and --verbose option is set' do
+        include_context 'command with verbose mode'
+
+        include_examples 'prints to stdout'
+        include_examples 'does not remove files'
+        include_examples 'does not remove database entries'
+      end
+
+      context 'and --non-interactive option is set' do
+        include_context 'command with non-interactive mode'
+
+        let(:confirmation_prompt) { '' }
+
+        include_examples 'prints to stdout'
+        include_examples 'does not remove files'
+        include_examples 'does not remove database entries'
+      end
+    end
+
+    context 'when there are stale packages' do
+      let(:mirrored_repos) { [dummy_repo, dummy_repo_with_src] }
+      let(:stale_files) { [stale_rpm1, stale_drpm1, stale_rpm2, stale_drpm2] }
+      let(:stale_database_entries) { [stale_rpm1, stale_rpm2, stale_drpm2] }
+
+      let(:expected_result_output) do
+        <<~OUTPUT.chomp
+          \e[1mDirectory: #{dummy_repo_with_src[:dir]}\e[0m
+          Cleaned 2 files (#{file_human_size(10824)}), 1 database entry.
+
+          \e[1mDirectory: #{dummy_repo[:dir]}\e[0m
+          Cleaned 2 files (#{file_human_size(4038)}), 2 database entries.
+
+          #{'-' * 80}
+          \e[32;1mTotal: cleaned 4 files (#{file_human_size(14862)}), 3 database entries.\e[0m
+        OUTPUT
+      end
+
+      context 'and no options have been passed' do
+        include_context 'mirror directory with stale files'
+        include_context 'database entries for stale files'
+        include_context 'command without options'
+
+        include_examples 'prints to stdout'
+        include_examples 'remove files'
+        include_examples 'remove database entries'
+      end
+
+      context 'and --dry-run option is set' do
+        include_context 'mirror directory with stale files'
+        include_context 'database entries for stale files'
+        include_context 'command with dry run option'
+
+        include_examples 'prints to stdout'
+        include_examples 'does not remove files'
+        include_examples 'does not remove database entries'
+      end
+
+      context 'and --verbose option is set' do
+        let(:expected_result_output) do
+          <<~OUTPUT.chomp
+          \e[1mDirectory: #{dummy_repo_with_src[:dir]}\e[0m
+            Cleaned 'x86_64/lemon-0.0.1_0.0.2-lp151.2.1.x86_64.drpm' (#{file_human_size(3544)}), 0 database entries.
+            Cleaned 'x86_64/lemon-0.0.2-lp151.2.1.x86_64.rpm' (#{file_human_size(7280)}), 1 database entry.
+          Cleaned 2 files (#{file_human_size(10824)}), 1 database entry.
+
+          \e[1mDirectory: #{dummy_repo[:dir]}\e[0m
+            Cleaned 'blueberry-0.1-0.x86_64.drpm' (#{file_human_size(2088)}), 1 database entry.
+            Cleaned 'blueberry-0.2-0.x86_64.rpm' (#{file_human_size(1950)}), 1 database entry.
+          Cleaned 2 files (#{file_human_size(4038)}), 2 database entries.
+
+          #{'-' * 80}
+          \e[32;1mTotal: cleaned 4 files (#{file_human_size(14862)}), 3 database entries.\e[0m
+          OUTPUT
+        end
+
+        include_context 'mirror directory with stale files'
+        include_context 'database entries for stale files'
+        include_context 'command with verbose mode'
+
+        include_examples 'prints to stdout'
+        include_examples 'remove files'
+        include_examples 'remove database entries'
+      end
+
+      context 'and --non-interactive option is set' do
+        include_context 'mirror directory with stale files'
+        include_context 'database entries for stale files'
+        include_context 'command with non-interactive mode'
+
+        include_examples 'prints to stdout'
+        include_examples 'remove files'
+        include_examples 'remove database entries'
+      end
+
+      context 'and there are stale source packages' do
+        let(:stale_files) { [stale_src1, stale_src2, stale_rpm1, stale_drpm1, stale_rpm2, stale_drpm2] }
+        let(:stale_database_entries) { [stale_rpm1, stale_rpm2, stale_drpm2, stale_src2] }
+        let(:expected_result_output) do
+          <<~OUTPUT.chomp
+          \e[1mDirectory: #{dummy_repo_with_src[:dir]}\e[0m
+            Cleaned 'src/lemon-0.0.1-lp151.1.1.src.rpm' (#{file_human_size(7518)}), 0 database entries.
+            Cleaned 'src/lemon-0.0.2-lp151.2.1.src.rpm' (#{file_human_size(7528)}), 1 database entry.
+            Cleaned 'x86_64/lemon-0.0.1_0.0.2-lp151.2.1.x86_64.drpm' (#{file_human_size(3544)}), 0 database entries.
+            Cleaned 'x86_64/lemon-0.0.2-lp151.2.1.x86_64.rpm' (#{file_human_size(7280)}), 1 database entry.
+          Cleaned 4 files (#{file_human_size(25870)}), 2 database entries.
+
+          \e[1mDirectory: #{dummy_repo[:dir]}\e[0m
+            Cleaned 'blueberry-0.1-0.x86_64.drpm' (#{file_human_size(2088)}), 1 database entry.
+            Cleaned 'blueberry-0.2-0.x86_64.rpm' (#{file_human_size(1950)}), 1 database entry.
+          Cleaned 2 files (#{file_human_size(4038)}), 2 database entries.
+
+          #{'-' * 80}
+          \e[32;1mTotal: cleaned 6 files (#{file_human_size(29908)}), 4 database entries.\e[0m
+          OUTPUT
+        end
+
+        include_context 'mirror directory with stale files'
+        include_context 'database entries for stale files'
+        include_context 'command with verbose mode'
+
+        include_examples 'prints to stdout'
+        include_examples 'remove files'
+        include_examples 'remove database entries'
+      end
+    end
+  end
+end

--- a/spec/support/cli_helpers.rb
+++ b/spec/support/cli_helpers.rb
@@ -1,0 +1,14 @@
+def silence_stdout
+  @original_stdout = $stdout
+
+  $stdout = StringIO.new
+
+  yield
+
+  $stdout = @original_stdout
+  @original_stdout = nil
+end
+
+def file_human_size(size_in_bytes)
+  ActiveSupport::NumberHelper.number_to_human_size(size_in_bytes)
+end

--- a/spec/support/shared_contexts/cli/clean.rb
+++ b/spec/support/shared_contexts/cli/clean.rb
@@ -1,0 +1,78 @@
+shared_context 'command without options' do
+  let(:argv) { ['packages'] }
+
+  around do |example|
+    $stdin = StringIO.new("#{input}\n\n")
+    example.run
+    $stdin = STDIN
+  end
+end
+
+shared_context 'command with dry run option' do
+  let(:argv) { ['packages', '--dry-run'] }
+
+  around do |example|
+    $stdin = StringIO.new("#{input}\n\n")
+    example.run
+    $stdin = STDIN
+  end
+end
+
+shared_context 'command with verbose mode' do
+  let(:argv) { ['packages', '--verbose'] }
+
+  around do |example|
+    $stdin = StringIO.new("#{input}\n\n")
+    example.run
+    $stdin = STDIN
+  end
+end
+
+shared_context 'command with non-interactive mode' do
+  let(:argv) { ['packages', '--non-interactive'] }
+  let(:confirmation_prompt) { '' }
+end
+
+shared_context 'mirror directory without stale files' do
+  before do
+    mirrored_repos.each do |repo|
+      FileUtils.mkdir_p(repo[:dir])
+      FileUtils.cp_r(file_fixture(repo[:fixture]).to_s, mirror_dir)
+    end
+  end
+end
+
+shared_context 'mirror directory with stale files' do
+  before do
+    mirrored_repos.each do |repo|
+      FileUtils.mkdir_p(repo[:dir])
+      FileUtils.cp_r(file_fixture(repo[:fixture]).to_s, mirror_dir)
+
+      Dir.glob(File.join(repo[:dir], '**', '*.{rpm,drpm}')).each do |file|
+        DownloadedFile.create(
+          checksum: SecureRandom.uuid,
+          checksum_type: :uuid,
+          local_path: file,
+          size: File.size(file)
+        )
+      end
+    end
+
+    stale_files.each do |file|
+      FileUtils.cp(file_fixture(file[:fixture]).to_s, file[:file])
+    end
+  end
+end
+
+shared_context 'database entries for stale files' do
+  before do
+    stale_database_entries.each do |file|
+      DownloadedFile.create(
+        checksum: SecureRandom.uuid,
+        checksum_type: :uuid,
+        local_path: file[:file],
+        size: file[:size]
+      )
+    end
+  end
+end

--- a/spec/support/shared_contexts/cli/clean.rb
+++ b/spec/support/shared_contexts/cli/clean.rb
@@ -61,14 +61,14 @@ shared_context 'mirror repositories' do
   end
 end
 
-shared_context 'mirror repositories with stale files' do
+shared_context 'mirror repositories with dangling files' do
   include_context 'mirror repositories'
 
   before do
-    fresh_stale = [fresh_stale_list, 1.day.before(current_time).to_time]
-    stale       = [stale_list,       2.days.before(current_time).to_time]
+    fresh_dangling = [fresh_dangling_list, 1.day.before(current_time).to_time]
+    dangling       = [dangling_list,       2.days.before(current_time).to_time]
 
-    [fresh_stale, stale].each do |list, time|
+    [fresh_dangling, dangling].each do |list, time|
       list.files.each do |file|
         FileUtils.cp(File.join(mirror_dir, file[:fixture]).to_s, file[:file])
         File.utime(time, time, file[:file])

--- a/spec/support/shared_contexts/cli/clean.rb
+++ b/spec/support/shared_contexts/cli/clean.rb
@@ -58,15 +58,22 @@ shared_context 'mirror directory with stale files' do
       end
     end
 
-    stale_files.each do |file|
-      FileUtils.cp(file_fixture(file[:fixture]).to_s, file[:file])
+    fresh_stale = [fresh_stale_files, 1.day.before(current_time).to_time]
+    stale       = [stale_files,       2.days.before(current_time).to_time]
+
+    [fresh_stale, stale].each do |files, time|
+      files.each do |file|
+        FileUtils.cp(file_fixture(file[:fixture]).to_s, file[:file])
+        File.utime(time, time, file[:file])
+      end
     end
   end
 end
 
 shared_context 'database entries for stale files' do
   before do
-    stale_database_entries.each do |file|
+    entries = fresh_stale_database_entries + stale_database_entries
+    entries.each do |file|
       DownloadedFile.create(
         checksum: SecureRandom.uuid,
         checksum_type: :uuid,

--- a/spec/support/shared_examples/cli/clean.rb
+++ b/spec/support/shared_examples/cli/clean.rb
@@ -1,0 +1,55 @@
+shared_examples 'prints to stdout' do
+  it 'prints a proper message to stdout' do
+    expect { command }
+      .to output(expected_output).to_stdout
+      .and output('').to_stderr
+  end
+end
+
+shared_examples 'does not remove files' do
+  it 'does not remove any files' do
+    silence_stdout do
+      expect { command }
+        .not_to change { Dir.glob(File.join(mirror_dir, '**', '*')).count }
+    end
+  end
+end
+
+shared_examples 'does not remove database entries' do
+  it 'does not remove any database entries' do
+    silence_stdout do
+      expect { command }
+        .not_to change(DownloadedFile, :count)
+    end
+  end
+end
+
+shared_examples 'remove files' do
+  it 'remove all stale files' do
+    silence_stdout do
+      expect { command }
+        .to change { Dir.glob(File.join(mirror_dir, '**', '*')).count }
+        .by(-stale_files.count)
+    end
+  end
+end
+
+shared_examples 'remove source files' do
+  it 'remove source files' do
+    silence_stdout do
+      expect { command }
+        .to change { Dir.glob(File.join(mirror_dir, '**', '*.src.rpm')).count }
+        .by(-stale_files.count)
+    end
+  end
+end
+
+shared_examples 'remove database entries' do
+  it 'remove all database entries referring to stale files' do
+    silence_stdout do
+      expect { command }
+        .to change(DownloadedFile, :count)
+        .by(-stale_database_entries.count)
+    end
+  end
+end

--- a/spec/support/shared_examples/cli/clean.rb
+++ b/spec/support/shared_examples/cli/clean.rb
@@ -24,8 +24,8 @@ shared_examples 'does not remove database entries' do
   end
 end
 
-shared_examples 'remove files' do
-  it 'remove all stale files' do
+shared_examples 'removes files' do
+  it 'removes all stale files' do
     silence_stdout do
       expect { command }
         .to change { Dir.glob(File.join(mirror_dir, '**', '*')).count }
@@ -34,8 +34,8 @@ shared_examples 'remove files' do
   end
 end
 
-shared_examples 'remove source files' do
-  it 'remove source files' do
+shared_examples 'removes source files' do
+  it 'removes source files' do
     silence_stdout do
       expect { command }
         .to change { Dir.glob(File.join(mirror_dir, '**', '*.src.rpm')).count }
@@ -44,12 +44,35 @@ shared_examples 'remove source files' do
   end
 end
 
-shared_examples 'remove database entries' do
-  it 'remove all database entries referring to stale files' do
+shared_examples 'removes database entries' do
+  it 'removes all database entries referencing stale files' do
     silence_stdout do
       expect { command }
         .to change(DownloadedFile, :count)
         .by(-stale_database_entries.count)
+    end
+  end
+end
+
+shared_examples 'does not remove fresh stale files' do
+  it 'does not remove fresh stale files' do
+    silence_stdout do
+      # File.stat will fail if the file doesn't exist, which come in hand in
+      # case the implementation fails to keep the files.
+      expect { command }.not_to change {
+        fresh_stale_files.map { |f| File.stat(f[:file]).inspect }
+      }
+    end
+  end
+end
+
+shared_examples 'does not remove database entries of fresh stale files' do
+  it 'does not remove database entries referencing fresh stale files' do
+    fresh_files = fresh_stale_database_entries.pluck(:file)
+    silence_stdout do
+      expect { command }.not_to change {
+        DownloadedFile.where(local_path: fresh_files).pluck(:local_path)
+      }.from(fresh_files)
     end
   end
 end

--- a/spec/support/shared_examples/cli/clean.rb
+++ b/spec/support/shared_examples/cli/clean.rb
@@ -25,40 +25,40 @@ shared_examples 'does not remove database entries' do
 end
 
 shared_examples 'removes files' do
-  it 'removes all stale files' do
+  it 'removes all dangling files' do
     silence_stdout do
       expect { command }
         .to change { Dir.glob(File.join(mirror_dir, '**', '*.*rpm')).count }
-        .by(-stale_list.files.count - stale_list.hardlinks.count)
+        .by(-dangling_list.files.count - dangling_list.hardlinks.count)
     end
   end
 end
 
 shared_examples 'removes database entries' do
-  it 'removes all database entries referencing stale files' do
+  it 'removes all database entries referencing dangling files' do
     silence_stdout do
       expect { command }
         .to change(DownloadedFile, :count)
-        .by(-stale_list.db_entries.count)
+        .by(-dangling_list.db_entries.count)
     end
   end
 end
 
-shared_examples 'does not remove fresh stale files' do
-  it 'does not remove fresh stale files' do
+shared_examples 'does not remove fresh dangling files' do
+  it 'does not remove fresh dangling files' do
     silence_stdout do
       # File.stat will fail if the file doesn't exist, which come in hand in
       # case the implementation fails to keep the files.
       expect { command }.not_to change {
-        fresh_stale_list.files.map { |f| File.stat(f[:file]).inspect }
+        fresh_dangling_list.files.map { |f| File.stat(f[:file]).inspect }
       }
     end
   end
 end
 
-shared_examples 'does not remove database entries of fresh stale files' do
-  it 'does not remove database entries referencing fresh stale files' do
-    fresh_files = fresh_stale_list.db_entries.pluck(:file)
+shared_examples 'does not remove database entries of fresh dangling files' do
+  it 'does not remove database entries referencing fresh dangling files' do
+    fresh_files = fresh_dangling_list.db_entries.pluck(:file)
     silence_stdout do
       expect { command }.not_to change {
         DownloadedFile.where(local_path: fresh_files).pluck(:local_path)


### PR DESCRIPTION
## Description

This PR proposes an implementation for an `rmt-cli clean packages` command, which allows RMT users to remove stale packages from disk and database entries referencing those files.

Fixes  #662, though not exactly described: instead of directly checking the SCC API for identifying stale files, it relies on locally mirrored metadata, which, indirectly, should reflect the data on SCC (if mirror service is enabled in the RMT host).

## Change Type

*Please select the correct option.*

- [x] **Bug Fix** (a non-breaking change which fixes an issue)
- [x] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [x] I have verified that my code follows RMT's coding standards with `rubocop`.
- [x] I have reviewed my own code and believe that it's ready for an external review.
- [x] I have provided comments for any hard-to-understand code.
- [x] I have documented the `MANUAL.md` file with any changes to the user experience.
- [x] RMT's test coverage remains at 100%.
- [x] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.