### PR TITLE
make sure fixed version of yum (not affected with bsc#1221223) is installed

### DIFF
--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu Mar 12 11:20:00 UTC 2024 - Zuzana Petrova <zpetrova@suse.com>
+
+- make sure yum that can read repomd.xml correctly is installed (bsc#1221223)
+
+-------------------------------------------------------------------
 Thu Mar 07 15:33:00 UTC 2024 - Likhitha Priya <likhitha.priyad@suse.com>
 
 - Version 2.15:

--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -8,8 +8,8 @@ Thu Mar 07 15:33:00 UTC 2024 - Likhitha Priya <likhitha.priyad@suse.com>
   * Updated supportconfig script (bsc#1216389)
   * Support zstd compression for repository metadata (bsc#1218775)
   * Do not add credential handling to normal repository URLs (bsc#1219153)
-    * Fix for SUSE Liberty registration script to allow RHEL7/SLL7/CentOS7 clients to register to RMT servers
-  * make sure yum that can read repomd.xml correctly is installed (bsc#1221223)
+  * Fix for SUSE Liberty registration script to allow RHEL7/SLL7/CentOS7 clients to register to RMT servers
+    * make sure yum that can read repomd.xml correctly is installed (bsc#1221223)
   * Provide user/group symbol for user created during pre (boo#1219540)
   * Disable authentication for license files in pubcloud context
   * Higher registration sharing timeout

--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -1,9 +1,4 @@
 -------------------------------------------------------------------
-Thu Mar 12 11:20:00 UTC 2024 - Zuzana Petrova <zpetrova@suse.com>
-
-- make sure yum that can read repomd.xml correctly is installed (bsc#1221223)
-
--------------------------------------------------------------------
 Thu Mar 07 15:33:00 UTC 2024 - Likhitha Priya <likhitha.priyad@suse.com>
 
 - Version 2.15:
@@ -13,7 +8,8 @@ Thu Mar 07 15:33:00 UTC 2024 - Likhitha Priya <likhitha.priyad@suse.com>
   * Updated supportconfig script (bsc#1216389)
   * Support zstd compression for repository metadata (bsc#1218775)
   * Do not add credential handling to normal repository URLs (bsc#1219153)
-  * Fix for SUSE Liberty registration script to allow RHEL7/SLL7/CentOS7 clients to register to RMT servers
+    * Fix for SUSE Liberty registration script to allow RHEL7/SLL7/CentOS7 clients to register to RMT servers
+  * make sure yum that can read repomd.xml correctly is installed (bsc#1221223)
   * Provide user/group symbol for user created during pre (boo#1219540)
   * Disable authentication for license files in pubcloud context
   * Higher registration sharing timeout

--- a/public/tools/rmt-client-setup-res
+++ b/public/tools/rmt-client-setup-res
@@ -190,6 +190,7 @@ elif [[ ${SLL_version} -eq 7 ]]; then
 	 $YUM_CONFIG_MGR --enable *suse.* > /dev/null
 
 	$YUM install sles_es-release-server suseconnect-ng librepo
+	$YUM update yum
 
 
 fi


### PR DESCRIPTION
## Description

Please describe your change and provide as much context as possible.

Newest yum update released last week break our repository (cannot read repomd.xml)
(bsc#1221223)
This script makes sure fixed yum is installed.

Fixes # (issue)
(bsc#1221223)

## Change Type

*Please select the correct option.*

- [x ] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [ ] I have verified that my code follows RMT's coding standards with `rubocop`.
- [ x] I have reviewed my own code and believe that it's ready for an external review.
- [ x] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] RMT's test coverage remains at 100%.
- [ x] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

My changes are trivial, so I think changelog entry is not necessary, but nyway I wrote changelog entry.

## Other Notes

Please use this space to provide notes or thoughts to the team, such as tips on how to review/demo your changes.
