### PR TITLE
CentOS8 client cannot register to rpm

### DIFF
--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu Oct 12 11:00:00 UTC 2023 - Zuzana Petrova <zpetrova@suse.com>
+
+- rmt-client-setup-res script: fix for CentOS8 clients (bsc#1214709)
+
+-------------------------------------------------------------------
 Wed Oct 04 13:23:00 UTC 2023 - Felix Schnizlein <fschnizlein@suse.com>
 
 - Version 2.15:

--- a/public/tools/rmt-client-setup-res
+++ b/public/tools/rmt-client-setup-res
@@ -128,7 +128,7 @@ dnf config-manager --disable $(dnf repolist -q | awk '{ print $1 }' | grep -v re
 
 # on Centos /usr/share/redhat-release is a file, on RHEL and RES it is a directory
 # so this is CentOS only workaround
-if [ -f /usr/share/redhat-release ]; then
+if [ -f /usr/share/redhat-release ] | [ -h /usr/share/redhat-release ]; then
    rm -f /usr/share/redhat-release;
 fi
 


### PR DESCRIPTION
symlink, but rpm expected directory.

## Description

in centos8 /usr/share/redhat-release is a symlink to centos-release. When register client to rmt, rpm tries to update centos-release.rpm to sll-release.rpm and fails because it cannot convert symlink to directory. Solution is to remove the file before register.

Fixes # (issue)

## Change Type

*Please select the correct option.*

- [ x] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [ ] I have verified that my code follows RMT's coding standards with `rubocop`.
- [ x] I have reviewed my own code and believe that it's ready for an external review.
- [ x] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ x] RMT's test coverage remains at 100%.
- [ x] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Other Notes

Please use this space to provide notes or thoughts to the team, such as tips on how to review/demo your changes.
