### PR TITLE
Set the cache path for repository and registry in a path owned by _rmt

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -20,8 +20,8 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   config.cache_config_file = '/var/lib/rmt/rmt-cache-trim.sh'
-  config.repo_cache_dir = '/run/rmt/cache/repository'
-  config.registry_cache_dir = '/run/rmt/cache/registry'
+  config.repo_cache_dir = Rails.root.join('tmp/cache/repository')
+  config.registry_cache_dir = Rails.root.join('tmp/cache/registry')
   cache_config_content = [
     "REPOSITORY_CLIENT_CACHE_DIRECTORY=#{config.repo_cache_dir}",
     'REPOSITORY_CACHE_EXPIRY_MINUTES=20',


### PR DESCRIPTION
## Description

The path agreed to use for the new cache is owned by root,
so new path set for registry and repository cache

## Change Type

*Please select the correct option.*

- [X] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have verified that my code follows RMT's coding standards with `rubocop`.
- [X] I have reviewed my own code and believe that it's ready for an external review.
- [ ] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [X] RMT's test coverage remains at 100%.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Other Notes

Please use this space to provide notes or thoughts to the team, such as tips on how to review/demo your changes.
