### PR TITLE
Bump repomd_parser to 0.1.6 for ztd and pin gems which have 2.6+ dependency on later versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,14 +9,14 @@ gem 'puma', '~> 5.6.2'
 gem 'mysql2', '~> 0.5.3'
 
 gem 'nokogiri', '< 1.13' # Locked because of Ruby >= 2.6 dependency
-gem 'thor'
+gem 'thor', '<= 1.2.2' # Locked because of Ruby >= 2.6 dependency
 gem 'activesupport', '~> 6.1.7'
 gem 'actionpack', '~> 6.1.7'
 gem 'actionview', '~> 6.1.7'
 gem 'activemodel', '~> 6.1.7'
 gem 'activerecord', '~> 6.1.7'
 gem 'railties', '~> 6.1.7'
-gem 'repomd_parser', '~> 0.1.4'
+gem 'repomd_parser', '~> 0.1.6'
 
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 # gem 'jbuilder', '~> 2.5'
@@ -60,7 +60,7 @@ group :test do
   gem 'rspec-command', '1.0.3'
   gem 'rspec-rails', '~> 5.0'
   gem 'factory_bot_rails', '~> 6.2.0'
-  gem 'ffaker'
+  gem 'ffaker', '<= 2.21.0' # Locked because of Ruby >= 3.0 dependency
   gem 'rspec-its'
   gem 'fakefs', '~> 1.4', require: 'fakefs/safe'
   gem 'shoulda-matchers'
@@ -76,7 +76,7 @@ end
 gem 'simplecov', require: false, group: :test
 
 gem 'versionist'
-gem 'responders'
+gem 'responders', '~> 3.1.1'
 gem 'typhoeus'
 gem 'active_model_serializers'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -194,9 +194,10 @@ GEM
       ffi (~> 1.0)
     rdiscount (2.2.0.2)
     regexp_parser (2.6.0)
-    repomd_parser (0.1.5)
+    repomd_parser (0.1.6)
       nokogiri (~> 1.8)
-    responders (3.1.0)
+      zstd-ruby (~> 1.3, >= 1.3.5.0)
+    responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
     rexml (3.2.6)
@@ -310,6 +311,7 @@ GEM
       hashdiff (>= 0.4.0, < 2.0.0)
     yard (0.9.25)
     zeitwerk (2.6.12)
+    zstd-ruby (1.5.5.0)
 
 PLATFORMS
   ruby
@@ -328,7 +330,7 @@ DEPENDENCIES
   factory_bot_rails (~> 6.2.0)
   fakefs (~> 1.4)
   fast_gettext (~> 2.2)
-  ffaker
+  ffaker (<= 2.21.0)
   fuubar
   gettext
   gettext_i18n_rails
@@ -343,8 +345,8 @@ DEPENDENCIES
   public_suffix (< 5)
   puma (~> 5.6.2)
   railties (~> 6.1.7)
-  repomd_parser (~> 0.1.4)
-  responders
+  repomd_parser (~> 0.1.6)
+  responders (~> 3.1.1)
   ronn
   rspec-command (= 1.0.3)
   rspec-its
@@ -360,7 +362,7 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
   strong_migrations
   terminal-table (~> 3.0)
-  thor
+  thor (<= 1.2.2)
   timecop
   typhoeus
   vcr (~> 6.0)

--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -7,6 +7,7 @@ Wed Oct 04 13:23:00 UTC 2023 - Felix Schnizlein <fschnizlein@suse.com>
   * Dropping Rails Secrets facilities and related config files (bsc#1215176)
   * rmt-client-setup-res script: fix for CentOS8 clients (bsc#1214709)
   * Updated supportconfig script (bsc#1216389)
+  * Support zstd compression for repository metadata (bsc#1218775)
 
 -------------------------------------------------------------------
 Thu Jun 06 15:44:00 UTC 2023 - Luís Caparroz <lcaparroz@suse.com>


### PR DESCRIPTION
part of: https://trello.com/c/BfrlfQwR/3154-support-zst-compression-format-in-rmt
Also handles:  https://github.com/SUSE/rmt/pull/1045 and https://github.com/SUSE/rmt/pull/1042
fixes: https://github.com/SUSE/rmt/issues/1050

This is updating `repomd_parser` which now comes with zstd support and pinning gems which updates now requires `ruby 2.6+` to work.

**How to review this pull request:**
- Run `bundle` and see updates coming through

- Check `zstd` support:

```
$ bin/rmt-cli repos custom add http://download.opensuse.org/tumbleweed/repo/oss/ tumble-oss
$ bin/rmt-cli mirror repository tumble-oss
# expect: Wait until it starts downloading `rpm` packages to know it successfully parsed the `primary.xml.zst` file
```

**Thank you for reviewing this pull request! If you have questions, please do not hesitate to ask!** :rocket:
