### PR TITLE
Fix secrets file access mode - for real!

### DIFF
--- a/lib/tasks/encrypted_key.rake
+++ b/lib/tasks/encrypted_key.rake
@@ -6,6 +6,8 @@ namespace :rmt do
 
       Rails::Generators::EncryptionKeyFileGenerator
         .new.add_key_file('config/secrets.yml.key')
+
+      FileUtils.chmod(0o640, 'config/secrets.yml.key')
     end
 
     desc 'Create the `secret_key_base` for Rails'
@@ -13,6 +15,8 @@ namespace :rmt do
       Rails::Secrets.write(
         { 'production' => { 'secret_key_base' => SecureRandom.hex(64) } }.to_yaml
       )
+
+      FileUtils.chmod(0o640, 'config/secrets.yml.enc')
     end
   end
 end

--- a/package/files/update_rmt_app_dir_permissions.sh
+++ b/package/files/update_rmt_app_dir_permissions.sh
@@ -20,7 +20,7 @@ fi
 # Change secrets encrypted and key files to nginx readable
 secret_key_files=('config/secrets.yml.key' 'config/secrets.yml.enc')
 
-for secretFile in $secret_key_files; do
+for secretFile in ${secret_key_files[@]}; do
   file_path="$app_dir/$secretFile"
   if [[ -e $file_path ]]; then
     if [[ "$(stat -c "%U %G" $file_path)" == "root root" ]]; then

--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -6,6 +6,8 @@ Wed Oct 04 13:23:00 UTC 2023 - Felix Schnizlein <fschnizlein@suse.com>
     allow transmitting system information dynamically. (jsc#PED-3734)
   * Fix secrets access for server user (bsc#1215176)
   * rmt-client-setup-res script: fix for CentOS8 clients (bsc#1214709)
+  * Updated supportconfig script (bsc#1216389)
+
 -------------------------------------------------------------------
 Thu Jun 06 15:44:00 UTC 2023 - Luís Caparroz <lcaparroz@suse.com>
 


### PR DESCRIPTION
## Description

The problem is that the file permission where originally wrong and breaks RMT completely because it can not read the secrets. This fixes the permissions for both files without relying on handling this in the spec file where it should **not** be handled anyway.

![image](https://github.com/SUSE/rmt/assets/4460715/db94ca2c-fb83-4d61-8702-9f8a61b23e72)


original:
```
-rwxr-xr-x 1 root root  1277 Dec 12 05:42 /usr/share/rmt/config/secrets.yml
-rw-r--r-- 1 root nginx  280 Jan  2 13:52 /usr/share/rmt/config/secrets.yml.enc
-rw------- 1 root nginx   32 Jan  2 13:52 /usr/share/rmt/config/secrets.yml.key
```
but we need due to hardening:

```
-rwxr-xr-x 1 root root  1277 Dec 12 05:42 /usr/share/rmt/config/secrets.yml
-rw-r----- 1 root nginx  280 Jan  2 13:52 /usr/share/rmt/config/secrets.yml.enc
-rw-r----- 1 root nginx   32 Jan  2 13:52 /usr/share/rmt/config/secrets.yml.key
```
see: https://bugzilla.suse.com/show_bug.cgi?id=1215176

Fixes file permission for `config/secrets.yml.key` and `config/secrets.yml.enc` to `0640` during fresh install.

**part of**: https://trello.com/c/hL2IyVT1/3061-fix-rmt-server-install-creates-secretsymlkey-with-root-owner
**fixed version of**: https://github.com/SUSE/rmt/pull/1062

**How to test this pull request:**

```bash
$ docker run --rm -it registry.suse.com/suse/sle15:15.4
> zypper ar https://download.opensuse.org/repositories/systemsmanagement:/SCC:/RMT/SLE_15_SP4/systemsmanagement:SCC:RMT.repo
> zypper refresh
> zypper in rmt-server
> ls -la /usr/share/rmt/config
# expect: File permissions for .enc and .key are 0640
```

**Thank you for reviewing this pull request** :rocket:
