### PR TITLE
Remove old RES7 repositories in a database migration

### DIFF
--- a/db/migrate/20240129140413_remove_obsolete_res7_repositories.rb
+++ b/db/migrate/20240129140413_remove_obsolete_res7_repositories.rb
@@ -1,0 +1,14 @@
+class RemoveObsoleteRes7Repositories < ActiveRecord::Migration[6.1]
+  def change
+    # RES7 was historically a product managed by Novell. With the upcoming
+    # SUSE Liberty 7, RES7 was moved into IBS (SUSE build service).
+    # This resulted in repositories being renamed.
+    # This migration removes the now obsolete repositories, since RMT does
+    # not remove these automatically.
+
+    # Affected repositories are:
+    # - 1963: https://updates.suse.com/repo/$RCE/RES7/src/
+    # - 1736: https://updates.suse.com/repo/$RCE/RES7/x86_64/
+    Repository.where(scc_id: [1963, 1736]).destroy_all
+  end
+end


### PR DESCRIPTION
part of: https://trello.com/c/BSMxlGDN/3166-help-liberty-team-get-suseconnect-working-on-liberty-7

This removes the old obsolete repositories, since RMT does not automatically remove them.

**How to test this change:**

- Find a RMT server which is running for some time now.
- Check if the server is affected by:
```
$ rails c
> Product.find(1251).repositories.pluck(:name,:scc_id,  :external_url)
# expect: It should show 4 repositories including 'RES' and 'RES' (src)
```
- Run the migration:
```
$ rails db:migrate
$ rails c
> Product.find(1251).repositories.pluck(:name,:scc_id,  :external_url)
# expect: Does only show 2 repositories
```

**As always, if you have question or suggestions, please do not hesitate to ask!**:rocket:

Thank you!
