### PR TITLE
Do not carry over the request host, the URL is the same

### DIFF
--- a/engines/registry/app/controllers/registry/registry_controller.rb
+++ b/engines/registry/app/controllers/registry/registry_controller.rb
@@ -20,8 +20,7 @@ module Registry
     # https://distribution.github.io/distribution/spec/api/#listing-repositories
     def catalog
       access_scope = AccessScope.parse('registry:catalog:*')
-      origin_url = request.protocol + request.host
-      repos = access_scope.allowed_paths(System.find_by(login: @client&.account), origin_url)
+      repos = access_scope.allowed_paths(System.find_by(login: @client&.account))
       logger.debug("Returning #{repos.size} repos for client #{@client}")
 
       response.set_header('Docker-Distribution-Api-Version', REGISTRY_API_VERSION)

--- a/engines/registry/app/models/access_scope.rb
+++ b/engines/registry/app/models/access_scope.rb
@@ -78,8 +78,8 @@ class AccessScope
     raise Registry::Exceptions::InvalidScope.new('Invalid scope format') unless %r{^[a-z0-9\-_/:*(),.]+$}i.match?(scope)
   end
 
-  def allowed_paths(system = nil, origin_url = nil)
-    repo_list = RegistryCatalogService.new.repos(reload: false, system: system, origin_url: origin_url)
+  def allowed_paths(system = nil)
+    repo_list = RegistryCatalogService.new.repos(reload: false, system: system)
     access_policies_yml = YAML.safe_load(
       File.read(Rails.application.config.access_policies)
     )

--- a/engines/registry/spec/app/controllers/registry_controller_spec.rb
+++ b/engines/registry/spec/app/controllers/registry_controller_spec.rb
@@ -61,7 +61,7 @@ module Registry
 
 
       before do
-        stub_request(:get, "https://www.example.com:80/api/registry/authorize?account=#{system.login}&scope=registry:catalog:*&service=SUSE%20Linux%20OCI%20Registry")
+        stub_request(:get, "https://registry-example.susecloud.net/api/registry/authorize?account=#{system.login}&scope=registry:catalog:*&service=SUSE%20Linux%20OCI%20Registry")
          .with(
            headers: {
              'Accept' => '*/*',

--- a/engines/registry/spec/app/services/registry_catalog_service_spec.rb
+++ b/engines/registry/spec/app/services/registry_catalog_service_spec.rb
@@ -4,7 +4,7 @@ describe RegistryCatalogService do
   subject(:registry) { described_class.new }
 
   let(:system) { create(:system) }
-  let(:root_url) { 'smt-ec2.susecloud.net' }
+  let(:root_url) { 'registry-example.susecloud.net' }
   let(:auth_url) { "https://#{root_url}/api/registry/authorize" }
   let(:params) { "account=#{system.login}&scope=registry:catalog:*&service=SUSE%20Linux%20OCI%20Registry" }
   let(:response) { { repositories: repositories_returned } }
@@ -30,6 +30,6 @@ describe RegistryCatalogService do
 
   it 'lists all repos' do
     allow(System).to receive(:where).and_return([system])
-    expect(registry.repos(system: system, origin_url: "https://#{root_url}").length).to eq repositories_returned.size
+    expect(registry.repos(system: system).length).to eq repositories_returned.size
   end
 end


### PR DESCRIPTION
## Description

Use the framework value to determine the full URL
and set it in the method instead of carrying over
the different methods and classes

Tests updated

## Change Type

*Please select the correct option.*

- [X] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have verified that my code follows RMT's coding standards with `rubocop`.
- [X] I have reviewed my own code and believe that it's ready for an external review.
- [ ] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [X] RMT's test coverage remains at 100%.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Other Notes

Please use this space to provide notes or thoughts to the team, such as tips on how to review/demo your changes.
