### PR TITLE
fix links to jira to let them be auto discovered

### DIFF
--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -5,7 +5,7 @@ Thu April 18 09:27:00 UTC 2024 - Adnilson Delgado <adnilson.delgado@suse.com>
   * Improve CLI mirroring summary information by adding the mirror repositories, the file count and size. (gh#702)
   * Copy metadata content to repodata/ and not create a seperate subdirectory repodata/repodata (gh#1136)
   * Adding Uptime tracking capability
-    * Uptime data is included in the data sent to SCC via RMT (PED-7982, PED-8018)
+    * Uptime data is included in the data sent to SCC via RMT (jsc#PED-7982, jsc#PED-8018)
 
 -------------------------------------------------------------------
 Thu April 11 15:22:00 UTC 2024 - Felix Schnizlein <fschnizlein@suse.com>


### PR DESCRIPTION
card: https://trello.com/c/DZm26xHm/3342-rmt-metadata-is-not-correctly-moved-to-repository-root-but-into-repodata-repodata-if-exists

Links in the Changelog file should have the format <source>#<identifier>

For PED this is: `jsc#PED-<id>`
For Github it is: `gh#<issue>`
For Bugzilla:  `bsc#<id>`

**How to review this pull request:**

Check PED entries in the Changelog file have the correct format

Thank you very much for the review :rocket: 

cheers,