### PR TITLE
Do not add service credential url paramter if not necessary

### DIFF
--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -30,9 +30,15 @@ class ServicesController < ApplicationController
 
     builder = Builder::XmlMarkup.new
     service_xml = builder.repoindex(ttl: ZYPPER_SERVICE_TTL) do
+      # NOTE: We only care to add the ?credentials parameter to the repository URL if
+      # we are *NOT* dealing with plain RMT but the authentication engine of Public Cloud.
+      # The engine requires to supply the service name to function properly, since repositories
+      # are authenticated in this case.
+      service_name = defined?(StrictAuthentication::Engine) ? service.name : nil
+
       repos.each do |repo|
         attributes = {
-          url: make_repo_url(request.base_url, repo.local_path, service.name),
+          url: make_repo_url(request.base_url, repo.local_path, service_name),
           alias: repo.name,
           name: repo.name,
           autorefresh: repo.autorefresh,

--- a/lib/rmt/misc.rb
+++ b/lib/rmt/misc.rb
@@ -4,6 +4,9 @@ module RMT
   module Misc
     def self.make_repo_url(base_url, local_path, service_name = nil)
       uri = URI.join(base_url, File.join(RMT::DEFAULT_MIRROR_URL_PREFIX, local_path))
+      # NOTE: Make sure to only add the credentials where necessary (Pubcloud? or SMT?)
+      # In all other cases do not add them, since this will break other repository
+      # managers such as yum!
       uri.query = "credentials=#{service_name}" if service_name
       uri.to_s
     end

--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -1,5 +1,5 @@
 -------------------------------------------------------------------
-Wed Oct 04 13:23:00 UTC 2023 - Felix Schnizlein <fschnizlein@suse.com>
+Thu Jan 25 17:40:00 UTC 2024 - Felix Schnizlein <fschnizlein@suse.com>
 
 - Version 2.15:
   * Moving system hardware information to systems database table to
@@ -8,6 +8,7 @@ Wed Oct 04 13:23:00 UTC 2023 - Felix Schnizlein <fschnizlein@suse.com>
   * rmt-client-setup-res script: fix for CentOS8 clients (bsc#1214709)
   * Updated supportconfig script (bsc#1216389)
   * Support zstd compression for repository metadata (bsc#1218775)
+  * Do not add credential handling to normal repository URLs (#1219153)
 
 -------------------------------------------------------------------
 Thu Jun 06 15:44:00 UTC 2023 - Luís Caparroz <lcaparroz@suse.com>

--- a/spec/requests/services_controller_spec.rb
+++ b/spec/requests/services_controller_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe ServicesController do
 
       let(:model_urls) do
         service.repositories.reject(&:installer_updates).map do |repo|
-          RMT::Misc.make_repo_url('http://www.example.com', repo.local_path, service.name)
+          RMT::Misc.make_repo_url('http://www.example.com', repo.local_path)
         end
       end
 


### PR DESCRIPTION
In normal RMT environments, zypper services do not need a ?credentials URL parameter since the repository path is not authenticated.
So do not add it and allow yum to work with RMT for SLL7

part of: https://trello.com/c/BSMxlGDN/3166-help-liberty-team-get-suseconnect-working-on-liberty-7

**How to review this pull request:**

```bash
$ cd <rmt>
$ git checkout no-credentials-in-service-url
$ rails server

# another terminal
$ docker run --rm -it --network=host registry.suse.com/suse/sle15:15.4
> zypper in -y suseconnect-ng curl tidy
> SUSEConnect --url http://localhost:4224
> cat /etc/zypp/credentials.d/SCCcredentials
> curl -u <username:password> http://localhost:4224/services/2292 | tidy -xml -iq 
# expect: There is no `?credentials=XXX` in the repo.url
```

**If you have any questions, please do not hesitate to reach out to me!** :rocket:

**Thank you!**