### PR TITLE
support: migrated to supportconfig.rc

### DIFF
--- a/support/README.md
+++ b/support/README.md
@@ -1,7 +1,7 @@
 Supportconfig plugin development notes
 ======================================
 
-Library of useful functions is installed by supportutils at: /usr/lib/supportconfig/resources/scplugin.rc
+Library of useful functions is installed by supportutils at: /usr/lib/supportconfig/resources/supportconfig.rc
 
 plugin functions begin with 'p'.
 

--- a/support/rmt
+++ b/support/rmt
@@ -5,31 +5,30 @@
 #              about RMT
 # License:     GPLv2
 # Author:      SCC Team <happy-customer@suse.de>
-# Modified:    2018 April 18
+# Modified:    2023-12-18
 #############################################################
 
-SVER=0.0.2
-RCFILE="/usr/lib/supportconfig/resources/scplugin.rc"
+SVER='0.0.3'
+RCFILE="/usr/lib/supportconfig/resources/supportconfig.rc"
+OF='output-rmt.txt'
 
 [ -s $RCFILE ] && . $RCFILE || { echo "ERROR: Initializing resource file: $RCFILE"; exit 1; }
 
 ## Our own helper functions
 validate_rpm_if_installed() {
   THISRPM=$1
-  echo "#==[ Validating RPM ]=================================#"
+  log_write $OF '#==[ Validating RPM ]=================================#'
   if rpm -q "$THISRPM" >/dev/null 2>&1; then
-    echo "# rpm -V $THISRPM"
-
-    if rpm -V "$THISRPM"; then
-      echo "Status: Passed"
+    if rpm -V $THISRPM >> ${LOG}/${OF} 2>&1; then
+      log_write $OF "Status: Passed"
     else
-      echo "Status: WARNING"
+      log_write $OF "Status: WARNING"
     fi
   else
-    echo "package $THISRPM is not installed"
-    echo "Status: Skipped"
+    log_write $OF "package $THISRPM is not installed"
+    log_write $OF "Status: Skipped"
   fi
-  echo
+  log_write $OF
 }
 
 RPMLIST=(rmt-server nginx mariadb)
@@ -40,51 +39,51 @@ LOG_UNITS=(rmt-server.service rmt-server-migration.service rmt-server-sync.servi
 
 CONF_FILES=(/etc/rmt.conf /etc/nginx/vhosts.d/rmt-server-http.conf /etc/nginx/vhosts.d/rmt-server-https.conf)
 
-section_header "Supportconfig Plugin for RMT, v${SVER}"
-if ! rpm -q rmt-server &>/dev/null; then
-  echo -e "ERROR: RMT rpm package ('rmt-server') not installed\n"
-  exit 111
-fi
+log_entry $OF note "Supportconfig Plugin for RMT, v${SVER}"
+rpm_verify $OF rmt-server || exit 111
 
-plugin_tag "Packages"
+log_entry $OF note 'Packages'
+
 for pkg in "${RPMLIST[@]}"; do
   validate_rpm_if_installed "$pkg"
 done
 
-plugin_tag "Configuration"
-pconf_files "$CONF_FILES"
+log_entry $OF note "Configuration"
+conf_files $OF "$CONF_FILES"
 
-plugin_tag "SSL Configuration"
-plugin_command "ls -l /usr/share/rmt/ssl/"
+log_entry $OF note "SSL Configuration"
+log_cmd $OF "ls -l /usr/share/rmt/ssl/"
 
 if systemctl --quiet is-active nginx; then
-  plugin_command "echo | openssl s_client -showcerts -servername localhost -connect localhost:443 2>/dev/null | openssl x509 -inform pem -noout -text"
+  log_cmd $OF "echo | openssl s_client -showcerts -servername localhost -connect localhost:443 2>/dev/null | openssl x509 -inform pem -noout -text"
 else
   for cert in /usr/share/rmt/ssl/rmt-ca.crt /usr/share/rmt/ssl/rmt-server.crt; do
-    plugin_command "openssl x509 -inform pem -noout -text -in $cert"
+    log_cmd $OF "openssl x509 -inform pem -noout -text -in $cert"
   done
 fi
 
-plugin_tag "Service Status"
+log_entry $OF note "Service Status"
 for i in "${STATUS_UNITS[@]}"; do
-  plugin_command "systemctl status $i"
+  log_cmd $OF "systemctl status $i"
 done
 
-plugin_tag "Mirroring Status"
-plugin_command "rmt-cli products list"
-plugin_command "rmt-cli repos list"
+log_entry $OF note "Mirroring Status"
+log_cmd $OF "rmt-cli products list"
+log_cmd $OF "rmt-cli repos list"
 
-plugin_tag "Service Logs"
+log_entry $OF note "Service Logs"
 for service in "${LOG_UNITS[@]}"; do
-  plugin_command "journalctl -n1000 -u $service"
+  log_cmd $OF "journalctl -n1000 -u $service"
 done
 
-plugin_tag "Custom Repos"
-plugin_command "rmt-cli repos custom list"
+log_entry $OF note "Custom Repos"
+log_cmd $OF "rmt-cli repos custom list"
 custom_repos=$(rmt-cli repos custom list --csv 2>/dev/null | sed 1d | cut -d ',' -f 1)
 if [ -n "$custom_repos" ]; then
   for custom in $custom_repos; do
-    echo "Products bound to custom repo id: $custom"
-    plugin_command "rmt-cli repos custom products $custom"
+    log_write $OF "Products bound to custom repo id: $custom"
+    log_cmd $OF "rmt-cli repos custom products $custom"
   done
 fi
+_sanitize_file $OF
+


### PR DESCRIPTION
## Description

ALP will not support the deprecated scplugin.rc framework. This commit, then, migrates our support script to work with supportconfig.rc.

This patch has been originally contributed by Jason Record on the linked Bugzilla entry.

Fixes bsc#1216389

## How to demo

**NOTE**: I have tested the following on a SLES15 SP4 machine. It would be extra dope if you could test it on other environments such as SLES12 LTSS.

The easiest route is to either install RMT on a machine, or re-use an existing installation. Thus, before any of this, ensure that `rmt-server` and `supportutils` are installed on your system. Then just copy the `support/rmt` file from this PR into `/usr/lib/supportconfig/plugins` and give it executable rights (as root):

```
# cp <path>/support/rmt /usr/lib/supportconfig/plugins/
# chmod +x /usr/lib/supportconfig/plugins/rmt
```

To ensure that the installation works, run `supportconfig` like so:

```
# supportconfig -F
```

There should be `prmt` (the 'p' is just a prefix for 'plugin'). You could try running just this plugin:

```
# supportconfig -i prmt
```

On the generated tarball, make sure that there is a file named `output-rmt.txt` with the results from this run.

Note that stuff like passwords have been blanked out by `supportconfig.rc`, this is to be expected. As a reference, this is the configuration as shown from my machine:

```
database:
  host: localhost
  database: rmt
  username: rmt
  password: *REMOVED BY SUPPORTCONFIG*
  adapter: mysql2
  encoding: utf8
  timeout: 5000
  pool: 5
```

## Change Type

*Please select the correct option.*

- [x] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [x] I have verified that my code follows RMT's coding standards with `rubocop`.
- [x] I have reviewed my own code and believe that it's ready for an external review.
- [x] I have provided comments for any hard-to-understand code.
- [x] I have documented the `MANUAL.md` file with any changes to the user experience.
- [x] RMT's test coverage remains at 100%.
- [x] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Other Notes

Please use this space to provide notes or thoughts to the team, such as tips on how to review/demo your changes.
