### PR TITLE
Sll 185

### DIFF
--- a/public/tools/rmt-client-setup-res
+++ b/public/tools/rmt-client-setup-res
@@ -10,6 +10,8 @@ SUSECONNECT=/usr/bin/SUSEConnect
 RPM=/usr/bin/rpm
 DNF=/usr/bin/dnf
 CURL=/usr/bin/curl
+TEMPFILE="/etc/pki/ca-trust/source/anchors/rmt.crt"
+UPDATE_CA_TRUST=/usr/bin/update-ca-trust
 
 PARAMS=$@
 
@@ -79,6 +81,30 @@ if [ ! -x $CURL ]; then
     exit 1
 fi
 
+# Import Self-signed CERT as Trusted
+if [ -z "$REGCERT" ]; then
+    CERTURL=`echo "$REGURL" | awk -F/ '{print "https://" $3 "/rmt.crt"}'`
+else
+    CERTURL="$REGCERT"
+fi
+
+if [ -x $CURL ]; then
+    $CURL --tlsv1.2 --silent --insecure --connect-timeout 10 --output $TEMPFILE $CERTURL
+    if [ $? -ne 0 ]; then
+        echo "Download failed. Abort."
+        exit 1
+    fi
+else
+    download_tool_basename=$(basename $CURL)
+    echo "Binary to download the certificate not found. Please install $download_tool_basename. Abort."
+    exit 1
+fi
+
+if [ -x $UPDATE_CA_TRUST ]; then
+    $UPDATE_CA_TRUST enable
+    $UPDATE_CA_TRUST extract
+fi
+
 SLL_version=`cat /etc/os-release | grep "VERSION_ID" | cut -d\" -f2 | cut -d\. -f1`
 if [[ ${SLL_version} > 8 ]]; then                                                                                                       
    SLL_name="SLL";                                                                                                                
@@ -105,6 +131,10 @@ if [ -f /etc/dnf/protected.d/redhat-release.conf ]; then
     rm -f /etc/dnf/protected.d/redhat-release.conf;
 fi
 
+echo "Importing repomd.xml.key"
+$CURL --silent --show-error --insecure  ${REGURL}/repo/SUSE/Updates/${SLL_name}/${SLL_version}/x86_64/update/repodata/repomd.xml.key --output repomd.xml.key
+$RPM --import repomd.xml.key
+
 if [ ! -x $SUSECONNECT ]; then
     echo "Downloading SUSEConnect"
 
@@ -124,9 +154,6 @@ fi
 $CURL --silent --show-error --insecure $REGURL/tools/rmt-client-setup --output rmt-client-setup
 echo "Running rmt-client-setup $PARAMS"
 sh rmt-client-setup $PARAMS
-
-echo "Importing repomd.xml.key"
-$RPM --import ${REGURL}/repo/SUSE/Updates/${SLL_name}/${SLL_version}/x86_64/update/repodata/repomd.xml.key
 
 if [[ ${SLL_version} > 8 ]]; then 
     systemctl start suseconnect-keepalive.timer

--- a/public/tools/rmt-client-setup-res
+++ b/public/tools/rmt-client-setup-res
@@ -146,6 +146,13 @@ if [ ! -x $SUSECONNECT ]; then
     $DNF config-manager --add-repo ${REGURL}/repo/SUSE/Updates/${SLL_name}/${SLL_version}/x86_64/update
     $DNF config-manager --add-repo ${REGURL}/repo/SUSE/Updates/${SLL_name}-AS/${SLL_version}/x86_64/update
     $DNF install --allowerasing ${SLL_release_package}
+
+    // For SLL8, remove all old signing keys and import SUSE keys installed with sles_es-release package
+    if [[ ${SLL_version} -eq 8 ]]; then
+        $RPM -e gpg-pubkey-*
+        $RPM --import /etc/pki/rpm-gpg/*
+    fi
+
     $DNF install SUSEConnect librepo
     $DNF config-manager --set-disabled "${RMTNAME}_repo_SUSE_Updates_${SLL_name}_${SLL_version}_x86_64_update"
     $DNF config-manager --set-disabled "${RMTNAME}_repo_SUSE_Updates_${SLL_name}-AS_${SLL_version}_x86_64_update"

--- a/public/tools/rmt-client-setup-res
+++ b/public/tools/rmt-client-setup-res
@@ -12,8 +12,14 @@ DNF=/usr/bin/dnf
 CURL=/usr/bin/curl
 TEMPFILE="/etc/pki/ca-trust/source/anchors/rmt.crt"
 UPDATE_CA_TRUST=/usr/bin/update-ca-trust
+RPM_GPG_KEY_LOCATION="/etc/pki/rpm-gpg"
 
 PARAMS=$@
+
+function import_rpm_signing_keys()
+{
+    $RPM --import ${RPM_GPG_KEY_LOCATION}/*
+}
 
 function usage()
 {
@@ -147,15 +153,17 @@ if [ ! -x $SUSECONNECT ]; then
     $DNF config-manager --add-repo ${REGURL}/repo/SUSE/Updates/${SLL_name}-AS/${SLL_version}/x86_64/update
     $DNF install --allowerasing ${SLL_release_package}
 
-    // For SLL8, remove all old signing keys and import SUSE keys installed with sles_es-release package
+    # For RHEL8/CentOS8, remove all old signing keys and import SUSE keys installed with sles_es-release package
     if [[ ${SLL_version} -eq 8 ]]; then
-        $RPM -e gpg-pubkey-*
-        $RPM --import /etc/pki/rpm-gpg/*
+        import_rpm_signing_keys
     fi
 
     $DNF install SUSEConnect librepo
     $DNF config-manager --set-disabled "${RMTNAME}_repo_SUSE_Updates_${SLL_name}_${SLL_version}_x86_64_update"
     $DNF config-manager --set-disabled "${RMTNAME}_repo_SUSE_Updates_${SLL_name}-AS_${SLL_version}_x86_64_update"
+elif [[ ${SLL_version} -eq 8 ]]; then
+    # For SLL8, the release package is already installed, just import the keys
+    import_rpm_signing_keys
 fi
 
 $CURL --silent --show-error --insecure $REGURL/tools/rmt-client-setup --output rmt-client-setup


### PR DESCRIPTION
## Description

When registering SUSE Liberty Linux, download and import the repository certificate, and also import the signing keys for SLL8.
For SLL8, we changed signing key during the lifecycle, and the old method used by the script was importing only the latest signing key from the repository.
Now all valid signing keys are imported into the RPM database.
Contains a fix for systems installed from SLL8 media.

Fixes # (issue)
#994 
https://jira.suse.com/browse/SLL-185
https://jira.suse.com/browse/SLL-201

## Change Type

*Please select the correct option.*

- [x] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [x] I have verified that my code follows RMT's coding standards with `rubocop`.
- [x] I have reviewed my own code and believe that it's ready for an external review.
- [x] I have provided comments for any hard-to-understand code.
- [x] I have documented the `MANUAL.md` file with any changes to the user experience.
- [x] RMT's test coverage remains at 100%.
- [x] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Other Notes

Please use this space to provide notes or thoughts to the team, such as tips on how to review/demo your changes.
