### PR TITLE
Remove BYOS param for updating the cache

### DIFF
--- a/engines/instance_verification/lib/instance_verification/engine.rb
+++ b/engines/instance_verification/lib/instance_verification/engine.rb
@@ -1,7 +1,7 @@
 require 'fileutils'
 
 module InstanceVerification
-  def self.update_cache(remote_ip, system_login, product_id, is_byos: false, registry: false) # rubocop:disable Lint/UnusedMethodArgument
+  def self.update_cache(remote_ip, system_login, product_id, registry: false)
     # TODO: BYOS scenario
     # to be addressed on a different PR
     unless registry
@@ -111,7 +111,7 @@ module InstanceVerification
           )
 
           raise 'Unspecified error' unless verification_provider.instance_valid?
-          InstanceVerification.update_cache(request.remote_ip, @system.login, product.id, is_byos: @system.proxy_byos)
+          InstanceVerification.update_cache(request.remote_ip, @system.login, product.id)
         end
 
         # Verify that the base product doesn't change in the offline migration

--- a/engines/registry/spec/requests/api/connect/v3/systems/activations_controller_spec.rb
+++ b/engines/registry/spec/requests/api/connect/v3/systems/activations_controller_spec.rb
@@ -38,7 +38,7 @@ describe Api::Connect::V3::Systems::ActivationsController, type: :request do
       it 'refreshes registry cache key only' do
         FileUtils.mkdir_p('repo/cache')
         FileUtils.touch(cache_name)
-        expect(InstanceVerification).to receive(:update_cache).with('127.0.0.1', system.login, nil, is_byos: system.proxy_byos, registry: true)
+        expect(InstanceVerification).to receive(:update_cache).with('127.0.0.1', system.login, nil, registry: true)
         get '/connect/systems/activations', headers: headers
         FileUtils.rm_rf('repo/cache')
         data = JSON.parse(response.body)

--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -275,7 +275,7 @@ module SccProxy
               raise ActionController::TranslatedError.new(error['error'])
             end
             logger.info "Product #{@product.product_string} successfully activated with SCC"
-            InstanceVerification.update_cache(request.remote_ip, @system.login, @product.id, is_byos: @system.proxy_byos)
+            InstanceVerification.update_cache(request.remote_ip, @system.login, @product.id)
           end
         end
       end

--- a/engines/zypper_auth/lib/zypper_auth/engine.rb
+++ b/engines/zypper_auth/lib/zypper_auth/engine.rb
@@ -19,7 +19,7 @@ module ZypperAuth
       cache_path = File.join(Rails.application.config.repo_cache_dir, cache_key)
       if File.exist?(cache_path)
         # only update registry cache key
-        InstanceVerification.update_cache(request.remote_ip, system.login, nil, is_byos: system.proxy_byos, registry: true)
+        InstanceVerification.update_cache(request.remote_ip, system.login, nil, registry: true)
         return true
       end
 
@@ -32,14 +32,14 @@ module ZypperAuth
 
       is_valid = verification_provider.instance_valid?
       # update repository and registry cache
-      InstanceVerification.update_cache(request.remote_ip, system.login, base_product.id, is_byos: system.proxy_byos)
+      InstanceVerification.update_cache(request.remote_ip, system.login, base_product.id)
       is_valid
     rescue InstanceVerification::Exception => e
       message = ''
       if system.proxy_byos
         result = SccProxy.scc_check_subscription_expiration(request.headers, system.login, system.system_token, logger)
         if result[:is_active]
-          InstanceVerification.update_cache(request.remote_ip, system.login, base_product.id, is_byos: system.proxy_byos)
+          InstanceVerification.update_cache(request.remote_ip, system.login, base_product.id)
           return true
         end
 


### PR DESCRIPTION
## Description

Remove `is_byos` param when updating the InstanceVerification cache, currently not used

## Change Type

*Please select the correct option.*

- [ ] **Bug Fix** (a non-breaking change which fixes an issue)
- [X] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have verified that my code follows RMT's coding standards with `rubocop`.
- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [X] RMT's test coverage remains at 100%.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Other Notes

Please use this space to provide notes or thoughts to the team, such as tips on how to review/demo your changes.
