### PR TITLE
Update system from hybrid to payg if no more non free products active

### DIFF
--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -405,8 +405,8 @@ module SccProxy
               # it is OK to remove it from SCC
               response = SccProxy.deactivate_product_scc(auth, @product, @system.system_token)
               handle_response(response)
-              # if the system does not have more non free products activated on SCC
-              # system should turn to hybrid
+              # if the system does not have more products activated on SCC
+              # switch it back to payg
               @system.payg! if no_more_activations scc_systems_activations
             elsif result[:message].downcase.include?('unexpected error')
               raise ActionController::TranslatedError.new(result[:message])

--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -414,7 +414,7 @@ module SccProxy
               # switch it back to payg
               # drop the just de-activated activation from the list to avoid another call to SCC
               # and check if there is any product
-              @system.payg! if @scc_systems_activations.reject! { |act| act['service']['product']['id'] == @product.id }.blank?
+              @system.payg! if @scc_systems_activations.reject { |act| act['service']['product']['id'] == @product.id }.blank?
             elsif result[:message].downcase.include?('unexpected error')
               raise ActionController::TranslatedError.new(result[:message])
             end

--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -408,7 +408,7 @@ module SccProxy
               # if product is found on SCC, regardless of the state
               # it is OK to remove it from SCC
               SccProxy.deactivate_product_scc(auth, @product, @system.system_token, logger)
-              handle_system_mode(auth) if scc_systems_activations.reject { |act| act['service']['product']['id'] == @product.id }.blank?
+              make_system_payg(auth) if scc_systems_activations.reject { |act| act['service']['product']['id'] == @product.id }.blank?
             end
           end
           logger.info "Product '#{@product.friendly_name}' successfully deactivated from SCC"
@@ -423,7 +423,7 @@ module SccProxy
           JSON.parse(response.body)
         end
 
-        def handle_system_mode(auth)
+        def make_system_payg(auth)
           # if the system does not have more products activated on SCC
           # switch it back to payg
           # drop the just de-activated activation from the list to avoid another call to SCC

--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -389,6 +389,7 @@ module SccProxy
 
         protected
 
+        # rubocop:disable Metrics/PerceivedComplexity
         def scc_deactivate_product
           auth = request.headers['HTTP_AUTHORIZATION']
           if @system.byos? && @product[:product_type] != 'base'
@@ -416,6 +417,7 @@ module SccProxy
           end
           logger.info "Product '#{@product.friendly_name}' successfully deactivated from SCC"
         end
+        # rubocop:enable Metrics/PerceivedComplexity
 
         def find_hybrid_product_on_scc(headers)
           response = SccProxy.get_scc_activations(headers, @system.system_token, @system.proxy_byos_mode)

--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -407,7 +407,7 @@ module SccProxy
               handle_response(response)
               # if the system does not have more products activated on SCC
               # switch it back to payg
-              @system.payg! if no_more_activations scc_systems_activations
+              @system.payg! unless system_has_paid_extension? scc_systems_activations
             elsif result[:message].downcase.include?('unexpected error')
               raise ActionController::TranslatedError.new(result[:message])
             end
@@ -433,13 +433,13 @@ module SccProxy
           end
         end
 
-        def no_more_activations(scc_systems_activations)
+        def system_has_paid_extension?(scc_systems_activations)
           active_products_classes = scc_systems_activations.map do |act|
             if act['status'].casecmp('active').zero? && act['service']['product']['product_class'] != @product.product_class
               act['service']['product']['product_class']
             end
           end.flatten.compact
-          active_products_classes.empty?
+          active_products_classes.present?
         end
       end
 

--- a/engines/scc_proxy/spec/requests/api/connect/v4/systems/products_controller_spec.rb
+++ b/engines/scc_proxy/spec/requests/api/connect/v4/systems/products_controller_spec.rb
@@ -187,7 +187,7 @@ product_type: 'module')
           end
         end
 
-        context 'when SCC API suceeds for HYBRiD system' do
+        context 'when SCC API suceeds for HYBRID system' do
           let(:product) do
             FactoryBot.create(:product, :product_sles, :extension, :with_mirrored_repositories, :with_mirrored_extensions, :activated, system: system_hybrid)
           end
@@ -204,8 +204,8 @@ product_type: 'module')
               base_url: URI::HTTP.build({ scheme: response.request.scheme, host: response.request.host }).to_s
               ).to_json
           end
-
           let(:scc_systems_activations_url) { 'https://scc.suse.com/connect/systems/activations' }
+          let(:scc_systems_url) { 'https://scc.suse.com/connect/systems' }
 
           before do
             stub_request(:delete, scc_systems_products_url)
@@ -215,7 +215,6 @@ product_type: 'module')
                 headers: {}
               )
             stub_request(:get, scc_systems_activations_url).to_return(status: 200, body: body_active, headers: {})
-            delete url, params: payload, headers: headers
           end
 
           context 'when only one product was active' do
@@ -239,9 +238,38 @@ product_type: 'module')
               }].to_json
             end
 
-            it 'makes the hybrid system payg' do
-              updated_system = System.find_by(login: system_hybrid.login)
-              expect(updated_system.payg?).to eq(true)
+            context 'when deactivating the system succeeds' do
+              before do
+                stub_request(:delete, scc_systems_url).to_return(status: 204, body: '', headers: {})
+                delete url, params: payload, headers: headers
+              end
+
+              it 'makes the hybrid system payg' do
+                updated_system = System.find_by(login: system_hybrid.login)
+                expect(updated_system.payg?).to eq(true)
+              end
+            end
+
+            context 'when deactivating the system fails' do
+              before do
+                allow(Rails.logger).to receive(:info)
+                stub_request(:delete, scc_systems_url).to_return(
+                  status: 422,
+                  body: '{"error": "Oh oh, something went wrong"}',
+                  headers: {}
+                )
+                delete url, params: payload, headers: headers
+              end
+
+              it 'makes the hybrid system payg' do
+                expect(Rails.logger).to(
+                  have_received(:info).with(
+                    "Could not de-activate system #{system_hybrid.login}, error: Oh oh, something went wrong 422"
+                    ).once
+                  )
+                data = JSON.parse(response.body)
+                expect(data['error']).to eq('Oh oh, something went wrong')
+              end
             end
           end
 
@@ -284,224 +312,15 @@ product_type: 'module')
               ].to_json
             end
 
+            before do
+              stub_request(:delete, scc_systems_url).to_return(status: 204, body: '', headers: {})
+              delete url, params: payload, headers: headers
+            end
+
             it 'keeps the system as hybrid' do
               updated_system = System.find_by(login: system_hybrid.login)
               expect(updated_system.hybrid?).to eq(true)
             end
-          end
-        end
-
-        context 'when SCC API returns an error' do
-          let(:product) do
-            FactoryBot.create(:product, :product_sles, :extension, :with_mirrored_repositories, :with_mirrored_extensions, :activated, system: system_hybrid)
-          end
-          let(:payload) do
-            {
-              identifier: product.identifier,
-              version: product.version,
-              arch: product.arch
-            }
-          end
-          let(:serialized_service_json) do
-            V3::ServiceSerializer.new(
-              product.service,
-              base_url: URI::HTTP.build({ scheme: response.request.scheme, host: response.request.host }).to_s
-              ).to_json
-          end
-          let(:body_active) do
-            {
-              id: 1,
-              regcode: '631dc51f',
-              name: 'Subscription 1',
-              type: 'FULL',
-              status: 'ACTIVE',
-              starts_at: 'null',
-              expires_at: DateTime.parse((Time.zone.today + 1).to_s),
-              system_limit: 6,
-              systems_count: 1,
-              service: {
-                product: {
-                  id: system_hybrid.activations.first.product.id,
-                  product_class: system_hybrid.activations.first.product.product_class
-                }
-              }
-            }
-          end
-          let(:scc_systems_activations_url) { 'https://scc.suse.com/connect/systems/activations' }
-
-          before do
-            stub_request(:delete, scc_systems_products_url)
-              .to_return(
-                status: 422,
-                body: "{\"error\": \"Could not de-activate product \'#{product.friendly_name}\'\"}",
-                headers: {}
-              )
-            stub_request(:get, scc_systems_activations_url).to_return(status: 200, body: [body_active].to_json, headers: {})
-            delete url, params: payload, headers: headers
-          end
-
-          it 'reports an error' do
-            data = JSON.parse(response.body)
-            expect(data['error']).to eq('Could not de-activate product \'SUSE Linux Enterprise Server 15 SP3 x86_64\'')
-          end
-        end
-
-        context 'when product is expired' do
-          let(:product) do
-            FactoryBot.create(:product, :product_sles, :extension, :with_mirrored_repositories, :with_mirrored_extensions, :activated, system: system_hybrid)
-          end
-          let(:payload) do
-            {
-              identifier: product.identifier,
-              version: product.version,
-              arch: product.arch
-            }
-          end
-          let(:serialized_service_json) do
-            V3::ServiceSerializer.new(
-              product.service,
-              base_url: URI::HTTP.build({ scheme: response.request.scheme, host: response.request.host }).to_s
-              ).to_json
-          end
-          let(:body_expired) do
-            {
-              id: 1,
-              regcode: '631dc51f',
-              name: 'Subscription 1',
-              type: 'FULL',
-              status: 'EXPIRED',
-              starts_at: 'null',
-              expires_at: DateTime.parse((Time.zone.today - 1).to_s),
-              system_limit: 6,
-              systems_count: 1,
-              service: {
-                product: {
-                  id: system_hybrid.activations.first.product.id,
-                  product_class: system_hybrid.activations.first.product.product_class
-                }
-              }
-            }
-          end
-          let(:scc_systems_activations_url) { 'https://scc.suse.com/connect/systems/activations' }
-
-          before do
-            stub_request(:delete, scc_systems_products_url)
-              .to_return(
-                status: 422,
-                body: "{\"error\": \"Could not de-activate product \'#{product.friendly_name}\'\"}",
-                headers: {}
-              )
-            stub_request(:get, scc_systems_activations_url).to_return(status: 200, body: [body_expired].to_json, headers: {})
-            delete url, params: payload, headers: headers
-          end
-
-          it 'reports an error' do
-            data = JSON.parse(response.body)
-            expect(data['error']).to eq('Could not de-activate product \'SUSE Linux Enterprise Server 15 SP3 x86_64\'')
-          end
-        end
-
-        context 'when product is not active' do
-          let(:product) do
-            FactoryBot.create(:product, :product_sles, :extension, :with_mirrored_repositories, :with_mirrored_extensions, :activated, system: system_hybrid)
-          end
-          let(:payload) do
-            {
-              identifier: product.identifier,
-              version: product.version,
-              arch: product.arch
-            }
-          end
-          let(:serialized_service_json) do
-            V3::ServiceSerializer.new(
-              product.service,
-              base_url: URI::HTTP.build({ scheme: response.request.scheme, host: response.request.host }).to_s
-              ).to_json
-          end
-          let(:body_not_activated) do
-            {
-              id: 1,
-              regcode: '631dc51f',
-              name: 'Subscription 1',
-              type: 'FULL',
-              status: 'ACTIVE',
-              starts_at: 'null',
-              expires_at: DateTime.parse((Time.zone.today - 1).to_s),
-              system_limit: 6,
-              systems_count: 1,
-              service: {
-                product: {
-                  id: 1,
-                  product_class: product.product_class + 'FOO'
-                }
-              }
-            }
-          end
-          let(:scc_systems_activations_url) { 'https://scc.suse.com/connect/systems/activations' }
-
-          before do
-            stub_request(:get, scc_systems_activations_url).to_return(status: 200, body: [body_not_activated].to_json, headers: {})
-            delete url, params: payload, headers: headers
-          end
-
-          it 'reports an error' do
-            data = JSON.parse(response.body)
-            expect(data['error']).to eq(nil)
-          end
-        end
-
-        context 'when product has unknown status' do
-          let(:product) do
-            FactoryBot.create(:product, :product_sles, :extension, :with_mirrored_repositories, :with_mirrored_extensions, :activated, system: system_hybrid)
-          end
-          let(:payload) do
-            {
-              identifier: product.identifier,
-              version: product.version,
-              arch: product.arch
-            }
-          end
-          let(:serialized_service_json) do
-            V3::ServiceSerializer.new(
-              product.service,
-              base_url: URI::HTTP.build({ scheme: response.request.scheme, host: response.request.host }).to_s
-              ).to_json
-          end
-          let(:body_unknown_status) do
-            {
-              id: 1,
-              regcode: '631dc51f',
-              name: 'Subscription 1',
-              type: 'FULL',
-              status: 'FOO',
-              starts_at: 'null',
-              expires_at: DateTime.parse((Time.zone.today - 1).to_s),
-              system_limit: 6,
-              systems_count: 1,
-              service: {
-                product: {
-                  id: system_hybrid.activations.first.product.id,
-                  product_class: system_hybrid.activations.first.product.product_class + 'FOO'
-                }
-              }
-            }
-          end
-          let(:scc_systems_activations_url) { 'https://scc.suse.com/connect/systems/activations' }
-
-          before do
-            stub_request(:delete, scc_systems_products_url)
-              .to_return(
-                status: 422,
-                body: "{\"error\": \"Could not de-activate product \'#{product.friendly_name}\'\"}",
-                headers: {}
-              )
-            stub_request(:get, scc_systems_activations_url).to_return(status: 200, body: [body_unknown_status].to_json, headers: {})
-            delete url, params: payload, headers: headers
-          end
-
-          it 'reports an error' do
-            data = JSON.parse(response.body)
-            expect(data['error']).to eq('Unexpected error when checking product subscription.')
           end
         end
       end


### PR DESCRIPTION
## Description

When deactivating a product on a hybrid system, if there are no more non free product active for that system on SCC, that system is no longer hybrid but payg and should get updated on the db

## How to test 

- start a SLES 15.4 PAYG instance
- activate LTSS (`registercloudguest -r FOO`)
- check is active `SUSEConnect -l` and see LTSS being active
- remove LTSS (`SUSEConnect -d -p LTSS`)
- the system must be `payg` / 1 in the db, in the RMT server, access the db, and run
```SQL 
select proxy_byos_mode from systems where login = 'SCC_that_system_login'
```
The value for that field should be 1

## Change Type

*Please select the correct option.*

- [ ] **Bug Fix** (a non-breaking change which fixes an issue)
- [X] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

