### PR TITLE
Fix wrongly named variable for the registry cache path

### DIFF
--- a/engines/registry/lib/registry/engine.rb
+++ b/engines/registry/lib/registry/engine.rb
@@ -2,7 +2,7 @@ module Registry
   class << self
     def remove_auth_cache(registry_cache_key)
       cache_path = File.join(Rails.application.config.registry_cache_dir, registry_cache_key)
-      File.unlink(registry_cache_path) if File.exist?(cache_path)
+      File.unlink(cache_path) if File.exist?(cache_path)
     end
   end
 


### PR DESCRIPTION
## Description

Variable has the wrong name

## Change Type

*Please select the correct option.*

- [X] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have verified that my code follows RMT's coding standards with `rubocop`.
- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [X] RMT's test coverage remains at 100%.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Other Notes

Please use this space to provide notes or thoughts to the team, such as tips on how to review/demo your changes.
