### PR TITLE
Handle non free extension with regcode

### DIFF
--- a/engines/instance_verification/lib/instance_verification/engine.rb
+++ b/engines/instance_verification/lib/instance_verification/engine.rb
@@ -58,7 +58,7 @@ module InstanceVerification
 
           if product.base?
             verify_base_product_activation(product)
-          elsif !product.free? && (!params.key?(:token) || params[:token].empty?)
+          elsif !product.free? && params[:token].blank?
             verify_payg_extension_activation!(product)
           end
         rescue InstanceVerification::Exception => e

--- a/engines/instance_verification/lib/instance_verification/engine.rb
+++ b/engines/instance_verification/lib/instance_verification/engine.rb
@@ -58,9 +58,8 @@ module InstanceVerification
 
           if product.base?
             verify_base_product_activation(product)
-          elsif !product.free? && @system.payg?
-            token_not_provided = !params.key?(:token) || params[:token].empty?
-            verify_payg_extension_activation!(product) if token_not_provided
+          elsif !product.free? && (!params.key?(:token) || params[:token].empty?)
+            verify_payg_extension_activation!(product)
           end
         rescue InstanceVerification::Exception => e
           unless @system.byos?

--- a/engines/instance_verification/lib/instance_verification/engine.rb
+++ b/engines/instance_verification/lib/instance_verification/engine.rb
@@ -58,8 +58,9 @@ module InstanceVerification
 
           if product.base?
             verify_base_product_activation(product)
-          else
-            verify_extension_activation(product)
+          elsif !product.free? && @system.payg?
+            token_not_provided = !params.key?(:token) || params[:token].empty?
+            verify_payg_extension_activation!(product) if token_not_provided
           end
         rescue InstanceVerification::Exception => e
           unless @system.byos?
@@ -79,11 +80,10 @@ module InstanceVerification
           raise ActionController::TranslatedError.new('Unexpected instance verification error has occurred')
         end
 
-        def verify_extension_activation(product)
+        def verify_payg_extension_activation!(product)
           return if product.free?
 
           base_product = @system.products.find_by(product_type: :base)
-
           subscription = Subscription.joins(:product_classes).find_by(
             subscription_product_classes: {
               product_class: base_product.product_class
@@ -91,7 +91,7 @@ module InstanceVerification
           )
 
           # This error would occur only if there's a problem with subscription setup on SCC side
-          raise "Can't find a subscription for base product #{base_product.product_string}" unless subscription
+          raise InstanceVerification::Exception, "Can't find a subscription for base product #{base_product.product_string}" unless subscription
 
           allowed_product_classes = subscription.product_classes.pluck(:product_class)
 
@@ -100,6 +100,8 @@ module InstanceVerification
               'The product is not available for this instance'
             )
           end
+          logger.info "Product #{@product.product_string} available for this instance"
+          InstanceVerification.update_cache(request.remote_ip, @system.login, @product.id)
         end
 
         def verify_base_product_activation(product)

--- a/engines/instance_verification/lib/instance_verification/engine.rb
+++ b/engines/instance_verification/lib/instance_verification/engine.rb
@@ -100,7 +100,7 @@ module InstanceVerification
             )
           end
           logger.info "Product #{@product.product_string} available for this instance"
-          InstanceVerification.update_cache(request.remote_ip, @system.login, @product.id)
+          InstanceVerification.update_cache(request.remote_ip, @system.login, product.id)
         end
 
         def verify_base_product_activation(product)

--- a/engines/instance_verification/spec/requests/api/connect/v3/systems/products_controller_spec.rb
+++ b/engines/instance_verification/spec/requests/api/connect/v3/systems/products_controller_spec.rb
@@ -48,7 +48,7 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
 
       context 'when system has hw_info' do
         let(:instance_data) { 'dummy_instance_data' }
-        let(:system) { FactoryBot.create(:system, :with_system_information, instance_data: instance_data) }
+        let(:system) { FactoryBot.create(:system, :byos, :with_system_information, instance_data: instance_data) }
         let(:serialized_service_json) do
           V3::ServiceSerializer.new(
             product.service,
@@ -97,29 +97,12 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
             expect(data['error']).to eq('Unexpected instance verification error has occurred')
           end
         end
-
-        context 'when verification provider raises an instance verification exception' do
-          let(:scc_activate_url) { 'https://scc.suse.com/connect/systems/products' }
-
-          before do
-            expect(InstanceVerification::Providers::Example).to receive(:new)
-              .with(be_a(ActiveSupport::Logger), be_a(ActionDispatch::Request), payload, instance_data).and_return(plugin_double)
-            expect(plugin_double).to receive(:instance_valid?).and_raise(InstanceVerification::Exception, 'Custom plugin error')
-
-            post url, params: payload, headers: headers
-          end
-
-          it 'renders an error with exception details' do
-            data = JSON.parse(response.body)
-            expect(data['error']).to eq('Instance verification failed: Custom plugin error')
-          end
-        end
       end
     end
 
     context 'when the system is payg' do
       context "when system doesn't have hw_info" do
-        let(:system) { FactoryBot.create(:system) }
+        let(:system) { FactoryBot.create(:system, :payg) }
 
         it 'class instance verification provider' do
           expect(InstanceVerification::Providers::Example).to receive(:new)
@@ -133,7 +116,7 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
 
       context 'when system has hw_info' do
         let(:instance_data) { 'dummy_instance_data' }
-        let(:system) { FactoryBot.create(:system, :with_system_information, instance_data: instance_data) }
+        let(:system) { FactoryBot.create(:system, :payg, :with_system_information, instance_data: instance_data) }
         let(:serialized_service_json) do
           V3::ServiceSerializer.new(
             product.service,
@@ -198,7 +181,7 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
         let(:instance_data) { 'dummy_instance_data' }
         let(:system) do
           FactoryBot.create(
-            :system, :byos, :with_system_information, :with_activated_product, product: base_product, instance_data: instance_data
+            :system, :payg, :with_system_information, :with_activated_product, product: base_product, instance_data: instance_data
           )
         end
         let(:serialized_service_json) do
@@ -268,21 +251,6 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
             let(:product_classes) { [base_product.product_class] }
 
             it 'reports an error' do
-              data = JSON.parse(response.body)
-              expect(data['error']).to eq('Instance verification failed: The product is not available for this instance')
-            end
-          end
-
-          context 'when a suitable subscription is found' do
-            let(:product) do
-              FactoryBot.create(
-                :product, :with_mirrored_repositories, :extension, free: false, base_products: [base_product]
-              )
-            end
-            let(:product_classes) { [base_product.product_class, product.product_class] }
-            let(:plugin_double) { instance_double('InstanceVerification::Providers::Example') }
-
-            it 'returns error when SCC call fails' do
               data = JSON.parse(response.body)
               expect(data['error']).to eq('Instance verification failed: The product is not available for this instance')
             end
@@ -541,20 +509,6 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
       context 'when the extension is not free' do
         let(:base_product) { FactoryBot.create(:product, :with_mirrored_repositories) }
 
-        context 'when a suitable subscription is not found' do
-          let(:product) do
-            FactoryBot.create(
-              :product, :with_mirrored_repositories, :extension, free: false, base_products: [base_product]
-              )
-          end
-          let(:product_classes) { [base_product.product_class] }
-
-          it 'reports an error' do
-            data = JSON.parse(response.body)
-            expect(data['error']).to eq('Instance verification failed: The product is not available for this instance')
-          end
-        end
-
         context 'when a suitable subscription is found' do
           let(:product) do
             FactoryBot.create(
@@ -565,91 +519,14 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
           let(:plugin_double) { instance_double('InstanceVerification::Providers::Example') }
 
           context 'when no regcode is provided' do
-            it 'returns error' do
+            it 'activates the product' do
               data = JSON.parse(response.body)
-              expect(data['error']).to eq('A registration code is required to activate this product')
+              expect(data['id']).to eq(product.id)
             end
           end
         end
       end
     end
-
-    # context 'when activating extensions without errors' do
-    #   let(:instance_data) { 'dummy_instance_data' }
-    #   let(:system) do
-    #     FactoryBot.create(
-    #       :system, :hybrid, :with_system_information, :with_activated_product, product: base_product, instance_data: instance_data
-    #       )
-    #   end
-    #   let(:serialized_service_json) do
-    #     V3::ServiceSerializer.new(
-    #       product.service,
-    #       base_url: URI::HTTP.build({ scheme: response.request.scheme, host: response.request.host }).to_s
-    #       ).to_json
-    #   end
-    #   let(:scc_activate_url) { 'https://scc.suse.com/connect/systems/products' }
-    #   let(:plugin_double) { instance_double('InstanceVerification::Providers::Example') }
-    #   let(:payload_token) do
-    #     {
-    #       identifier: product.identifier,
-    #       version: product.version,
-    #       arch: product.arch,
-    #       instance_data: 'dummy_instance_data',
-    #       proxy_byos_mode: :hybrid,
-    #       token: 'super_token',
-    #       hwinfo:
-    #       {
-    #         hostname: 'test',
-    #         cpus: '1',
-    #         sockets: '1',
-    #         hypervisor: 'Xen',
-    #         arch: 'x86_64',
-    #         uuid: 'ec235f7d-b435-e27d-86c6-c8fef3180a01',
-    #         cloud_provider: 'amazon'
-    #       }
-    #     }
-    #   end
-
-    #   let(:scc_response_body) do
-    #     {
-    #       id: 1234567,
-    #       login: 'SCC_3b336b126db1503a9513a14e92a6a62e',
-    #       password: '24f057b7941e80f9cf2d51e16e8af2d6'
-    #     }.to_json
-    #   end
-    #   let(:base_product) { FactoryBot.create(:product, :with_mirrored_repositories) }
-    #   let(:product_classes) { [base_product.product_class, product.product_class] }
-
-    #   before do
-    #     allow(InstanceVerification::Providers::Example).to receive(:new)
-    #       .with(be_a(ActiveSupport::Logger), be_a(ActionDispatch::Request), payload, instance_data).and_return(plugin_double)
-
-    #     allow(plugin_double).to receive(:instance_valid?).and_return(true)
-    #     allow(plugin_double).to receive(:parse_instance_data).and_return({ InstanceId: 'foo' })
-    #     # allow(InstanceVerification).to receive(:update_cache)
-
-    #     FactoryBot.create(:subscription, product_classes: product_classes)
-    #     stub_request(:post, scc_activate_url)
-    #       .to_return(
-    #         status: 201,
-    #         body: { ok: 'product activated correctly' }.to_json,
-    #         headers: {}
-    #       )
-    #     # stub the fake announcement call PAYG has to do to SCC
-    #     # to create the system before activate product (and skip validation)
-    #     stub_request(:post, 'https://scc.suse.com/connect/subscriptions/systems')
-    #       .to_return(status: 201, body: scc_response_body, headers: {})
-
-    #     post url, params: payload_token, headers: headers
-    #   end
-
-    #   context 'when regcode is provided' do
-    #     it 'returns service JSON' do
-    #       expect(response.body).to eq(serialized_service_json)
-    #       expect(InstanceVerification).to receive(:update_cache)
-    #     end
-    #   end
-    # end
   end
 
   describe '#upgrade' do

--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -307,6 +307,7 @@ module SccProxy
 
         # rubocop:disable Metrics/PerceivedComplexity
         # rubocop:disable Metrics/CyclomaticComplexity
+        # rubocop:disable Metrics/AbcSize
         def scc_activate_product
           logger.info "Activating product #{@product.product_string} to SCC"
           auth = nil
@@ -322,10 +323,14 @@ module SccProxy
             if @system.payg? && base_prod.present?
               raise 'Incompatible extension product' unless @product.arch == base_prod.arch && @product.version == base_prod.version
 
+              params['hostname'] = @system.system_information['hostname']
               params['proxy_byos_mode'] = mode
               params['scc_login'] = @system.login
               params['scc_password'] = @system.password
-              params['hwinfo']['instance_data'] = params['instance_data']
+              params['hwinfo'] = JSON.parse(@system.system_information)
+              params['hwinfo']['instance_data'] = @system.instance_data
+              auth = "Token token=#{params[:token]}"
+
               response = SccProxy.announce_system_scc(auth, params)
             end
           end
@@ -351,6 +356,7 @@ module SccProxy
           logger.info 'No token provided' if params[:token].blank?
         end
       end
+      # rubocop:enable Metrics/AbcSize
       # rubocop:enable Metrics/CyclomaticComplexity
       # rubocop:enable Metrics/PerceivedComplexity
 

--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -296,13 +296,12 @@ module SccProxy
             base_prod = @system.products.find_by(product_type: :base)
             if @system.payg? && base_prod.present?
               raise 'Incompatible extension product' unless @product.arch == base_prod.arch && @product.version == base_prod.version
-                # =>  @product.arch == base_prod.arch && @product.version == base_prod.version
-              request.headers['proxy_byos_mode'] = mode
-              request.headers['scc_login'] = @system.login
-              request.headers['scc_password'] = @system.password
-              request.headers['instance_data'] = params[:instance_data]
-              request.headers['hwinfo'] = params[:hwinfo]
-              response = SccProxy.announce_system_scc(auth, request.headers)
+
+              params['proxy_byos_mode'] = mode
+              params['scc_login'] = @system.login
+              params['scc_password'] = @system.password
+              params['hwinfo']['instance_data'] = params['instance_data']
+              response = SccProxy.announce_system_scc(auth, params)
             end
           end
 

--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -287,26 +287,23 @@ module SccProxy
           auth = nil
           auth = request.headers['HTTP_AUTHORIZATION'] if request.headers.include?('HTTP_AUTHORIZATION')
           mode = nil
+          token_not_provided = !params.key?(:token) || params[:token].empty?
           if @system.byos?
             mode = 'byos'
           elsif !@product.free? && @product.extension?
-            regcode_error_message = 'A registration code is required to activate this product'
-            raise ActionController::TranslatedError.new(regcode_error_message) if (@system.payg? || @system.hybrid?) && params[:token].nil?
-
-            # system is not BYOS and
-            # product is a non free extension
-            # and a registration code is provided
-            mode = 'hybrid'
-            # the extensions must be the same version and arch
-            # than base product
-            base_prod = @system.products.find_by(product_type: :base)
-            if base_prod.present? && @product.arch == base_prod.arch && @product.version == base_prod.version
-              request.headers['proxy_byos_mode'] = mode
-              request.headers['scc_login'] = @system.login
-              request.headers['scc_password'] = @system.password
-              request.headers['instance_data'] = params[:instance_data]
-              request.headers['hwinfo'] = params[:hwinfo]
-              response = SccProxy.announce_system_scc(auth, request.headers)
+            unless token_not_provided
+              mode = 'hybrid'
+              # the extensions must be the same version and arch
+              # than base product
+              base_prod = @system.products.find_by(product_type: :base)
+              if @system.payg? && base_prod.present? && @product.arch == base_prod.arch && @product.version == base_prod.version
+                request.headers['proxy_byos_mode'] = mode
+                request.headers['scc_login'] = @system.login
+                request.headers['scc_password'] = @system.password
+                request.headers['instance_data'] = params[:instance_data]
+                request.headers['hwinfo'] = params[:hwinfo]
+                response = SccProxy.announce_system_scc(auth, request.headers)
+              end
             end
           end
 
@@ -328,6 +325,7 @@ module SccProxy
             logger.info "Product #{@product.product_string} successfully activated with SCC"
             InstanceVerification.update_cache(request.remote_ip, @system.login, @product.id)
           end
+          logger.info 'No token provided' if token_not_provided
         end
       end
       # rubocop:enable Metrics/AbcSize

--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -281,7 +281,6 @@ module SccProxy
 
         # rubocop:disable Metrics/PerceivedComplexity
         # rubocop:disable Metrics/CyclomaticComplexity
-        # rubocop:disable Metrics/AbcSize
         def scc_activate_product
           logger.info "Activating product #{@product.product_string} to SCC"
           auth = nil
@@ -326,7 +325,6 @@ module SccProxy
           logger.info 'No token provided' if params[:token].blank?
         end
       end
-      # rubocop:enable Metrics/AbcSize
       # rubocop:enable Metrics/CyclomaticComplexity
       # rubocop:enable Metrics/PerceivedComplexity
 

--- a/engines/scc_proxy/spec/requests/api/connect/v3/systems/products_controller_spec.rb
+++ b/engines/scc_proxy/spec/requests/api/connect/v3/systems/products_controller_spec.rb
@@ -262,7 +262,7 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
     let(:instance_data) { 'dummy_instance_data' }
     let(:system) do
       FactoryBot.create(
-        :system, :with_system_information, :with_activated_product, product: base_product, instance_data: instance_data
+        :system, :payg, :with_system_information, :with_activated_product, product: base_product, instance_data: instance_data
       )
     end
     let(:serialized_service_json) do
@@ -293,7 +293,7 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
       post url, params: payload, headers: headers
     end
 
-    context 'when the extension is not free' do
+    context 'when the extension is not free and not regcode is provided' do
       let(:base_product) { FactoryBot.create(:product, :with_mirrored_repositories) }
 
       context 'when a suitable subscription is not found' do
@@ -319,9 +319,10 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
         end
         let(:product_classes) { [base_product.product_class, product.product_class] }
 
-        it 'returns error when SCC call fails' do
+        it 'activates the product' do
           data = JSON.parse(response.body)
-          expect(data['error']).to eq('Instance verification failed: The product is not available for this instance')
+          expect(data['id']).to eq(product.id)
+          # expect(data['error']).to eq('A registration code is required to activate this product')
         end
       end
     end
@@ -352,7 +353,9 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
 
       it 'reports an error' do
         data = JSON.parse(response.body)
-        expect(data['error']).to eq('Unexpected instance verification error has occurred')
+        expect(data['error']).to eq(
+          "Instance verification failed: Can't find a subscription for base product #{base_product.product_string}"
+        )
       end
     end
   end


### PR DESCRIPTION
## Description

When registering a PAYG system with a registration code for an add-on product, if the product needs to be activated via SCC, do not raise the exception unless there is not token for the activation
* Related Issue / Ticket / Trello card: <link reference>

## How to test 

Register a system with the LTSS regcode (new LTSS code on the client), this exception should not raise

## Change Type

*Please select the correct option.*

- [X] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

