### PR TITLE
Refactor repository and registry cache

### DIFF
--- a/engines/instance_verification/lib/instance_verification/engine.rb
+++ b/engines/instance_verification/lib/instance_verification/engine.rb
@@ -5,21 +5,46 @@ module InstanceVerification
     # TODO: BYOS scenario
     # to be addressed on a different PR
     unless registry
-      InstanceVerification.write_cache_file(
-        Rails.application.config.repo_cache_dir,
-        InstanceVerification.build_cache_key(remote_ip, system_login, base_product_id: product_id)
-      )
+      # write repository cache
+      repository_cache_path = InstanceVerification.repository_cache_path(remote_ip, system_login, product_id)
+      InstanceVerification.write_cache_file(repository_cache_path) unless registry
     end
 
-    InstanceVerification.write_cache_file(
+    # write registry cache
+    registry_cache_path = InstanceVerification.registry_cache_path(remote_ip, system_login)
+    InstanceVerification.write_cache_file(registry_cache_path)
+  end
+
+  def self.write_cache_file(cache_path)
+    Dir.mkdir(File.dirname(cache_path)) unless File.directory?(File.dirname(cache_path))
+
+    FileUtils.touch(cache_path)
+  end
+
+  def self.repository_cache_path(remote_ip, system_login, product_id)
+    File.join(
+      Rails.application.config.repo_cache_dir,
+      InstanceVerification.build_cache_key(remote_ip, system_login, product_id: product_id)
+    )
+  end
+
+  def self.registry_cache_path(remote_ip, system_login)
+    File.join(
       Rails.application.config.registry_cache_dir,
       InstanceVerification.build_cache_key(remote_ip, system_login)
     )
   end
 
-  def self.write_cache_file(cache_dir, cache_key)
-    FileUtils.mkdir_p(cache_dir)
-    FileUtils.touch(File.join(cache_dir, cache_key))
+  def self.remove_registry_cache(remote_ip, system_login)
+    registry_cache_path = InstanceVerification.registry_cache_path(remote_ip, system_login)
+    File.unlink(registry_cache_path) if File.exist?(registry_cache_path)
+  end
+
+  def self.build_cache_key(remote_ip, system_login, product_id: nil)
+    cache_key = [remote_ip, system_login]
+    cache_key.append(product_id) unless product_id.nil?
+
+    cache_key.join('-')
   end
 
   def self.verify_instance(request, logger, system)
@@ -30,10 +55,7 @@ module InstanceVerification
     return false unless base_product
 
     # check the cache for the system (20 min)
-    cache_path = File.join(
-      Rails.application.config.repo_cache_dir,
-      InstanceVerification.build_cache_key(request.remote_ip, system.login, base_product_id: base_product.id)
-    )
+    cache_path = InstanceVerification.repository_cache_path(request.remote_ip, system.login, base_product.id)
     if File.exist?(cache_path)
       # only update registry cache key
       InstanceVerification.update_cache(request.remote_ip, system.login, nil, is_byos: system.proxy_byos, registry: true)
@@ -80,13 +102,6 @@ module InstanceVerification
     logger.error('Backtrace:')
     logger.error(e.backtrace)
     false
-  end
-
-  def self.build_cache_key(remote_ip, login, base_product_id: nil)
-    cache_key = [remote_ip, login]
-    cache_key.append(base_product_id) unless base_product_id.nil?
-
-    cache_key.join('-')
   end
 
   class Engine < ::Rails::Engine
@@ -178,6 +193,7 @@ module InstanceVerification
           )
 
           raise 'Unspecified error' unless verification_provider.instance_valid?
+          # puts "AAAA"
           InstanceVerification.update_cache(request.remote_ip, @system.login, product.id, is_byos: @system.proxy_byos)
         end
 

--- a/engines/instance_verification/spec/requests/api/connect/v3/systems/products_controller_spec.rb
+++ b/engines/instance_verification/spec/requests/api/connect/v3/systems/products_controller_spec.rb
@@ -116,8 +116,8 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
           allow(File).to receive(:directory?)
           allow(Dir).to receive(:mkdir)
           allow(FileUtils).to receive(:touch)
-          expect(InstanceVerification).to receive(:write_cache_file).once.with('repo/cache', "127.0.0.1-#{system.login}-#{product_sap.id}")
-          expect(InstanceVerification).to receive(:write_cache_file).once.with('registry/cache', "127.0.0.1-#{system.login}")
+          expect(InstanceVerification).to receive(:write_cache_file).once.with("repo/cache/127.0.0.1-#{system.login}-#{product_sap.id}")
+          expect(InstanceVerification).to receive(:write_cache_file).once.with("registry/cache/127.0.0.1-#{system.login}")
           post url, params: payload_sap, headers: headers
         end
 

--- a/engines/registry/lib/registry/engine.rb
+++ b/engines/registry/lib/registry/engine.rb
@@ -1,11 +1,4 @@
 module Registry
-  class << self
-    def remove_auth_cache(registry_cache_key)
-      cache_path = File.join(Rails.application.config.registry_cache_dir, registry_cache_key)
-      File.unlink(registry_cache_path) if File.exist?(cache_path)
-    end
-  end
-
   class Engine < ::Rails::Engine
     isolate_namespace Registry
     config.generators.api_only = true
@@ -25,8 +18,7 @@ module Registry
         before_action :remove_auth_cache, only: %w[deregister]
 
         def remove_auth_cache
-          registry_cache_key = [request.remote_ip, @system.login].join('-')
-          Registry.remove_auth_cache(registry_cache_key)
+          InstanceVerification.remove_registry_cache(request.remote_ip, @system.login)
         end
       end
     end

--- a/engines/registry/spec/requests/api/connect/v3/systems/activations_controller_spec.rb
+++ b/engines/registry/spec/requests/api/connect/v3/systems/activations_controller_spec.rb
@@ -26,21 +26,22 @@ describe Api::Connect::V3::Systems::ActivationsController, type: :request do
 
       before do
         allow(File).to receive(:join).and_call_original
-        # allow(File).to receive(:exist?).with('repo/cache/127.0.0.1-login45-1052122')
-        # allow(File).to receive(:exist?).with("repo/cache/127.0.0.1-#{system.login}-#{system.products.first.id}").and_return(true)
-        # allow(File).to receive(:exist?).with("repo/cache/127.0.0.1-#{system.login}-#{system.products.first.id}").and_return(true)
-        # allow(File).to receive(:exist?)
+        allow(File).to receive(:directory?)
+        allow(Dir).to receive(:mkdir)
+        allow(FileUtils).to receive(:touch)
+        allow(InstanceVerification).to receive(:repository_cache_path).and_return('.')
+        allow(InstanceVerification).to receive(:registry_cache_path)
+        allow(InstanceVerification).to receive(:write_cache_file)
         allow(InstanceVerification).to receive(:update_cache)
         allow(InstanceVerification).to receive(:verify_instance).and_call_original
         headers['X-Instance-Data'] = 'IMDS'
       end
 
       it 'refreshes registry cache key only' do
-        FileUtils.mkdir_p('repo/cache')
-        FileUtils.touch(cache_name)
+        allow(File).to receive(:directory?)
+        allow(Dir).to receive(:mkdir)
         expect(InstanceVerification).to receive(:update_cache).with('127.0.0.1', system.login, nil, is_byos: system.proxy_byos, registry: true)
         get '/connect/systems/activations', headers: headers
-        FileUtils.rm_rf('repo/cache')
         data = JSON.parse(response.body)
         expect(data[0]['service']['url']).to match(%r{^plugin:/susecloud})
       end

--- a/engines/scc_proxy/spec/requests/api/connect/v3/systems/products_controller_spec.rb
+++ b/engines/scc_proxy/spec/requests/api/connect/v3/systems/products_controller_spec.rb
@@ -114,8 +114,8 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
             allow(FileUtils).to receive(:mkdir_p)
             allow(FileUtils).to receive(:touch)
 
-            allow(InstanceVerification).to receive(:write_cache_file).twice.with('repo/cache', "127.0.0.1-#{system.login}-#{product.id}")
-            allow(InstanceVerification).to receive(:write_cache_file).twice.with('registry/cache', "127.0.0.1-#{system.login}")
+            allow(InstanceVerification).to receive(:write_cache_file).twice.with("repo/cache/127.0.0.1-#{system.login}-#{product.id}")
+            allow(InstanceVerification).to receive(:write_cache_file).twice.with("registry/cache/127.0.0.1-#{system.login}")
           end
 
           it 'renders service JSON' do
@@ -132,8 +132,8 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
                 body: '{"error": "No product found on SCC for: foo bar x86_64 json api"}',
                 headers: {}
               )
-            allow(InstanceVerification).to receive(:write_cache_file).twice.with('repo/cache', "127.0.0.1-#{system.login}-#{product.id}")
-            allow(InstanceVerification).to receive(:write_cache_file).twice.with('registry/cache', "127.0.0.1-#{system.login}")
+            allow(InstanceVerification).to receive(:write_cache_file).twice.with("repo/cache/127.0.0.1-#{system.login}-#{product.id}")
+            allow(InstanceVerification).to receive(:write_cache_file).twice.with("registry/cache/127.0.0.1-#{system.login}")
             allow(FileUtils).to receive(:mkdir_p)
             allow(FileUtils).to receive(:touch)
 
@@ -165,8 +165,8 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
                 body: '{"id": "bar"}',
                 headers: {}
               )
-            allow(InstanceVerification).to receive(:write_cache_file).twice.with('repo/cache', "127.0.0.1-#{system.login}-#{product.id}")
-            allow(InstanceVerification).to receive(:write_cache_file).twice.with('registry/cache', "127.0.0.1-#{system.login}")
+            allow(InstanceVerification).to receive(:write_cache_file).twice.with("repo/cache/127.0.0.1-#{system.login}-#{product.id}")
+            allow(InstanceVerification).to receive(:write_cache_file).twice.with("registry/cache/127.0.0.1-#{system.login}")
             allow(File).to receive(:directory?)
             allow(FileUtils).to receive(:mkdir_p)
             allow(FileUtils).to receive(:touch)
@@ -201,8 +201,8 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
                 headers: {}
               )
 
-            allow(InstanceVerification).to receive(:write_cache_file).twice.with('repo/cache', "127.0.0.1-#{system.login}-#{product.id}")
-            allow(InstanceVerification).to receive(:write_cache_file).twice.with('registry/cache', "127.0.0.1-#{system.login}")
+            allow(InstanceVerification).to receive(:write_cache_file).twice.with("repo/cache/127.0.0.1-#{system.login}-#{product.id}")
+            allow(InstanceVerification).to receive(:write_cache_file).twice.with("registry/cache/127.0.0.1-#{system.login}")
             allow(File).to receive(:directory?)
             allow(FileUtils).to receive(:mkdir_p)
             allow(FileUtils).to receive(:touch)


### PR DESCRIPTION
## Description

- Remove registry cache in the same engine that it is created
- Get repository and registry cache paths in one place to avoid duplication

## Change Type

*Please select the correct option.*

- [ ] **Bug Fix** (a non-breaking change which fixes an issue)
- [X] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have verified that my code follows RMT's coding standards with `rubocop`.
- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [X] RMT's test coverage remains at 100%.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Other Notes

Please use this space to provide notes or thoughts to the team, such as tips on how to review/demo your changes.
