### PR TITLE
Check access for repositories or registry for LTSS

### DIFF
--- a/engines/registry/app/models/access_scope.rb
+++ b/engines/registry/app/models/access_scope.rb
@@ -88,9 +88,9 @@ class AccessScope
     allowed_products = (active_products & access_policies_yml.keys)
     allowed_glob_paths = access_policies_yml.values_at(*allowed_products).flatten
 
-    if !system.nil? && system.hybrid?
+    if system && system.hybrid?
       allowed_product_class = allowed_products.detect { |s| s.downcase.include?('ltss') }
-      unless allowed_product_class.empty?
+      if allowed_product_class.present?
         activation_state = SccProxy.scc_check_subscription_expiration(
           nil, system.login, system.system_token, Rails.logger, system.proxy_byos_mode, allowed_product_class
           )

--- a/engines/registry/app/models/access_scope.rb
+++ b/engines/registry/app/models/access_scope.rb
@@ -88,15 +88,19 @@ class AccessScope
     allowed_products = (active_products & access_policies_yml.keys)
     allowed_glob_paths = access_policies_yml.values_at(*allowed_products).flatten
 
-    allowed_product_class = allowed_products.detect { |s| s.downcase.include?('ltss') }
-    if !system.nil? && system.hybrid? && !allowed_product_class.empty?
-      activation_state = SccProxy.scc_check_subscription_expiration(
-        nil, system.login, system.system_token, Rails.logger, system.proxy_byos_mode, allowed_product_class
-      )
-      unless activation_state
-        Rails.logger.info "Access to #{allowed_product_class} denied: #{activation_state[:message]}"
-        @allowed_paths = []
-        return
+    if !system.nil? && system.hybrid?
+      allowed_product_class = allowed_products.detect { |s| s.downcase.include?('ltss') }
+      unless allowed_product_class.empty?
+        activation_state = SccProxy.scc_check_subscription_expiration(
+          nil, system.login, system.system_token, Rails.logger, system.proxy_byos_mode, allowed_product_class
+          )
+        unless activation_state[:is_active]
+          Rails.logger.info(
+            "Access to #{allowed_product_class} from system #{system.login} denied: #{activation_state[:message]}"
+          )
+          @allowed_paths = []
+          return
+        end
       end
     end
     @allowed_paths = parse_repos(repo_list, allowed_glob_paths)

--- a/engines/registry/app/models/access_scope.rb
+++ b/engines/registry/app/models/access_scope.rb
@@ -92,7 +92,7 @@ class AccessScope
       allowed_product_class = allowed_products.detect { |s| s.downcase.include?('ltss') }
       if allowed_product_class.present?
         activation_state = SccProxy.scc_check_subscription_expiration(
-          nil, system.login, system.system_token, Rails.logger, system.proxy_byos_mode, allowed_product_class
+          {}, system.login, system.system_token, Rails.logger, system.proxy_byos_mode, allowed_product_class
           )
         unless activation_state[:is_active]
           Rails.logger.info(

--- a/engines/registry/spec/app/models/access_scope_spec.rb
+++ b/engines/registry/spec/app/models/access_scope_spec.rb
@@ -152,13 +152,13 @@ RSpec.describe AccessScope, type: :model do
             type: 'a',
             name: 'suse/sles/*',
             actions: ['pull']
-            )
+          )
         end
 
         it 'returns default auth actions (no free repos included)' do
           yaml_string = access_policy_content
           data = YAML.safe_load yaml_string
-          data[product1.product_class] = 'suse/**'
+          data[product1.product_class] = 'suse/sles/**'
           File.write('engines/registry/spec/data/access_policy_yaml.yml', YAML.dump(data))
           allow_any_instance_of(RegistryCatalogService).to receive(:repos).and_return(['suse/sles/super_repo'])
           allow(File).to receive(:read).and_return(File.read('engines/registry/spec/data/access_policy_yaml.yml'))
@@ -172,6 +172,64 @@ RSpec.describe AccessScope, type: :model do
               'name' => 'suse/sles/*'
             }
           )
+        end
+      end
+
+      context 'when product is LTSS' do
+        let(:system) do
+          system = FactoryBot.create(:system, :hybrid)
+          system.activations << [
+            FactoryBot.create(:activation, system: system, service: product1.service),
+            FactoryBot.create(:activation, system: system, service: product2.service)
+          ]
+          system
+        end
+
+        subject(:access_scope) do
+          described_class.new(
+            type: 'a',
+            name: 'suse/ltss/**',
+            actions: ['pull']
+            )
+        end
+
+        let(:product1) do
+          product = FactoryBot.create(:product, :with_mirrored_repositories)
+          product.repositories.where(enabled: false).update(mirroring_enabled: false)
+          product.update(product_class: 'SLES15-SP4-LTSS-X86')
+          product
+        end
+
+        context 'when activation expired' do
+          let(:scc_response) do
+            {
+              is_active: false,
+              message: 'You shall not have access to those repos !'
+            }
+          end
+
+          before do
+            allow(SccProxy).to receive(:scc_check_subscription_expiration).and_return(scc_response)
+          end
+
+          it 'returns no actions allowed' do
+            yaml_string = access_policy_content
+            data = YAML.safe_load yaml_string
+            data[product1.product_class] = 'suse/ltss/**'
+            File.write('engines/registry/spec/data/access_policy_yaml.yml', YAML.dump(data))
+            allow_any_instance_of(RegistryCatalogService).to receive(:repos).and_return(['suse/ltss/ltss_repo'])
+            allow(File).to receive(:read).and_return(File.read('engines/registry/spec/data/access_policy_yaml.yml'))
+            possible_access = access_scope.granted(client: client)
+
+            expect(possible_access).to eq(
+              {
+                'type' => 'a',
+                'actions' => [],
+                'class' => nil,
+                'name' => 'suse/ltss/**'
+              }
+            )
+          end
         end
       end
 

--- a/engines/registry/spec/app/models/access_scope_spec.rb
+++ b/engines/registry/spec/app/models/access_scope_spec.rb
@@ -105,6 +105,7 @@ RSpec.describe AccessScope, type: :model do
     end
   end
 
+  # rubocop:disable RSpec/NestedGroups
   describe ".granted['actions']" do
     let(:product1) do
       product = FactoryBot.create(:product, :with_mirrored_repositories)
@@ -176,15 +177,6 @@ RSpec.describe AccessScope, type: :model do
       end
 
       context 'when product is LTSS' do
-        let(:system) do
-          system = FactoryBot.create(:system, :hybrid)
-          system.activations << [
-            FactoryBot.create(:activation, system: system, service: product1.service),
-            FactoryBot.create(:activation, system: system, service: product2.service)
-          ]
-          system
-        end
-
         subject(:access_scope) do
           described_class.new(
             type: 'a',
@@ -193,6 +185,14 @@ RSpec.describe AccessScope, type: :model do
             )
         end
 
+        let(:system) do
+          system = FactoryBot.create(:system, :hybrid)
+          system.activations << [
+            FactoryBot.create(:activation, system: system, service: product1.service),
+            FactoryBot.create(:activation, system: system, service: product2.service)
+          ]
+          system
+        end
         let(:product1) do
           product = FactoryBot.create(:product, :with_mirrored_repositories)
           product.repositories.where(enabled: false).update(mirroring_enabled: false)
@@ -284,4 +284,5 @@ RSpec.describe AccessScope, type: :model do
       end
     end
   end
+  # rubocop:enable RSpec/NestedGroups
 end

--- a/engines/registry/spec/data/access_policy_yaml.yml
+++ b/engines/registry/spec/data/access_policy_yaml.yml
@@ -23,3 +23,4 @@ free:
 - suse/sles/**
 - suse/vmdp/**
 - trento/**
+115AA: suse/**

--- a/engines/registry/spec/data/access_policy_yaml.yml
+++ b/engines/registry/spec/data/access_policy_yaml.yml
@@ -23,4 +23,3 @@ free:
 - suse/sles/**
 - suse/vmdp/**
 - trento/**
-115AA: suse/**

--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -166,7 +166,7 @@ module SccProxy
     end
 
     def get_scc_activations(headers, system_token, mode)
-      auth = headers['HTTP_AUTHORIZATION'] if headers.include?('HTTP_AUTHORIZATION')
+      auth = headers['HTTP_AUTHORIZATION'] if headers && headers.include?('HTTP_AUTHORIZATION')
       uri = URI.parse(SYSTEMS_ACTIVATIONS_URL)
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true
@@ -182,14 +182,14 @@ module SccProxy
     end
 
     def product_class_access(scc_systems_activations, product)
-      active_products_ids = scc_systems_activations.map { |act| act['service']['product']['id'] if act['status'].casecmp('active').zero? }.flatten
-      if active_products_ids.include?(product)
+      active_products_names = scc_systems_activations.map { |act| act['service']['product']['product_class'] if act['status'].casecmp('active').zero? }.flatten
+      if active_products_names.include?(product)
         { is_active: true }
       else
-        expired_products_ids = scc_systems_activations.map { |act| act['service']['product']['id'] unless act['status'].casecmp('active').zero? }.flatten
-        message = if expired_products_ids.all?(&:nil?)
+        expired_products_names = scc_systems_activations.map { |act| act['service']['product']['product_class'] unless act['status'].casecmp('active').zero? }.flatten
+        message = if expired_products_names.all?(&:nil?)
                     'Product not activated.'
-                  elsif expired_products_ids.include?(product)
+                  elsif expired_products_names.include?(product)
                     'Subscription expired.'
                   else
                     'Unexpected error when checking product subscription.'

--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -186,7 +186,9 @@ module SccProxy
       if active_products_names.include?(product)
         { is_active: true }
       else
-        expired_products_names = scc_systems_activations.map { |act| act['service']['product']['product_class'] unless act['status'].casecmp('active').zero? }.flatten
+        expired_products_names = scc_systems_activations.map do |act|
+          act['service']['product']['product_class'] unless act['status'].casecmp('active').zero?
+        end.flatten
         message = if expired_products_names.all?(&:nil?)
                     'Product not activated.'
                   elsif expired_products_names.include?(product)
@@ -228,7 +230,7 @@ module SccProxy
       end
     end
 
-    def scc_check_subscription_expiration(headers, login, system_token, logger, mode, product = nil)
+    def scc_check_subscription_expiration(headers, login, system_token, logger, mode, product = nil) # rubocop:disable Metrics/ParameterLists
       response = SccProxy.get_scc_activations(headers, system_token, mode)
       unless response.code_type == Net::HTTPOK
         logger.info "Could not get the system (#{login}) activations, error: #{response.message} #{response.code}"

--- a/engines/zypper_auth/lib/zypper_auth/engine.rb
+++ b/engines/zypper_auth/lib/zypper_auth/engine.rb
@@ -50,7 +50,7 @@ module ZypperAuth
     end
 
     def handle_scc_subscription(request, system, verification_provider, logger)
-      result = SccProxy.scc_check_subscription_expiration(request.headers, system.login, system.system_token, logger)
+      result = SccProxy.scc_check_subscription_expiration(request.headers, system.login, system.system_token, logger, system.proxy_byos_mode)
       return true if result[:is_active]
 
       ZypperAuth.zypper_auth_message(request, system, verification_provider, result[:message])

--- a/engines/zypper_auth/lib/zypper_auth/engine.rb
+++ b/engines/zypper_auth/lib/zypper_auth/engine.rb
@@ -31,44 +31,14 @@ module ZypperAuth
       )
 
       is_valid = verification_provider.instance_valid?
-      if is_valid && system.hybrid?
-        result = SccProxy.scc_check_subscription_expiration(request.headers, system.login, system.system_token, logger)
-        unless result[:is_active]
-          details = [ "System login: #{system.login}", "IP: #{request.remote_ip}" ]
-          details << "Instance ID: #{verification_provider.instance_id}" if verification_provider.instance_id
-          details << "Billing info: #{verification_provider.instance_billing_info}" if verification_provider.instance_billing_info
-
-          ZypperAuth.auth_logger.info <<~LOGMSG
-            Access to the repos denied: #{result[:message]}
-          LOGMSG
-          return false
-        end
-      end
+      return false if is_valid && system.hybrid? && !handle_scc_subscription(request, system, verification_provider, logger)
       # update repository and registry cache
       InstanceVerification.update_cache(request.remote_ip, system.login, base_product.id)
       is_valid
     rescue InstanceVerification::Exception => e
-      message = ''
-      if system.byos?
-        result = SccProxy.scc_check_subscription_expiration(request.headers, system.login, system.system_token, logger)
-        if result[:is_active]
-          InstanceVerification.update_cache(request.remote_ip, system.login, base_product.id)
-          return true
-        end
+      return handle_scc_subscription(request, system, verification_provider, logger) if system.byos?
 
-        message = result[:message]
-      else
-        message = e.message
-      end
-      details = [ "System login: #{system.login}", "IP: #{request.remote_ip}" ]
-      details << "Instance ID: #{verification_provider.instance_id}" if verification_provider.instance_id
-      details << "Billing info: #{verification_provider.instance_billing_info}" if verification_provider.instance_billing_info
-
-      ZypperAuth.auth_logger.info <<~LOGMSG
-        Access to the repos denied: #{message}
-        #{details.join(', ')}
-      LOGMSG
-
+      ZypperAuth.zypper_auth_message(request, system, verification_provider, e.message)
       false
     rescue StandardError => e
       logger.error('Unexpected instance verification error has occurred:')
@@ -77,6 +47,25 @@ module ZypperAuth
       logger.error('Backtrace:')
       logger.error(e.backtrace)
       false
+    end
+
+    def handle_scc_subscription(request, system, verification_provider, logger)
+      result = SccProxy.scc_check_subscription_expiration(request.headers, system.login, system.system_token, logger)
+      return true if result[:is_active]
+
+      ZypperAuth.zypper_auth_message(request, system, verification_provider, result[:message])
+      false
+    end
+
+    def zypper_auth_message(request, system, verification_provider, message)
+      details = [ "System login: #{system.login}", "IP: #{request.remote_ip}" ]
+      details << "Instance ID: #{verification_provider.instance_id}" if verification_provider.instance_id
+      details << "Billing info: #{verification_provider.instance_billing_info}" if verification_provider.instance_billing_info
+
+      ZypperAuth.auth_logger.info <<~LOGMSG
+        Access to the repos denied: #{message}
+        #{details.join(', ')}
+      LOGMSG
     end
   end
 

--- a/engines/zypper_auth/lib/zypper_auth/engine.rb
+++ b/engines/zypper_auth/lib/zypper_auth/engine.rb
@@ -31,6 +31,19 @@ module ZypperAuth
       )
 
       is_valid = verification_provider.instance_valid?
+      if is_valid && system.hybrid?
+        result = SccProxy.scc_check_subscription_expiration(request.headers, system.login, system.system_token, logger)
+        unless result[:is_active]
+          details = [ "System login: #{system.login}", "IP: #{request.remote_ip}" ]
+          details << "Instance ID: #{verification_provider.instance_id}" if verification_provider.instance_id
+          details << "Billing info: #{verification_provider.instance_billing_info}" if verification_provider.instance_billing_info
+
+          ZypperAuth.auth_logger.info <<~LOGMSG
+            Access to the repos denied: #{result[:message]}
+          LOGMSG
+          return false
+        end
+      end
       # update repository and registry cache
       InstanceVerification.update_cache(request.remote_ip, system.login, base_product.id)
       is_valid

--- a/engines/zypper_auth/spec/requests/strict_authentication/authentication_controller_spec.rb
+++ b/engines/zypper_auth/spec/requests/strict_authentication/authentication_controller_spec.rb
@@ -220,6 +220,10 @@ describe StrictAuthentication::AuthenticationController, type: :request do
         end
 
         context 'regcode check fails' do
+          let(:error_message) do
+            "Access to the repos denied: You shall not have access to those repos !\nSystem login: #{system_hybrid.login}, IP: 127.0.0.1\n"
+          end
+
           before do
             Rails.cache.clear
             expect_any_instance_of(InstanceVerification::Providers::Example).to receive(:instance_valid?).and_return(true)
@@ -230,11 +234,7 @@ describe StrictAuthentication::AuthenticationController, type: :request do
             allow(Dir).to receive(:mkdir)
             allow(FileUtils).to receive(:touch)
             allow(ZypperAuth.auth_logger).to receive(:info)
-            expect(ZypperAuth.auth_logger).to(
-              receive(:info).with(
-                "Access to the repos denied: You shall not have access to those repos !\n"
-                )
-              )
+            expect(ZypperAuth.auth_logger).to(receive(:info).with(error_message))
             get '/api/auth/check', headers: headers
           end
 

--- a/engines/zypper_auth/spec/requests/strict_authentication/authentication_controller_spec.rb
+++ b/engines/zypper_auth/spec/requests/strict_authentication/authentication_controller_spec.rb
@@ -134,7 +134,7 @@ describe StrictAuthentication::AuthenticationController, type: :request do
         context 'when subscription is active' do
           before do
             stub_request(:get, scc_systems_activations_url).to_return(status: 200, body: [body_active].to_json, headers: {})
-            expect(URI).to receive(:encode_www_form).with({ byos: true })
+            expect(URI).to receive(:encode_www_form).with({ byos_mode: 'byos' })
             allow(File).to receive(:directory?).and_return(true)
             allow(Dir).to receive(:mkdir)
             allow(FileUtils).to receive(:touch)
@@ -147,7 +147,7 @@ describe StrictAuthentication::AuthenticationController, type: :request do
         context 'when subscription is expired' do
           before do
             stub_request(:get, scc_systems_activations_url).to_return(status: 200, body: [body_expired].to_json, headers: {})
-            expect(URI).to receive(:encode_www_form).with({ byos: true })
+            expect(URI).to receive(:encode_www_form).with({ byos_mode: 'byos' })
             get '/api/auth/check', headers: headers
           end
 
@@ -157,7 +157,7 @@ describe StrictAuthentication::AuthenticationController, type: :request do
         context 'when product is not activated' do
           before do
             stub_request(:get, scc_systems_activations_url).to_return(status: 200, body: [body_not_activated].to_json, headers: {})
-            expect(URI).to receive(:encode_www_form).with({ byos: true })
+            expect(URI).to receive(:encode_www_form).with({ byos_mode: 'byos' })
             get '/api/auth/check', headers: headers
           end
 
@@ -167,7 +167,7 @@ describe StrictAuthentication::AuthenticationController, type: :request do
         context 'when status from SCC is unknown' do
           before do
             stub_request(:get, scc_systems_activations_url).to_return(status: 200, body: [body_unknown_status].to_json, headers: {})
-            expect(URI).to receive(:encode_www_form).with({ byos: true })
+            expect(URI).to receive(:encode_www_form).with({ byos_mode: 'byos' })
             allow(File).to receive(:directory?)
             allow(Dir).to receive(:mkdir)
             allow(FileUtils).to receive(:touch)
@@ -180,7 +180,7 @@ describe StrictAuthentication::AuthenticationController, type: :request do
         context 'when SCC request fails' do
           before do
             stub_request(:get, scc_systems_activations_url).to_return(status: 401, body: [body_expired].to_json, headers: {})
-            expect(URI).to receive(:encode_www_form).with({ byos: true })
+            expect(URI).to receive(:encode_www_form).with({ byos_mode: 'byos' })
             allow(File).to receive(:directory?)
             allow(Dir).to receive(:mkdir)
             allow(FileUtils).to receive(:touch)
@@ -209,16 +209,190 @@ describe StrictAuthentication::AuthenticationController, type: :request do
 
       context 'system is hybrid' do
         include_context 'auth header', :system_hybrid, :login, :password
+        let(:scc_systems_activations_url) { 'https://scc.suse.com/connect/systems/activations' }
         let(:system_hybrid) { FactoryBot.create(:system, :hybrid, :with_activated_product) }
         let(:requested_uri) { '/repo' + system_hybrid.repositories.first[:local_path] + '/repodata/repomd.xml' }
         let(:headers) { auth_header.merge({ 'X-Original-URI': requested_uri, 'X-Instance-Data': 'test' }) }
 
         before do
           Rails.cache.clear
-          expect_any_instance_of(InstanceVerification::Providers::Example).to receive(:instance_valid?).and_return(true)
           allow(InstanceVerification).to receive(:update_cache)
           allow(Dir).to receive(:mkdir)
           allow(FileUtils).to receive(:touch)
+        end
+
+        context 'when subscription is active' do
+          let(:body_active) do
+            {
+              id: 1,
+              regcode: '631dc51f',
+              name: 'Subscription 1',
+              type: 'FULL',
+              status: 'ACTIVE',
+              starts_at: 'null',
+              expires_at: DateTime.parse((Time.zone.today + 1).to_s),
+              system_limit: 6,
+              systems_count: 1,
+              service: {
+                product: {
+                  id: system_hybrid.activations.first.product.id,
+                  product_class: system_hybrid.activations.first.product.product_class + '-LTSS'
+                }
+              }
+            }
+          end
+          let(:headers) { auth_header }
+
+          before do
+            stub_request(:get, scc_systems_activations_url).to_return(status: 200, body: [body_active].to_json, headers: {})
+            # allow(SccProxy).to receive(:get_scc_activations).and_return(status: 200, body: [body_active].to_json, headers: {})
+            expect(URI).to receive(:encode_www_form).with({ byos_mode: 'hybrid' })
+            allow(File).to receive(:directory?).and_return(true)
+            allow(Dir).to receive(:mkdir)
+            allow(FileUtils).to receive(:touch)
+            # get '/api/auth/check', headers: headers
+          end
+
+          it 'returns true' do
+            result = SccProxy.scc_check_subscription_expiration(
+              headers,
+              system_hybrid.login,
+              system_hybrid.system_token,
+              nil,
+              system_hybrid.proxy_byos_mode,
+              system_hybrid.activations.first.product.product_class + '-LTSS'
+            )
+            expect(result[:is_active]).to be(true)
+          end
+        end
+
+        context 'when subscription is expired' do
+          let(:body_expired) do
+            {
+              id: 1,
+              regcode: '631dc51f',
+              name: 'Subscription 1',
+              type: 'FULL',
+              status: 'EXPIRED',
+              starts_at: 'null',
+              expires_at: DateTime.parse((Time.zone.today - 1).to_s),
+              system_limit: 6,
+              systems_count: 1,
+              service: {
+                product: {
+                  id: system_hybrid.activations.first.product.id,
+                  product_class: system_hybrid.activations.first.product.product_class + '-LTSS'
+                }
+              }
+            }
+          end
+
+          before do
+            stub_request(:get, scc_systems_activations_url).to_return(status: 200, body: [body_expired].to_json, headers: {})
+            expect(URI).to receive(:encode_www_form).with({ byos_mode: 'hybrid' })
+            allow(File).to receive(:directory?).and_return(true)
+            allow(Dir).to receive(:mkdir)
+            allow(FileUtils).to receive(:touch)
+          end
+
+          it 'returns false, expired' do
+            result = SccProxy.scc_check_subscription_expiration(
+              headers,
+              system_hybrid.login,
+              system_hybrid.system_token,
+              nil,
+              system_hybrid.proxy_byos_mode,
+              system_hybrid.activations.first.product.product_class + '-LTSS'
+            )
+            expect(result[:is_active]).to eq(false)
+            expect(result[:message]).to eq('Subscription expired.')
+          end
+        end
+
+        context 'when product is not activated' do
+          let(:body_not_activated) do
+            {
+              id: 1,
+              regcode: '631dc51f',
+              name: 'Subscription 1',
+              type: 'FULL',
+              status: 'FOO',
+              starts_at: 'null',
+              expires_at: DateTime.parse((Time.zone.today - 1).to_s),
+              system_limit: 6,
+              systems_count: 1,
+              service: {
+                product: {
+                  id: system_hybrid.activations.first.product.id,
+                  product_class: nil
+                }
+              }
+            }
+          end
+
+          before do
+            stub_request(:get, scc_systems_activations_url).to_return(status: 200, body: [body_not_activated].to_json, headers: {})
+            expect(URI).to receive(:encode_www_form).with({ byos_mode: 'hybrid' })
+            allow(File).to receive(:directory?).and_return(true)
+            allow(Dir).to receive(:mkdir)
+            allow(FileUtils).to receive(:touch)
+          end
+
+          it 'returns product not activated' do
+            result = SccProxy.scc_check_subscription_expiration(
+              headers,
+              system_hybrid.login,
+              system_hybrid.system_token,
+              nil,
+              system_hybrid.proxy_byos_mode,
+              system_hybrid.activations.first.product.product_class + '-LTSS'
+            )
+            expect(result[:is_active]).to eq(false)
+            expect(result[:message]).to eq('Product not activated.')
+          end
+        end
+
+        context 'when unexpected error' do
+          let(:body_unexpected) do
+            {
+              id: 1,
+              regcode: '631dc51f',
+              name: 'Subscription 1',
+              type: 'FULL',
+              status: 'FOO',
+              starts_at: 'null',
+              expires_at: DateTime.parse((Time.zone.today - 1).to_s),
+              system_limit: 6,
+              systems_count: 1,
+              service: {
+                product: {
+                  id: system_hybrid.activations.first.product.id,
+                  product_class: system_hybrid.activations.first.product.product_class
+                }
+              }
+            }
+          end
+
+          before do
+            stub_request(:get, scc_systems_activations_url).to_return(status: 200, body: [body_unexpected].to_json, headers: {})
+            expect(URI).to receive(:encode_www_form).with({ byos_mode: 'hybrid' })
+            allow(File).to receive(:directory?).and_return(true)
+            allow(Dir).to receive(:mkdir)
+            allow(FileUtils).to receive(:touch)
+          end
+
+          it 'returns unexpected error' do
+            result = SccProxy.scc_check_subscription_expiration(
+              headers,
+              system_hybrid.login,
+              system_hybrid.system_token,
+              nil,
+              system_hybrid.proxy_byos_mode,
+              system_hybrid.activations.first.product.product_class + '-LTSS'
+            )
+            expect(result[:is_active]).to eq(false)
+            expect(result[:message]).to eq('Unexpected error when checking product subscription.')
+          end
         end
 
         context 'regcode check fails' do
@@ -234,6 +408,7 @@ describe StrictAuthentication::AuthenticationController, type: :request do
           end
 
           before do
+            expect_any_instance_of(InstanceVerification::Providers::Example).to receive(:instance_valid?).and_return(true)
             allow(SccProxy).to receive(:scc_check_subscription_expiration).and_return(scc_response)
             expect(SccProxy).to receive(:scc_check_subscription_expiration)
             allow(ZypperAuth.auth_logger).to receive(:info)
@@ -253,6 +428,7 @@ describe StrictAuthentication::AuthenticationController, type: :request do
           end
 
           before do
+            expect_any_instance_of(InstanceVerification::Providers::Example).to receive(:instance_valid?).and_return(true)
             allow(SccProxy).to receive(:scc_check_subscription_expiration).and_return(scc_response)
             expect(SccProxy).to receive(:scc_check_subscription_expiration)
             allow(ZypperAuth.auth_logger).to receive(:info)


### PR DESCRIPTION
## Description

If the system is hybrid, it means is PAYG with an add on product (extension) activated. 
If instance metadata verification succeeded for that system, we check that the registration code is still valid.

* https://trello.com/c/D09lCvMp
* https://confluence.suse.com/display/publiccloud/LTSS+support+for+PAYG+instances

## How to test 

Running `zypper ref` or a `zypper` command on a hybrid system (PAYG with an add-on product activated) 
with a expired subscription should show access denied message

## Change Type

*Please select the correct option.*

- [ ] **Bug Fix** (a non-breaking change which fixes an issue)
- [X] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

