### PR TITLE
2.15 Pre-release

### DIFF
--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -1,14 +1,15 @@
 -------------------------------------------------------------------
-Thu Jan 25 17:40:00 UTC 2024 - Felix Schnizlein <fschnizlein@suse.com>
+Thu Feb 08 15:33:00 UTC 2024 - Felix Schnizlein <fschnizlein@suse.com>
 
 - Version 2.15:
   * Moving system hardware information to systems database table to
     allow transmitting system information dynamically. (jsc#PED-3734)
   * Dropping Rails Secrets facilities and related config files (bsc#1215176)
-  * rmt-client-setup-res script: fix for CentOS8 clients (bsc#1214709)
   * Updated supportconfig script (bsc#1216389)
   * Support zstd compression for repository metadata (bsc#1218775)
-  * Do not add credential handling to normal repository URLs (#1219153)
+  * Do not add credential handling to normal repository URLs (bsc#1219153)
+  * Disable authentication for license files in pubcloud context
+  * Higher registration sharing timeout
 
 -------------------------------------------------------------------
 Thu Jun 06 15:44:00 UTC 2023 - Luís Caparroz <lcaparroz@suse.com>


### PR DESCRIPTION
We are almost there, just waiting for SLL7 script changes to release 2.15 finally!
The pre-release is for PCT/SRE to test the release early.

It is still missing SLL7 script changes.