### PR TITLE
Harden our shellout commands to work with paths that contain special characters

### DIFF
--- a/lib/rmt/gpg.rb
+++ b/lib/rmt/gpg.rb
@@ -1,6 +1,7 @@
 require 'English'
 require 'fileutils'
 require 'tmpdir'
+require 'shellwords'
 
 class RMT::GPG
   class RMT::GPG::Exception < RuntimeError
@@ -28,7 +29,8 @@ class RMT::GPG
   protected
 
   def run_import_key
-    cmd = "gpg --homedir #{@tmpdir} --no-default-keyring --keyring #{@keyring} --import #{@key_file} 2>&1"
+    cmd = "gpg --homedir #{@tmpdir.shellescape} --no-default-keyring " \
+      "--keyring #{@keyring.shellescape} --import #{@key_file.shellescape} 2>&1"
     out = `#{cmd}`
 
     if $CHILD_STATUS.exitstatus != 0
@@ -39,7 +41,8 @@ class RMT::GPG
   end
 
   def run_verify_signature
-    cmd = "gpg --homedir #{@tmpdir} --no-default-keyring --keyring #{@keyring} --verify #{@signature_file} #{@metadata_file} 2>&1"
+    cmd = "gpg --homedir #{@tmpdir.shellescape} --no-default-keyring " \
+      "--keyring #{@keyring.shellescape} --verify #{@signature_file.shellescape} #{@metadata_file.shellescape} 2>&1"
     out = `#{cmd}`
 
     if $CHILD_STATUS.exitstatus != 0

--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -1,3 +1,7 @@
+Unreleased:
+
+- Fix for mirroring products that contain special characters (eg.: '$') in their path
+
 -------------------------------------------------------------------
 Wed Aug 21 15:28:43 UTC 2024 - Jesús Bermúdez Velázquez <jesus.bv@suse.com>
 

--- a/spec/lib/rmt/gpg_spec.rb
+++ b/spec/lib/rmt/gpg_spec.rb
@@ -23,6 +23,14 @@ describe RMT::GPG do
       end
     end
 
+    context 'when the path contains characters that need to get escaped' do
+      it 'returns true' do
+        allow(Dir).to receive(:mktmpdir).with('rmt-mirror-gpg')
+          .and_return(Dir.mktmpdir('rmt-mirr$r-gpg'))
+        expect(verifier.verify_signature).to eq(true)
+      end
+    end
+
     context 'when the GPG key is invalid' do
       let(:key_file) { File.join(file_fixture('gpg'), 'bad.xml.key') }
 


### PR DESCRIPTION
Harden our shellout commands to work with paths that contain special characters. This fixes a regression that came up with 2.18, after moving the temp. download location into the repository directory. We have some repositories that contain '$' in their path (eg.: '/repo/$RCE/RES7-SUSE-Manager-Tools/x86_64/')

Those get correctly escaped now.

How to reproduce: 

```
bin/rmt-cli products enable res-manager-client/7/x86_64
bin/rmt-cli mirror product res-manager-client/7/x86_64
```