### PR TITLE
Fix redefinition warnings - warning: already initialized constant RMT::Downloader::RETRIES

### DIFF
--- a/lib/rmt/mirror/repomd.rb
+++ b/lib/rmt/mirror/repomd.rb
@@ -1,7 +1,4 @@
-require 'rmt/downloader'
-require 'rmt/gpg'
 require 'repomd_parser'
-require 'time'
 
 class RMT::Mirror::Repomd < RMT::Mirror::Base
 


### PR DESCRIPTION
## Description

Fixes redefinition warnings because we superfluously imported `rmt/downloader` explicitly while its already imported implicitly.

![image](https://github.com/SUSE/rmt/assets/4460715/5868a417-b09a-4c71-af5e-af3d76ed596e)


**How to test these changes?**

```
# or any other repomd based product!
$ bin/rmt-cli products enable SLES/15.4/x86_64
$ bin/rmt-cli mirror
# expect: You should not see any warnings as shown above!
```

Thank you very much! :rocket:

PS: As always, if you have trouble reviewing this pullrequest, please do not hesitate to reach out for help!