### PR TITLE
Handle the empty credentials from the container runtime tools on the client

### DIFF
--- a/engines/registry/app/controllers/registry/registry_controller.rb
+++ b/engines/registry/app/controllers/registry/registry_controller.rb
@@ -21,9 +21,7 @@ module Registry
     # Returns a Distribution Registry HTTP API V2 - compatible repository catalog as defined in
     # https://distribution.github.io/distribution/spec/api/#listing-repositories
     def catalog
-      unless @client && @client.account
-        raise RegistryAuthError, 'Could not find system with current credentials'
-      end
+      raise RegistryAuthError, 'Could not find system with current credentials' unless @client && @client.account
 
       access_scope = AccessScope.parse('registry:catalog:*')
       repos = access_scope.allowed_paths(System.find_by(login: @client&.account))

--- a/engines/registry/app/models/registry/authenticated_client.rb
+++ b/engines/registry/app/models/registry/authenticated_client.rb
@@ -4,20 +4,16 @@ class Registry::AuthenticatedClient
   def initialize(login, password, remote_ip)
     raise Registry::Exceptions::InvalidCredentials.new(message: 'expired credentials', login: login) unless cache_file_exist?(remote_ip, login)
 
-    if authenticate_by_system_credentials(login, password)
-      Rails.logger.info("Authenticated '#{self}'")
-    else
-      raise Registry::Exceptions::InvalidCredentials.new(login: login)
-    end
+    raise Registry::Exceptions::InvalidCredentials.new(login: login) unless authenticate_by_system_credentials(login, password)
+
+    Rails.logger.info("Authenticated '#{self}'")
   end
 
   private
 
   def authenticate_by_system_credentials(login, password)
     @systems = System.get_by_credentials(login, password)
-    if @systems.present?
-      @account = login
-    end
+    @account = login if @systems.present?
   end
 
   def cache_file_exist?(remote_ip, login)

--- a/engines/registry/app/models/registry/authenticated_client.rb
+++ b/engines/registry/app/models/registry/authenticated_client.rb
@@ -22,7 +22,6 @@ class Registry::AuthenticatedClient
       @account = login
       @auth_strategy = :system_credentials
     end
-    @auth_strategy
   end
 
   def cache_file_exist?(remote_ip, login)

--- a/engines/registry/app/models/registry/authenticated_client.rb
+++ b/engines/registry/app/models/registry/authenticated_client.rb
@@ -1,13 +1,10 @@
 class Registry::AuthenticatedClient
   include RegistryClient
 
-  attr_reader :auth_strategy
-
   def initialize(login, password, remote_ip)
     raise Registry::Exceptions::InvalidCredentials.new(message: 'expired credentials', login: login) unless cache_file_exist?(remote_ip, login)
 
-    authenticate_by_system_credentials(login, password)
-    if @auth_strategy
+    if authenticate_by_system_credentials(login, password)
       Rails.logger.info("Authenticated '#{self}'")
     else
       raise Registry::Exceptions::InvalidCredentials.new(login: login)
@@ -20,7 +17,6 @@ class Registry::AuthenticatedClient
     @systems = System.get_by_credentials(login, password)
     if @systems.present?
       @account = login
-      @auth_strategy = :system_credentials
     end
   end
 

--- a/engines/registry/spec/app/controllers/registry_controller_spec.rb
+++ b/engines/registry/spec/app/controllers/registry_controller_spec.rb
@@ -112,7 +112,7 @@ module Registry
 
         context 'when an error happens' do
           it 'denies the access' do
-            allow_any_instance_of(AccessScope).to receive(:allowed_paths).and_raise(StandardError, 'Foo')
+            allow_any_instance_of(AccessScope).to receive(:allowed_paths).and_raise(RegistryAuthError, 'Foo')
             allow(File).to receive(:read).and_return(access_policy_content)
             allow_any_instance_of(AuthenticatedClient).to receive(:cache_file_exist?).and_return(true)
             get(

--- a/engines/registry/spec/app/controllers/registry_controller_spec.rb
+++ b/engines/registry/spec/app/controllers/registry_controller_spec.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics/ModuleLength
 module Registry
   describe RegistryController, type: :request do
     describe '#authenticate' do
@@ -65,11 +66,11 @@ module Registry
         before do
           stub_request(:get, "https://registry-example.susecloud.net/api/registry/authorize?account=#{system.login}&scope=registry:catalog:*&service=SUSE%20Linux%20OCI%20Registry")
             .with(
-            headers: {
-              'Accept' => '*/*',
-              'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-              'User-Agent' => 'Ruby'
-            }
+              headers: {
+                'Accept' => '*/*',
+                'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                'User-Agent' => 'Ruby'
+              }
             ).to_return(status: 200, body: JSON.dump({ foo: 'foo' }), headers: {})
 
           stub_request(:get, "#{RegistryCatalogService.new.catalog_api_url}?n=1000")
@@ -187,3 +188,4 @@ module Registry
     end
   end
 end
+# rubocop:enable Metrics/ModuleLength

--- a/engines/registry/spec/app/models/registry/authenticated_client_spec.rb
+++ b/engines/registry/spec/app/models/registry/authenticated_client_spec.rb
@@ -24,7 +24,7 @@ describe Registry::AuthenticatedClient do
 
           it 'returns the auth strategy' do
             expect(client.systems).to eq([system])
-            expect(client.auth_strategy).to eq(:system_credentials)
+            expect(client.account).to eq(system.login)
           end
         end
 

--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -1,4 +1,17 @@
 -------------------------------------------------------------------
+Wed Aug 21 15:27:24 UTC 2024 - Jesús Bermúdez Velázquez <jesus.bv@suse.com>
+
+- Version 2.19
+- rmt-server-pubcloud:
+  - Handle empty credentials sent from container runtime tools
+  - De-registration of hybrid systems
+  - De-activation of a hybrid system non free extension
+  - Update SccProxy engine to support LTSS
+  - Check access for repository or registy for LTSS
+    verify instance method and registry engine update to support that
+  - Add support for non free extensions
+
+-------------------------------------------------------------------
 Mon Jul  8 09:59:59 UTC 2024 - Thomas Schmidt <tschmidt@suse.com>
 
 - Include new script to fix yum-utils issue (jsc#SLL-369)


### PR DESCRIPTION
## Description

When container runtime tools on the client do not send the proper credentials or an exception happens during the catalog search, handle the exception

## How to test 

Put wrong credentials on `/etc/containers/config.json` 
and run `podman search foo` and autentication required message is shown

```bash
ec2-user@ip-172-31-21-235:~> sudo /usr/bin/cloudguestregistryauth 
Credentials refreshed
ec2-user@ip-172-31-21-235:~> podman search foo
ERRO[0000] error getting search results from v2 endpoint "registry-ec2.susecloud.net": authentication required 
Error: 1 error occurred:
	* couldn't search registry "registry-ec2.susecloud.net": authentication required


ec2-user@ip-172-31-21-235:~> 
```

## Change Type

*Please select the correct option.*

- [ ] **Bug Fix** (a non-breaking change which fixes an issue)
- [X] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

