### PR TITLE
Add BYOS info to SCC GET request

### DIFF
--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -157,6 +157,7 @@ module SccProxy
       uri = URI.parse(SYSTEMS_ACTIVATIONS_URL)
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true
+      uri.query = URI.encode_www_form({ byos: true })
       scc_request = Net::HTTP::Get.new(uri.path, headers(auth, system_token))
       response = http.request(scc_request)
       unless response.code_type == Net::HTTPOK

--- a/engines/zypper_auth/spec/requests/strict_authentication/authentication_controller_spec.rb
+++ b/engines/zypper_auth/spec/requests/strict_authentication/authentication_controller_spec.rb
@@ -125,6 +125,7 @@ describe StrictAuthentication::AuthenticationController, type: :request do
         context 'when subscription is active' do
           before do
             stub_request(:get, scc_systems_activations_url).to_return(status: 200, body: [body_active].to_json, headers: {})
+            expect(URI).to receive(:encode_www_form).with({ byos: true })
             get '/api/auth/check', headers: headers
           end
 
@@ -134,6 +135,7 @@ describe StrictAuthentication::AuthenticationController, type: :request do
         context 'when subscription is expired' do
           before do
             stub_request(:get, scc_systems_activations_url).to_return(status: 200, body: [body_expired].to_json, headers: {})
+            expect(URI).to receive(:encode_www_form).with({ byos: true })
             get '/api/auth/check', headers: headers
           end
 
@@ -143,6 +145,7 @@ describe StrictAuthentication::AuthenticationController, type: :request do
         context 'when product is not activated' do
           before do
             stub_request(:get, scc_systems_activations_url).to_return(status: 200, body: [body_not_activated].to_json, headers: {})
+            expect(URI).to receive(:encode_www_form).with({ byos: true })
             get '/api/auth/check', headers: headers
           end
 
@@ -152,6 +155,7 @@ describe StrictAuthentication::AuthenticationController, type: :request do
         context 'when status from SCC is unknown' do
           before do
             stub_request(:get, scc_systems_activations_url).to_return(status: 200, body: [body_unknown_status].to_json, headers: {})
+            expect(URI).to receive(:encode_www_form).with({ byos: true })
             get '/api/auth/check', headers: headers
           end
 
@@ -161,6 +165,7 @@ describe StrictAuthentication::AuthenticationController, type: :request do
         context 'when SCC request fails' do
           before do
             stub_request(:get, scc_systems_activations_url).to_return(status: 401, body: [body_expired].to_json, headers: {})
+            expect(URI).to receive(:encode_www_form).with({ byos: true })
             get '/api/auth/check', headers: headers
           end
 

--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Wed Mar  6 14:08:42 UTC 2024 - Jesús Bermúdez Velázquez <jesus.bv@suse.com>
+
+- rmt-server-pubcloud
+  When checking SCC for subscription expiration
+  on a GET request, SCC does rotate the system token
+
+  Set the byos info on the request to fix that 
+
+-------------------------------------------------------------------
 Thu Feb 20 15:36:00 UTC 2024 - Zuzana Petrova <zpetrova@suse.com>
 
 - Fix for SUSE Liberty registration script to allow RHEL7/SLL7/CentOS7 


### PR DESCRIPTION
## Description

When checking SCC for subscription expiration
on a GET request, SCC does rotate the system token

Set the byos info on the request to fix that

Update changelog to keep track of pub cloud changes

## Change Type

*Please select the correct option.*

- [X] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have verified that my code follows RMT's coding standards with `rubocop`.
- [X] I have reviewed my own code and believe that it's ready for an external review.
- [ ] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [X] RMT's test coverage remains at 100%.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Other Notes

Please use this space to provide notes or thoughts to the team, such as tips on how to review/demo your changes.
