### PR TITLE
Fix the location for the registry cert

### DIFF
--- a/package/files/nginx-pubcloud/nginx-https.conf
+++ b/package/files/nginx-pubcloud/nginx-https.conf
@@ -99,8 +99,8 @@ server {
     error_log   /var/log/nginx/registry_https_error.log;
     root        /var/lib/docker-registry;
 
-    ssl_certificate     /etc/rmt/ssl/susecloud-registry-ec2.crt;
-    ssl_certificate_key /etc/rmt/ssl/susecloud-registry-ec2.key;
+    ssl_certificate     /etc/rmt/ssl/registry-server.crt;
+    ssl_certificate_key /etc/rmt/ssl/registry-server.key;
 
     ssl_protocols       TLSv1.2 TLSv1.3;
 


### PR DESCRIPTION
## Description

The reference to the path where the cert for the registry is located was incorrect.

Fixes # (issue)

## Change Type

*Please select the correct option.*

- [x ] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [ x] I have verified that my code follows RMT's coding standards with `rubocop`.
- [x ] I have reviewed my own code and believe that it's ready for an external review.
- [ ] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] RMT's test coverage remains at 100%.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Other Notes

Please use this space to provide notes or thoughts to the team, such as tips on how to review/demo your changes.
