### PR TITLE
Add proxy_byos_mode column

### DIFF
--- a/app/models/system.rb
+++ b/app/models/system.rb
@@ -1,6 +1,7 @@
 class System < ApplicationRecord
 
   enum proxy_byos: { payg: 0, byos: 1, hybrid: 2 }
+  self.ignored_columns = ['proxy_byos']
 
   after_initialize :init
 

--- a/app/models/system.rb
+++ b/app/models/system.rb
@@ -1,7 +1,6 @@
 class System < ApplicationRecord
 
-  enum proxy_byos: { payg: 0, byos: 1, hybrid: 2 }
-  self.ignored_columns = ['proxy_byos']
+  enum proxy_byos_mode: { payg: 0, byos: 1, hybrid: 2 }
 
   after_initialize :init
 

--- a/app/models/system.rb
+++ b/app/models/system.rb
@@ -1,5 +1,7 @@
 class System < ApplicationRecord
 
+  enum proxy_byos: { payg: 0, byos: 1, hybrid: 2 }
+
   after_initialize :init
 
   has_many :activations, dependent: :destroy

--- a/db/migrate/20240729103525_update_proxy_byos_column_type.rb
+++ b/db/migrate/20240729103525_update_proxy_byos_column_type.rb
@@ -5,11 +5,4 @@ class UpdateProxyByosColumnType < ActiveRecord::Migration[6.1]
     execute 'Update systems SET proxy_byos_mode = 1 WHERE proxy_byos = true'
     # remove_column :systems, :proxy_byos
   end
-
-  def down
-    add_column :systems, :proxy_byos, :boolean, default: false
-    execute 'Update systems SET proxy_byos = false WHERE proxy_byos_mode = 0'
-    execute 'Update systems SET proxy_byos = true WHERE proxy_byos_mode = 1'
-    # remove_column :systems, :proxy_byos_method
-  end
 end

--- a/db/migrate/20240729103525_update_proxy_byos_column_type.rb
+++ b/db/migrate/20240729103525_update_proxy_byos_column_type.rb
@@ -1,10 +1,8 @@
 class UpdateProxyByosColumnType < ActiveRecord::Migration[6.1]
   def up
     add_column :systems, :proxy_byos_mode, :integer, default: 0
-    safety_assured do
-      execute 'Update systems SET proxy_byos_mode = 0 WHERE proxy_byos = false'
-      execute 'Update systems SET proxy_byos_mode = 1 WHERE proxy_byos = true'
-    end
+    System.where(proxy_byos: false).in_batches.update_all proxy_byos_mode: 0
+    System.where(proxy_byos: true).in_batches.update_all proxy_byos_mode: 1
   end
 
   def down

--- a/db/migrate/20240729103525_update_proxy_byos_column_type.rb
+++ b/db/migrate/20240729103525_update_proxy_byos_column_type.rb
@@ -5,4 +5,8 @@ class UpdateProxyByosColumnType < ActiveRecord::Migration[6.1]
     execute 'Update systems SET proxy_byos_mode = 1 WHERE proxy_byos = true'
     # remove_column :systems, :proxy_byos
   end
+
+  def down
+    remove_column :systems, :proxy_byos_mode
+  end
 end

--- a/db/migrate/20240729103525_update_proxy_byos_column_type.rb
+++ b/db/migrate/20240729103525_update_proxy_byos_column_type.rb
@@ -1,8 +1,10 @@
 class UpdateProxyByosColumnType < ActiveRecord::Migration[6.1]
   def up
-    add_column :systems, :proxy_byos_mode, :integer, default: 0
-    execute 'Update systems SET proxy_byos_mode = 0 WHERE proxy_byos = false'
-    execute 'Update systems SET proxy_byos_mode = 1 WHERE proxy_byos = true'
+    safety_assured do
+      add_column :systems, :proxy_byos_mode, :integer, default: 0
+      execute 'Update systems SET proxy_byos_mode = 0 WHERE proxy_byos = false'
+      execute 'Update systems SET proxy_byos_mode = 1 WHERE proxy_byos = true'
+    end
     # remove_column :systems, :proxy_byos
   end
 

--- a/db/migrate/20240729103525_update_proxy_byos_column_type.rb
+++ b/db/migrate/20240729103525_update_proxy_byos_column_type.rb
@@ -1,19 +1,19 @@
 class UpdateProxyByosColumnType < ActiveRecord::Migration[6.1]
   def up
     safety_assured do
-      add_column :systems, :proxy_byos_method, :integer, default: 0
-      execute 'Update systems SET proxy_byos_method = 0 WHERE proxy_byos = false'
-      execute 'Update systems SET proxy_byos_method = 1 WHERE proxy_byos = true'
-      remove_column :systems, :proxy_byos
+      add_column :systems, :proxy_byos_mode, :integer, default: 0
+      execute 'Update systems SET proxy_byos_mode = 0 WHERE proxy_byos = false'
+      execute 'Update systems SET proxy_byos_mode = 1 WHERE proxy_byos = true'
+      # remove_column :systems, :proxy_byos
     end
   end
 
   def down
     safety_assured do
       add_column :systems, :proxy_byos, :boolean, default: false
-      execute 'Update systems SET proxy_byos = false WHERE proxy_byos_method = 0'
-      execute 'Update systems SET proxy_byos = true WHERE proxy_byos_method = 1'
-      remove_column :systems, :proxy_byos_method
+      execute 'Update systems SET proxy_byos = false WHERE proxy_byos_mode = 0'
+      execute 'Update systems SET proxy_byos = true WHERE proxy_byos_mode = 1'
+      # remove_column :systems, :proxy_byos_method
     end
   end
 end

--- a/db/migrate/20240729103525_update_proxy_byos_column_type.rb
+++ b/db/migrate/20240729103525_update_proxy_byos_column_type.rb
@@ -1,5 +1,23 @@
 class UpdateProxyByosColumnType < ActiveRecord::Migration[6.1]
-  def change
-    change_column(:systems, :proxy_byos, :integer, default: 0)
+  def up
+    add_column :systems, :proxy_byos_boolean, :booleanm, default: false
+    execute 'Update systems SET proxy_byos_boolean = false WHERE proxy_byos = false'
+    execute 'Update systems SET proxy_byos_boolean = true WHERE proxy_byos = true'
+    remove_column :systems, :proxy_byos
+    add_column :systems, :proxy_byos, :integer, default: 0
+    execute 'Update systems SET proxy_byos = 0 WHERE proxy_byos_boolean = false'
+    execute 'Update systems SET proxy_byos = 1 WHERE proxy_byos_boolean = true'
+    remove_column :systems, :proxy_byos_boolean
+  end
+
+  def down
+    add_column :systems, :proxy_byos_boolean, :boolean, default: false
+    execute 'Update systems SET proxy_byos_boolean = false WHERE proxy_byos = 0'
+    execute 'Update systems SET proxy_byos_boolean = true WHERE proxy_byos = 1'
+    remove_column :systems, :proxy_byos
+    add_column :systems, :proxy_byos, :boolean, default: false
+    execute 'Update systems SET proxy_byos = false WHERE proxy_byos_boolean = false'
+    execute 'Update systems SET proxy_byos = true WHERE proxy_byos_boolean = true'
+    remove_column :systems, :proxy_byos_boolean
   end
 end

--- a/db/migrate/20240729103525_update_proxy_byos_column_type.rb
+++ b/db/migrate/20240729103525_update_proxy_byos_column_type.rb
@@ -1,19 +1,15 @@
 class UpdateProxyByosColumnType < ActiveRecord::Migration[6.1]
   def up
-    safety_assured do
-      add_column :systems, :proxy_byos_mode, :integer, default: 0
-      execute 'Update systems SET proxy_byos_mode = 0 WHERE proxy_byos = false'
-      execute 'Update systems SET proxy_byos_mode = 1 WHERE proxy_byos = true'
-      # remove_column :systems, :proxy_byos
-    end
+    add_column :systems, :proxy_byos_mode, :integer, default: 0
+    execute 'Update systems SET proxy_byos_mode = 0 WHERE proxy_byos = false'
+    execute 'Update systems SET proxy_byos_mode = 1 WHERE proxy_byos = true'
+    # remove_column :systems, :proxy_byos
   end
 
   def down
-    safety_assured do
-      add_column :systems, :proxy_byos, :boolean, default: false
-      execute 'Update systems SET proxy_byos = false WHERE proxy_byos_mode = 0'
-      execute 'Update systems SET proxy_byos = true WHERE proxy_byos_mode = 1'
-      # remove_column :systems, :proxy_byos_method
-    end
+    add_column :systems, :proxy_byos, :boolean, default: false
+    execute 'Update systems SET proxy_byos = false WHERE proxy_byos_mode = 0'
+    execute 'Update systems SET proxy_byos = true WHERE proxy_byos_mode = 1'
+    # remove_column :systems, :proxy_byos_method
   end
 end

--- a/db/migrate/20240729103525_update_proxy_byos_column_type.rb
+++ b/db/migrate/20240729103525_update_proxy_byos_column_type.rb
@@ -1,23 +1,27 @@
 class UpdateProxyByosColumnType < ActiveRecord::Migration[6.1]
   def up
     add_column :systems, :proxy_byos_boolean, :boolean, default: false
-    execute 'Update systems SET proxy_byos_boolean = false WHERE proxy_byos = false'
-    execute 'Update systems SET proxy_byos_boolean = true WHERE proxy_byos = true'
-    remove_column :systems, :proxy_byos
-    add_column :systems, :proxy_byos, :integer, default: 0
-    execute 'Update systems SET proxy_byos = 0 WHERE proxy_byos_boolean = false'
-    execute 'Update systems SET proxy_byos = 1 WHERE proxy_byos_boolean = true'
-    remove_column :systems, :proxy_byos_boolean
+    safety_assured do
+      execute 'Update systems SET proxy_byos_boolean = false WHERE proxy_byos = false'
+      execute 'Update systems SET proxy_byos_boolean = true WHERE proxy_byos = true'
+      remove_column :systems, :proxy_byos
+      add_column :systems, :proxy_byos, :integer, default: 0
+      execute 'Update systems SET proxy_byos = 0 WHERE proxy_byos_boolean = false'
+      execute 'Update systems SET proxy_byos = 1 WHERE proxy_byos_boolean = true'
+      remove_column :systems, :proxy_byos_boolean
+    end
   end
 
   def down
     add_column :systems, :proxy_byos_boolean, :boolean, default: false
-    execute 'Update systems SET proxy_byos_boolean = false WHERE proxy_byos = 0'
-    execute 'Update systems SET proxy_byos_boolean = true WHERE proxy_byos = 1'
-    remove_column :systems, :proxy_byos
-    add_column :systems, :proxy_byos, :boolean, default: false
-    execute 'Update systems SET proxy_byos = false WHERE proxy_byos_boolean = false'
-    execute 'Update systems SET proxy_byos = true WHERE proxy_byos_boolean = true'
-    remove_column :systems, :proxy_byos_boolean
+    safety_assured do
+      execute 'Update systems SET proxy_byos_boolean = false WHERE proxy_byos = 0'
+      execute 'Update systems SET proxy_byos_boolean = true WHERE proxy_byos = 1'
+      remove_column :systems, :proxy_byos
+      add_column :systems, :proxy_byos, :boolean, default: false
+      execute 'Update systems SET proxy_byos = false WHERE proxy_byos_boolean = false'
+      execute 'Update systems SET proxy_byos = true WHERE proxy_byos_boolean = true'
+      remove_column :systems, :proxy_byos_boolean
+    end
   end
 end

--- a/db/migrate/20240729103525_update_proxy_byos_column_type.rb
+++ b/db/migrate/20240729103525_update_proxy_byos_column_type.rb
@@ -1,0 +1,5 @@
+class UpdateProxyByosColumnType < ActiveRecord::Migration[6.1]
+  def change
+    change_column(:systems, :proxy_byos, :integer, default: 0)
+  end
+end

--- a/db/migrate/20240729103525_update_proxy_byos_column_type.rb
+++ b/db/migrate/20240729103525_update_proxy_byos_column_type.rb
@@ -1,27 +1,19 @@
 class UpdateProxyByosColumnType < ActiveRecord::Migration[6.1]
   def up
-    add_column :systems, :proxy_byos_boolean, :boolean, default: false
     safety_assured do
-      execute 'Update systems SET proxy_byos_boolean = false WHERE proxy_byos = false'
-      execute 'Update systems SET proxy_byos_boolean = true WHERE proxy_byos = true'
+      add_column :systems, :proxy_byos_method, :integer, default: 0
+      execute 'Update systems SET proxy_byos_method = 0 WHERE proxy_byos = false'
+      execute 'Update systems SET proxy_byos_method = 1 WHERE proxy_byos = true'
       remove_column :systems, :proxy_byos
-      add_column :systems, :proxy_byos, :integer, default: 0
-      execute 'Update systems SET proxy_byos = 0 WHERE proxy_byos_boolean = false'
-      execute 'Update systems SET proxy_byos = 1 WHERE proxy_byos_boolean = true'
-      remove_column :systems, :proxy_byos_boolean
     end
   end
 
   def down
-    add_column :systems, :proxy_byos_boolean, :boolean, default: false
     safety_assured do
-      execute 'Update systems SET proxy_byos_boolean = false WHERE proxy_byos = 0'
-      execute 'Update systems SET proxy_byos_boolean = true WHERE proxy_byos = 1'
-      remove_column :systems, :proxy_byos
       add_column :systems, :proxy_byos, :boolean, default: false
-      execute 'Update systems SET proxy_byos = false WHERE proxy_byos_boolean = false'
-      execute 'Update systems SET proxy_byos = true WHERE proxy_byos_boolean = true'
-      remove_column :systems, :proxy_byos_boolean
+      execute 'Update systems SET proxy_byos = false WHERE proxy_byos_method = 0'
+      execute 'Update systems SET proxy_byos = true WHERE proxy_byos_method = 1'
+      remove_column :systems, :proxy_byos_method
     end
   end
 end

--- a/db/migrate/20240729103525_update_proxy_byos_column_type.rb
+++ b/db/migrate/20240729103525_update_proxy_byos_column_type.rb
@@ -1,11 +1,10 @@
 class UpdateProxyByosColumnType < ActiveRecord::Migration[6.1]
   def up
+    add_column :systems, :proxy_byos_mode, :integer, default: 0
     safety_assured do
-      add_column :systems, :proxy_byos_mode, :integer, default: 0
       execute 'Update systems SET proxy_byos_mode = 0 WHERE proxy_byos = false'
       execute 'Update systems SET proxy_byos_mode = 1 WHERE proxy_byos = true'
     end
-    # remove_column :systems, :proxy_byos
   end
 
   def down

--- a/db/migrate/20240729103525_update_proxy_byos_column_type.rb
+++ b/db/migrate/20240729103525_update_proxy_byos_column_type.rb
@@ -1,6 +1,6 @@
 class UpdateProxyByosColumnType < ActiveRecord::Migration[6.1]
   def up
-    add_column :systems, :proxy_byos_boolean, :booleanm, default: false
+    add_column :systems, :proxy_byos_boolean, :boolean, default: false
     execute 'Update systems SET proxy_byos_boolean = false WHERE proxy_byos = false'
     execute 'Update systems SET proxy_byos_boolean = true WHERE proxy_byos = true'
     remove_column :systems, :proxy_byos

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_01_29_140413) do
+ActiveRecord::Schema.define(version: 2024_07_29_103525) do
 
   create_table "activations", charset: "utf8", force: :cascade do |t|
     t.bigint "service_id", null: false
@@ -169,6 +169,7 @@ ActiveRecord::Schema.define(version: 2024_01_29_140413) do
     t.datetime "scc_registered_at"
     t.bigint "scc_system_id", comment: "System ID in SCC (if the system registration was forwarded; needed for forwarding de-registrations)"
     t.boolean "proxy_byos", default: false
+    t.integer "proxy_byos_mode", default: 0
     t.string "system_token"
     t.text "system_information", size: :long
     t.text "instance_data"


### PR DESCRIPTION
## Description

Before LTSS support proxy_byos was a boolean column, representing PAYG or BYOS

With LTSS, we need a column (proxy_byos_mode) to represent one more value, change the type to enum with the following mapping:

PAYG -> 0
BYOS -> 1
LTSS -> 2

## How to test 

Create a system with `:hybrid`, should not produce an error
Check that the just created system has `hybrid` to true

## Change Type

*Please select the correct option.*

- [ ] **Bug Fix** (a non-breaking change which fixes an issue)
- [X] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [ ] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

