### PR TITLE
Move registry engine config from core config to its engine

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -58,19 +58,6 @@ module RMT
     config.eager_load_paths << Rails.root.join('lib')
     config.eager_load_paths << Rails.root.join('app', 'validators')
 
-    # :nocov:
-    if defined?(Registry::Engine) && Rails.env.production?
-      # registry config needed
-      config.autoloader = :classic
-      config.registry_private_key = OpenSSL::PKey::RSA.new(
-        File.read('/etc/rmt/ssl/internal-registry.key')
-        )
-      config.registry_public_key = config.registry_private_key.public_key
-      config.access_policies = '/etc/rmt/access_policies.yml'
-      # registry config needed end
-    end
-    # :nocov:
-
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -27,14 +27,6 @@ Rails.application.configure do
   config.action_controller.perform_caching = false
   config.cache_store = :null_store
 
-  # for registry
-  config.access_policies = 'engines/registry/spec/data/access_policies.yml'
-  config.registry_private_key = OpenSSL::PKey::RSA.new(2048)
-  config.registry_public_key = config.registry_private_key.public_key
-  config.autoload_paths << Rails.root.join('engines/registry/spec/support/')
-  config.cache_config_file = Rails.root.join('engines/registry/spec/data/rmt-cache-trim.sh')
-  config.repo_cache_dir = 'repo/cache'
-  config.registry_cache_dir = 'registry/cache'
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false
 

--- a/engines/registry/config/environments/production.rb
+++ b/engines/registry/config/environments/production.rb
@@ -1,0 +1,13 @@
+# :nocov:
+module Registry
+  class Application < Rails::Application
+    # registry config needed
+    config.autoloader = :classic
+    config.registry_private_key = OpenSSL::PKey::RSA.new(
+      File.read('/etc/rmt/ssl/internal-registry.key')
+      )
+    config.registry_public_key = config.registry_private_key.public_key
+    config.access_policies = '/etc/rmt/access_policies.yml'
+  end
+end
+# :nocov:

--- a/engines/registry/config/environments/test.rb
+++ b/engines/registry/config/environments/test.rb
@@ -4,7 +4,8 @@
 # and recreated between test runs. Don't rely on the data there!
 
 Rails.application.configure do
-  config.cache_config_file = Rails.root.join('engines/registry/spec/data/rmt-cache-trim.sh')
-  config.repo_cache_dir = 'repo/cache'
-  config.registry_cache_dir = 'registry/cache'
+  config.access_policies = 'engines/registry/spec/data/access_policies.yml'
+  config.registry_private_key = OpenSSL::PKey::RSA.new(2048)
+  config.registry_public_key = config.registry_private_key.public_key
+  config.autoload_paths << Rails.root.join('engines/registry/spec/support/')
 end


### PR DESCRIPTION
Move registry cache declaration for testing into the right engine

## Description

Move Registry engine config from core to its engine
Move registry cache directory declaration to the right engine

Fixes # (issue)

## Change Type

*Please select the correct option.*

- [ ] **Bug Fix** (a non-breaking change which fixes an issue)
- [x] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [x] I have verified that my code follows RMT's coding standards with `rubocop`.
- [x] I have reviewed my own code and believe that it's ready for an external review.
- [x] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [x] RMT's test coverage remains at 100%.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Other Notes

Please use this space to provide notes or thoughts to the team, such as tips on how to review/demo your changes.
