### PR TITLE
Raise an exception for unknown CSPs

### DIFF
--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -68,7 +68,13 @@ module SccProxy
         nil,
         params['instance_data']
       )
-      instance_id_key = INSTANCE_ID_KEYS[params['hwinfo']['cloud_provider'].downcase.to_sym]
+      id_key = params['hwinfo']['cloud_provider'].downcase.to_sym
+      unless INSTANCE_ID_KEYS.key?(id_key)
+        error_message = 'Unknown cloud provider'
+        Rails.logger.error error_message
+        raise ActionController::TranslatedError.new(error_message)
+      end
+      instance_id_key = INSTANCE_ID_KEYS[id_key]
       iid = verification_provider.parse_instance_data
       iid[instance_id_key]
     end

--- a/engines/scc_proxy/spec/requests/api/connect/v3/subscriptions/systems_controller_spec.rb
+++ b/engines/scc_proxy/spec/requests/api/connect/v3/subscriptions/systems_controller_spec.rb
@@ -27,7 +27,7 @@ describe Api::Connect::V3::Subscriptions::SystemsController, type: :request do
               hypervisor: 'Xen',
               arch: 'x86_64',
               uuid: 'ec235f7d-b435-e27d-86c6-c8fef3180a01',
-              cloud_provider: 'super_cloud'
+              cloud_provider: 'amazon'
             }
         }
       end
@@ -110,7 +110,7 @@ describe Api::Connect::V3::Subscriptions::SystemsController, type: :request do
               hypervisor: 'Xen',
               arch: 'x86_64',
               uuid: 'ec235f7d-b435-e27d-86c6-c8fef3180a01',
-              cloud_provider: 'super_cloud'
+              cloud_provider: 'amazon'
             }
         }
       end
@@ -148,6 +148,34 @@ describe Api::Connect::V3::Subscriptions::SystemsController, type: :request do
           expect(response.code).to eq('401')
           expect(data['type']).to eq('error')
           expect(data['error']).to include('Unauthorized')
+        end
+      end
+
+      context 'unknown cloud provider' do
+        let(:params) do
+          {
+            hostname: 'test',
+            proxy_byos_mode: :payg,
+            instance_data: instance_data,
+            hwinfo:
+            {
+              hostname: 'test',
+              cpus: '1',
+              sockets: '1',
+              hypervisor: 'Xen',
+              arch: 'x86_64',
+              uuid: 'ec235f7d-b435-e27d-86c6-c8fef3180a01',
+              cloud_provider: 'super_cloud'
+            }
+          }
+        end
+
+        it 'returns error' do
+          post '/connect/subscriptions/systems', params: params, headers: { HTTP_AUTHORIZATION: 'Token token=bar' }
+          data = JSON.parse(response.body)
+          expect(response.code).to eq('422')
+          expect(data['type']).to eq('error')
+          expect(data['error']).to include('Unknown cloud provider')
         end
       end
 


### PR DESCRIPTION
## Description

Instead of saving `nil` or empty value on the DB for `system_token` field, raise an exception if the CSP value from the metadata is unknown

## How to test 

Create a system with an unknown CSP, request should fail

## Change Type

*Please select the correct option.*

- [ ] **Bug Fix** (a non-breaking change which fixes an issue)
- [X] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

