### PR TITLE
Force reauth

### DIFF
--- a/engines/registry/README.md
+++ b/engines/registry/README.md
@@ -3,11 +3,11 @@ Provide an authentication end point for a container registry.
 This supports access control based on system credentials to registry paths that are set to have access restrictions.
 
 
-The Activations endpoint would perform a validation of the instance metadata when the request has `X-Refresh-Registry-Creds` header and it would update the cache for granting access to the registry
+The Activations endpoint would perform a validation of the instance metadata when the request has `X-Instance-Data` header and it would update the cache for granting access to the registry
 
 Instance validation and cache:
 
-- If the registry header is set on the request, instance verification
+- If the instance data header is set on the request, instance verification
   and cache handling would be triggered
 - If instance metadata is valid, the cache would be updated if expired
   and access to the registry is granted

--- a/engines/registry/README.md
+++ b/engines/registry/README.md
@@ -1,3 +1,15 @@
 # Registry
 Provide an authentication end point for a container registry.
 This supports access control based on system credentials to registry paths that are set to have access restrictions.
+
+
+The Activations endpoint would perform a validation of the instance metadata when the request has `X-Refresh-Registry-Creds` header and it would update the cache for granting access to the registry
+
+Instance validation and cache:
+
+- If the registry header is set on the request, instance verification
+  and cache handling would be triggered
+- If instance metadata is valid, the cache would be updated if expired
+  and access to the registry is granted
+- If instance metadata is not valid, cache would not be updated and
+  access to the registry would be denied

--- a/engines/registry/app/controllers/registry/registry_controller.rb
+++ b/engines/registry/app/controllers/registry/registry_controller.rb
@@ -54,9 +54,11 @@ module Registry
       # skip authentication if this is not a login request
       return unless request.authorization
 
+      @remote_ip = request.remote_ip
+
       authenticate_or_request_with_http_basic('SUSE Registry Authentication') do |login, password|
         begin
-          @client = Registry::AuthenticatedClient.new(login, password)
+          @client = Registry::AuthenticatedClient.new(login, password, @remote_ip)
         rescue StandardError
           logger.info _('Could not find system with login \"%{login}\" and password \"%{password}\"') %
             { login: login, password: password }

--- a/engines/registry/app/controllers/registry/registry_controller.rb
+++ b/engines/registry/app/controllers/registry/registry_controller.rb
@@ -54,11 +54,9 @@ module Registry
       # skip authentication if this is not a login request
       return unless request.authorization
 
-      @remote_ip = request.remote_ip
-
       authenticate_or_request_with_http_basic('SUSE Registry Authentication') do |login, password|
         begin
-          @client = Registry::AuthenticatedClient.new(login, password, @remote_ip)
+          @client = Registry::AuthenticatedClient.new(login, password, request.remote_ip)
         rescue StandardError
           logger.info _('Could not find system with login \"%{login}\" and password \"%{password}\"') %
             { login: login, password: password }

--- a/engines/registry/app/models/registry/authenticated_client.rb
+++ b/engines/registry/app/models/registry/authenticated_client.rb
@@ -15,11 +15,12 @@ class Registry::AuthenticatedClient
   private
 
   def authenticate_by_system_credentials(login, password, remote_ip)
+    @systems = System.get_by_credentials(login, password)
     expiration_value = Settings[:registry].try(:token_expiration) || 8.hours.to_i
     cache_key = [remote_ip, login].join('-')
     registry_cache_path = Rails.root.join('tmp', 'registry', 'cache', cache_key)
     cache_created = File.exist?(registry_cache_path)
-    if cache_created
+    if !@systems.empty? && cache_created
       is_registry_cache_active = File.ctime(registry_cache_path) > expiration_value.seconds.ago
       if is_registry_cache_active
         @account = login

--- a/engines/registry/app/models/registry/authenticated_client.rb
+++ b/engines/registry/app/models/registry/authenticated_client.rb
@@ -15,17 +15,18 @@ class Registry::AuthenticatedClient
   private
 
   def authenticate_by_system_credentials(login, password, remote_ip)
-    @systems = System.get_by_credentials(login, password)
     expiration_value = Settings[:registry].try(:token_expiration) || 8.hours.to_i
     cache_key = [remote_ip, login].join('-')
     registry_cache_path = Rails.root.join('tmp', 'registry', 'cache', cache_key)
     cache_created = File.exist?(registry_cache_path)
-    time_has_not_expired = @systems.any? { |system| system.last_seen_at > expiration_value.seconds.ago }
-    if time_has_not_expired && cache_created
-      @account = login
-      @auth_strategy = :system_credentials
+    if cache_created
+      is_registry_cache_active = File.ctime(registry_cache_path) > expiration_value.seconds.ago
+      if is_registry_cache_active
+        @account = login
+        @auth_strategy = :system_credentials
+      end
+      File.delete(registry_cache_path) unless is_registry_cache_active
     end
-    File.delete(registry_cache_path) unless time_has_not_expired
     @auth_strategy
   end
 end

--- a/engines/registry/lib/registry/engine.rb
+++ b/engines/registry/lib/registry/engine.rb
@@ -11,8 +11,8 @@ module Registry
 
         def handle_cache
           # get request header
-          if request.headers['X-Registry']
-            # creatte cache directory
+          if request.headers['X-Refresh-Registry-Creds'] && ZypperAuth.verify_instance(request, logger, @system)
+            # create cache directory
             registry_cache_dir_path = Rails.root.join('tmp/registry/cache')
             FileUtils.mkdir_p(registry_cache_dir_path)
 

--- a/engines/registry/lib/registry/engine.rb
+++ b/engines/registry/lib/registry/engine.rb
@@ -1,6 +1,28 @@
+require 'fileutils'
+
 module Registry
   class Engine < ::Rails::Engine
     isolate_namespace Registry
     config.generators.api_only = true
+
+    # REGISTRY_CACHE_PATH = Rails.root.join('tmp', 'registry', 'cache')
+
+    config.after_initialize do
+      Api::Connect::V3::Systems::ActivationsController.class_eval do
+
+        before_action :handle_cache, only: %w[index]
+
+        def handle_cache
+          # get request header
+          if request.headers['X-Registry']
+            registry_cache_path = Rails.root.join('tmp', 'registry', 'cache')
+            Dir.mkdir(registry_cache_path) unless Dir.exist?(registry_cache_path)
+
+            cache_key = [request.remote_ip, @system.login].join('-')
+            FileUtils.touch File.join(registry_cache_path, cache_key)
+          end
+        end
+      end
+    end
   end
 end

--- a/engines/registry/lib/registry/engine.rb
+++ b/engines/registry/lib/registry/engine.rb
@@ -5,17 +5,14 @@ module Registry
     isolate_namespace Registry
     config.generators.api_only = true
 
-    # REGISTRY_CACHE_PATH = Rails.root.join('tmp', 'registry', 'cache')
-
     config.after_initialize do
       Api::Connect::V3::Systems::ActivationsController.class_eval do
-
         before_action :handle_cache, only: %w[index]
 
         def handle_cache
           # get request header
           if request.headers['X-Registry']
-            registry_cache_path = Rails.root.join('tmp', 'registry', 'cache')
+            registry_cache_path = Rails.root.join('tmp/registry/cache')
             Dir.mkdir(registry_cache_path) unless Dir.exist?(registry_cache_path)
 
             cache_key = [request.remote_ip, @system.login].join('-')

--- a/engines/registry/lib/registry/engine.rb
+++ b/engines/registry/lib/registry/engine.rb
@@ -11,7 +11,7 @@ module Registry
 
         def handle_cache
           # get request header
-          if request.headers['X-Refresh-Registry-Creds'] && ZypperAuth.verify_instance(request, logger, @system)
+          if request.headers['X-Instance-Data'] && ZypperAuth.verify_instance(request, logger, @system)
             # create cache directory
             registry_cache_dir_path = Rails.root.join('tmp/registry/cache')
             FileUtils.mkdir_p(registry_cache_dir_path)

--- a/engines/registry/spec/api/connect/v3/systems/activations_controller_spec.rb
+++ b/engines/registry/spec/api/connect/v3/systems/activations_controller_spec.rb
@@ -1,0 +1,40 @@
+describe Api::Connect::V3::Systems::ActivationsController, type: :request do
+  include_context 'auth header', :system, :login, :password
+  include_context 'version header', 3
+
+  describe '#activations for Registry' do
+    let(:system) { FactoryBot.create(:system, :with_activated_product) }
+    let(:headers) { auth_header.merge(version_header) }
+
+    context 'without X-Instance-Data headers or hw_info' do
+      it 'No instance metadata verification and no cache update' do
+        get '/connect/systems/activations', headers: headers
+        expect(ZypperAuth).not_to receive(:verify_instance)
+        expect(FileUtils).not_to receive(:touch)
+      end
+    end
+
+    context 'with invalid X-Instance-Data headers' do
+      let(:headers) { auth_header.merge(version_header).merge({ 'X-Instance-Data' => 'instance_data' }) }
+
+      it 'Instance metadata verification and no cache update' do
+        expect(ZypperAuth).to receive(:verify_instance)
+        expect(FileUtils).not_to receive(:touch)
+        get '/connect/systems/activations', headers: headers
+      end
+    end
+
+    context 'with X-Instance-Data headers' do
+      let(:headers) { auth_header.merge(version_header).merge({ 'X-Instance-Data' => 'instance_data' }) }
+
+      it 'verify the instance metadata and update the cache' do
+        expect(FileUtils).to receive(:touch)
+        allow(File).to receive(:join).and_return('foo')
+
+        allow(FileUtils).to receive(:mkdir_p)
+        allow(ZypperAuth).to receive(:verify_instance).and_return(true)
+        get '/connect/systems/activations', headers: headers
+      end
+    end
+  end
+end

--- a/engines/registry/spec/app/models/registry/authenticated_client_spec.rb
+++ b/engines/registry/spec/app/models/registry/authenticated_client_spec.rb
@@ -6,18 +6,21 @@ describe Registry::AuthenticatedClient do
       let(:system) { create(:system, :with_last_seen_at) }
 
       context 'with valid credentials' do
-        subject(:client) { described_class.new(system.login, system.password) }
+        subject(:client) { described_class.new(system.login, system.password, '23.23.23.23') }
 
         it 'returns the auth strategy' do
+          allow(File).to receive(:exist?).and_return(true)
           expect(client.systems).to eq([system])
           expect(client.auth_strategy).to eq(:system_credentials)
         end
       end
 
       context 'with invalid password' do
-        subject(:client) { described_class.new(system.login, 'wrong') }
+        subject(:client) { described_class.new(system.login, 'wrong', '23.23.23.23') }
 
         it 'raises' do
+          allow(File).to receive(:exist?).and_return(true)
+          allow(File).to receive(:delete)
           expect { client }.to raise_error(Registry::Exceptions::InvalidCredentials)
         end
       end
@@ -27,9 +30,10 @@ describe Registry::AuthenticatedClient do
       let(:system) { create(:system, last_seen_at: Settings[:registry].token_expiration.seconds.ago) }
 
       context 'even with valid credentials' do
-        subject(:client) { described_class.new(system.login, system.password) }
+        subject(:client) { described_class.new(system.login, system.password, '23.23.23.23') }
 
         it 'raises' do
+          allow(File).to receive(:delete)
           expect { client }.to raise_error(Registry::Exceptions::InvalidCredentials)
         end
       end

--- a/engines/registry/spec/app/models/registry/authenticated_client_spec.rb
+++ b/engines/registry/spec/app/models/registry/authenticated_client_spec.rb
@@ -3,13 +3,14 @@ require 'spec_helper'
 describe Registry::AuthenticatedClient do
   describe '.new' do
     context 'with system credentials' do
-      let(:system) { create(:system, :with_last_seen_at) }
+      let(:system) { create(:system) }
 
       context 'with valid credentials' do
         subject(:client) { described_class.new(system.login, system.password, '23.23.23.23') }
 
         it 'returns the auth strategy' do
           allow(File).to receive(:exist?).and_return(true)
+          allow(File).to receive(:ctime).and_return(Time.zone.now)
           expect(client.systems).to eq([system])
           expect(client.auth_strategy).to eq(:system_credentials)
         end
@@ -20,6 +21,7 @@ describe Registry::AuthenticatedClient do
 
         it 'raises' do
           allow(File).to receive(:exist?).and_return(true)
+          allow(File).to receive(:ctime).and_return(Time.zone.now)
           allow(File).to receive(:delete)
           expect { client }.to raise_error(Registry::Exceptions::InvalidCredentials)
         end


### PR DESCRIPTION
## Description

If the header for registry cache is set, create an empty file (remote IP-system_login as a name) in
`/var/lib/rmt/tmp/registry/cache/` to use as a cache

Use the cache file together with the expiration date to auth registry access

Once the cache time has expired, remove cache file

Fixes # (issue)

## Change Type

*Please select the correct option.*

- [ ] **Bug Fix** (a non-breaking change which fixes an issue)
- [X] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have verified that my code follows RMT's coding standards with `rubocop`.
- [X] I have reviewed my own code and believe that it's ready for an external review.
- [ ] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [X] RMT's test coverage remains at 100%.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

