### PR TITLE
Fix rmt-client-setup-res use case when registering LTSS on an SLL7 system previously converted from CentOS/RHEL

### DIFF
--- a/public/tools/rmt-client-setup-res
+++ b/public/tools/rmt-client-setup-res
@@ -238,9 +238,9 @@ $CURL --silent --show-error --insecure "$REGURL/tools/rmt-client-setup" --output
 echo "Running rmt-client-setup $PARAMS"
 if [ -n "$YES_PARAM" ]; then
     PARAMS=$(echo "$PARAMS" | sed 's/--yes//')
-    yes | sh rmt-client-setup "$PARAMS"
+    yes | sh rmt-client-setup $PARAMS
 else
-    sh rmt-client-setup "$PARAMS"
+    sh rmt-client-setup $PARAMS
 fi
 
 if [[ ${SLL_version} -gt 8 ]]; then 

--- a/public/tools/rmt-client-setup-res
+++ b/public/tools/rmt-client-setup-res
@@ -234,7 +234,7 @@ elif [[ ${SLL_version} -eq 8 ]]; then
     import_rpm_signing_keys
 fi
 
-$CURL --silent --show-error --insecure "$REGURL/tools/rmt-client-setup --output rmt-client-setup"
+$CURL --silent --show-error --insecure "$REGURL/tools/rmt-client-setup" --output rmt-client-setup
 echo "Running rmt-client-setup $PARAMS"
 if [ -n "$YES_PARAM" ]; then
     PARAMS=$(echo "$PARAMS" | sed 's/--yes//')

--- a/public/tools/rmt-client-setup-res
+++ b/public/tools/rmt-client-setup-res
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # rmt-client-setup-res: client use rmt-client-setup script to register with rmt.
 # This script assumes SUSEConnect is already installed on the system.
@@ -119,7 +119,7 @@ else
     CERTURL="$REGCERT"
 fi
 
-$CURL --tlsv1.2 --silent --insecure --connect-timeout 10 --output $TEMPFILE $CERTURL
+$CURL --tlsv1.2 --silent --insecure --connect-timeout 10 --output "$TEMPFILE" "$CERTURL"
 if [ $? -ne 0 ]; then
     echo "Download failed. Abort."
     exit 1
@@ -163,14 +163,12 @@ echo "Detected ${SLL_name} version: ${SLL_version}"
 
 echo "Importing repomd.xml.key"
 if [[ ${SLL_version} -eq 7 ]]; then
-  $CURL --silent --show-error --insecure ${REGURL}/repo/SUSE/Updates/${SLL_name%%-LTSS}/${SLL_version}-LTSS/x86_64/update/repodata/repomd.xml.key --output repomd.xml.key
+  $CURL --silent --show-error --insecure "${REGURL}/repo/SUSE/Updates/${SLL_name%%-LTSS}/${SLL_version}-LTSS/x86_64/update/repodata/repomd.xml.key" --output repomd.xml.key
 else
-  $CURL --silent --show-error --insecure ${REGURL}/repo/SUSE/Updates/${SLL_name}/${SLL_version}/x86_64/update/repodata/repomd.xml.key --output repomd.xml.key
+  $CURL --silent --show-error --insecure "${REGURL}/repo/SUSE/Updates/${SLL_name}/${SLL_version}/x86_64/update/repodata/repomd.xml.key" --output repomd.xml.key
 fi
 $RPM --import repomd.xml.key
 
-if [ ! -x $SUSECONNECT ]; then
-    echo "Downloading SUSEConnect"
 if [[ ${SLL_version} -gt 7 ]]; then
 
     if [ ! -x $DNF ]; then
@@ -180,14 +178,13 @@ if [[ ${SLL_version} -gt 7 ]]; then
 
     echo "Disabling all repositories"
     $DNF config-manager --disable $(dnf repolist -q | awk '{ print $1 }' | grep -v repo)
-    # sed -i 's/^enabled=1/enabled=0/' /etc/yum.repos.d/*           
     # on RHEL9 (not RHEL8) redhat-release is protected and cannot be updated to sll-release
     if [ -f /etc/dnf/protected.d/redhat-release.conf ]; then
        rm -f /etc/dnf/protected.d/redhat-release.conf
     fi
 
-    $DNF config-manager --add-repo ${REGURL}/repo/SUSE/Updates/${SLL_name}/${SLL_version}/x86_64/update
-    $DNF config-manager --add-repo ${REGURL}/repo/SUSE/Updates/${SLL_name}-AS/${SLL_version}/x86_64/update
+    $DNF config-manager --add-repo "${REGURL}/repo/SUSE/Updates/${SLL_name}/${SLL_version}/x86_64/update"
+    $DNF config-manager --add-repo "${REGURL}/repo/SUSE/Updates/${SLL_name}-AS/${SLL_version}/x86_64/update"
     $DNF install -y --allowerasing ${SLL_release_package}
 
     # For RHEL8/CentOS8, remove all old signing keys and import SUSE keys installed with sles_es-release package
@@ -195,7 +192,9 @@ if [[ ${SLL_version} -gt 7 ]]; then
         import_rpm_signing_keys
     fi
 
+    echo "Downloading SUSEConnect"
     $DNF install SUSEConnect librepo
+
     $DNF config-manager --set-disabled "${RMTNAME}_repo_SUSE_Updates_${SLL_name}_${SLL_version}_x86_64_update"
     $DNF config-manager --set-disabled "${RMTNAME}_repo_SUSE_Updates_${SLL_name}-AS_${SLL_version}_x86_64_update"
 
@@ -215,28 +214,33 @@ elif [[ ${SLL_version} -eq 7 ]]; then
        rm -f /usr/share/redhat-release
     fi
 
-    $YUM_CONFIG_MGR --add-repo ${REGURL}/repo/SUSE/Updates/${SLL_name%%-LTSS}/${SLL_version}-LTSS/x86_64/update
+    $YUM_CONFIG_MGR --add-repo "${REGURL}/repo/SUSE/Updates/${SLL_name%%-LTSS}/${SLL_version}-LTSS/x86_64/update"
     if [ ${SLL_name} = "RES-OL-LTSS" ]; then
-    	$YUM_CONFIG_MGR --add-repo ${REGURL}/repo/SUSE/Updates/RES-BASE/${SLL_version}/x86_64/update
+    	$YUM_CONFIG_MGR --add-repo "${REGURL}/repo/SUSE/Updates/RES-BASE/${SLL_version}/x86_64/update"
     fi	
     $YUM_CONFIG_MGR --enable *suse.* > /dev/null
 
-    $YUM install -y ${SLL_release_package} suseconnect-ng librepo
+    if [ ! -x $SUSECONNECT ]; then
+        $YUM install -y ${SLL_release_package} suseconnect-ng librepo
+    else
+        $YUM update -y ${SLL_release_package} suseconnect-ng librepo
+    fi
+
     $YUM update -y yum
     $YUM_CONFIG_MGR --disable \* > /dev/null
-fi
+
 elif [[ ${SLL_version} -eq 8 ]]; then
     # For SLL8, the release package is already installed, just import the keys
     import_rpm_signing_keys
 fi
 
-$CURL --silent --show-error --insecure $REGURL/tools/rmt-client-setup --output rmt-client-setup
+$CURL --silent --show-error --insecure "$REGURL/tools/rmt-client-setup --output rmt-client-setup"
 echo "Running rmt-client-setup $PARAMS"
 if [ -n "$YES_PARAM" ]; then
-    PARAMS=$(echo $PARAMS | sed 's/--yes//')
-    yes | sh rmt-client-setup $PARAMS
+    PARAMS=$(echo "$PARAMS" | sed 's/--yes//')
+    yes | sh rmt-client-setup "$PARAMS"
 else
-    sh rmt-client-setup $PARAMS
+    sh rmt-client-setup "$PARAMS"
 fi
 
 if [[ ${SLL_version} -gt 8 ]]; then 


### PR DESCRIPTION
## Description

This change fixes the use case when customer is registering LTSS on a CentOS/RHEL system that was previously registered as Linberty 7.

* Related Issue / Ticket / Trello card: https://jira.suse.com/browse/SLL-364

## How to test 

Automated tests (passed 4/4):
http://deliverance.suse.cz:8080/view/sll-test/job/sll-test-centos/89/
http://deliverance.suse.cz:8080/view/sll-test/job/sll-test-ol/28/
http://deliverance.suse.cz:8080/view/sll-test/job/sll-test-rhel/30/
http://deliverance.suse.cz:8080/view/sll-test/job/sll-test-sll/30/

## Change Type

*Please select the correct option.*

- [x] **Bug Fix** (a non-breaking change which fixes an issue)

## Checklist

*Please check off each item if the requirement is met.*

- [x] I have reviewed my own code and believe that it's ready for an external review.
- [x] I have provided comments for any hard-to-understand code.
- [-] I have documented the `MANUAL.md` file with any changes to the user experience.
- [x] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

