### PR TITLE
Set consistent cache handling time

### DIFF
--- a/engines/zypper_auth/lib/zypper_auth/engine.rb
+++ b/engines/zypper_auth/lib/zypper_auth/engine.rb
@@ -47,8 +47,6 @@ module ZypperAuth
         Access to the repos denied: #{message}
         #{details.join(', ')}
       LOGMSG
-
-      Rails.cache.write(cache_key, false, expires_in: 2.minutes)
       false
     rescue StandardError => e
       logger.error('Unexpected instance verification error has occurred:')


### PR DESCRIPTION

## Description

When no specific caching mechanism is configured for Rails the default file cache applies. In this case the `expire_in` argument for cahce.write is ignored. File cache clean up, i.e. expiry is covered by the rmt-server-trim-cache.service, which cleans the cache after 20 minutes. The cache trim service and the expiry time set in the code had different values leading to different behavior when a different Rails cache is configured. This commit addresses this discrepancy.

Fixes # (issue)

## Change Type

*Please select the correct option.*

- [ x] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [x ] I have verified that my code follows RMT's coding standards with `rubocop`.
- [ x] I have reviewed my own code and believe that it's ready for an external review.
- [ ] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [x ] RMT's test coverage remains at 100%.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Other Notes

Please use this space to provide notes or thoughts to the team, such as tips on how to review/demo your changes.
