### PR TITLE
Use the right header for SCC activations

### DIFF
--- a/engines/registry/app/models/access_scope.rb
+++ b/engines/registry/app/models/access_scope.rb
@@ -90,7 +90,7 @@ class AccessScope
       allowed_non_free_product_classes = allowed_product_classes.map { |s| s unless Product.find_by(product_class: s).free? }
       unless allowed_non_free_product_classes.empty?
         auth_header = {
-          Authorization: ActionController::HttpAuthentication::Basic.encode_credentials(system.login, system.password)
+          'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Basic.encode_credentials(system.login, system.password)
         }
         allowed_non_free_product_classes.each do |non_free_prod_class|
           activation_state = SccProxy.scc_check_subscription_expiration(

--- a/engines/registry/spec/app/models/access_scope_spec.rb
+++ b/engines/registry/spec/app/models/access_scope_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe AccessScope, type: :model do
             }
           end
           let(:header_expected) do
-            { Authorization: ActionController::HttpAuthentication::Basic.encode_credentials(system.login, system.password) }
+            { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Basic.encode_credentials(system.login, system.password) }
           end
 
           before do


### PR DESCRIPTION
## Description

When that header is missing, `podman search foo` would raise unauth exception
if the search uses a valid product like `podman search ltss` should return some paths but it returns nothing

Fails silently

## Change Type

*Please select the correct option.*

- [X] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

