### PR TITLE
Add missing build require for sqlite; the real pre-release

### DIFF
--- a/package/obs/rmt-server.spec
+++ b/package/obs/rmt-server.spec
@@ -49,6 +49,7 @@ BuildRequires:  gcc
 BuildRequires:  libcurl-devel
 BuildRequires:  libffi-devel
 BuildRequires:  libmysqlclient-devel
+BuildRequires:  sqlite-devel
 BuildRequires:  libxml2-devel
 BuildRequires:  libxslt-devel
 BuildRequires:  pkgconfig(systemd)


### PR DESCRIPTION
## Description

sqlite is missing as build requirement.

**How to review this pull request:**

- It builds in obs!