### PR TITLE
Propagate the upgrate call to SCC

### DIFF
--- a/engines/instance_verification/spec/requests/api/connect/v3/systems/products_controller_spec.rb
+++ b/engines/instance_verification/spec/requests/api/connect/v3/systems/products_controller_spec.rb
@@ -580,7 +580,7 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
           # pp headers
           stub_request(:put, scc_systems_products_url)
             .with({ headers: scc_headers, body: payload.merge({ byos_mode: 'byos' }) })
-            .and_return(status: 200, body: '', headers: {})
+            .and_return(status: 201, body: '', headers: {})
           request
         end
 

--- a/engines/instance_verification/spec/requests/api/connect/v3/systems/products_controller_spec.rb
+++ b/engines/instance_verification/spec/requests/api/connect/v3/systems/products_controller_spec.rb
@@ -551,65 +551,176 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
   describe '#upgrade' do
     subject { response }
 
-    let(:system) { FactoryBot.create(:system) }
+    let(:instance_data) { 'dummy_instance_data' }
     let(:request) { put url, headers: headers, params: payload }
-    let!(:old_product) { FactoryBot.create(:product, :with_mirrored_repositories, :activated, system: system) }
-    let(:payload) do
-      {
-        identifier: new_product.identifier,
-        version: new_product.version,
-        arch: new_product.arch
-      }
+
+    context 'when system is byos' do
+      let(:system) { FactoryBot.create(:system, :byos, :with_system_information, instance_data: instance_data) }
+      let!(:old_product) { FactoryBot.create(:product, :with_mirrored_repositories, :activated, system: system) }
+      let(:payload) do
+        {
+          identifier: new_product.identifier,
+          version: new_product.version,
+          arch: new_product.arch
+        }
+      end
+      let(:scc_systems_products_url) { 'https://scc.suse.com/connect/systems/products' }
+      let(:scc_headers) do
+        {
+          'Accept' => 'application/json,application/vnd.scc.suse.com.v4+json',
+          'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'Authorization' => headers['HTTP_AUTHORIZATION'],
+          'Content-Type' => 'application/json',
+          'User-Agent' => 'Ruby'
+        }
+      end
+
+      context 'when SCC upgrade success' do
+        before do
+          # pp headers
+          stub_request(:put, scc_systems_products_url)
+            .with({ headers: scc_headers, body: payload.merge({ byos_mode: 'byos' }) })
+            .and_return(status: 200, body: '', headers: {})
+          request
+        end
+
+        context "when migration target base product doesn't have an activated successor/predecessor" do
+          let(:new_product) { FactoryBot.create(:product, :with_mirrored_repositories) }
+
+          it 'HTTP response code is 422' do
+            expect(response).to have_http_status(422)
+          end
+
+          it 'renders an error' do
+            data = JSON.parse(response.body)
+            expect(data['error']).to eq('Migration target not allowed on this instance type')
+          end
+        end
+
+        context 'when migration target base product has the same identifier' do
+          let(:new_product) do
+            FactoryBot.create(
+              :product, :with_mirrored_repositories, identifier: old_product.identifier,
+              version: '999', predecessors: [ old_product ]
+              )
+          end
+
+          it 'HTTP response code is 201' do
+            expect(response).to have_http_status(201)
+          end
+
+          it "doesn't render an error" do
+            data = JSON.parse(response.body)
+            expect(data).not_to have_key('error')
+          end
+        end
+      end
+
+      context 'when SCC upgrade fails' do
+        before do
+          stub_request(:put, scc_systems_products_url)
+            .with({ headers: scc_headers, body: payload.merge({ byos_mode: 'byos' }) })
+            .and_return(
+              status: 401,
+              body: { error: 'error_message' }.to_json,
+              headers: {}
+            )
+          request
+        end
+
+        context "when migration target base product doesn't have an activated successor/predecessor" do
+          let(:new_product) { FactoryBot.create(:product, :with_mirrored_repositories) }
+
+          it 'HTTP response code is 422' do
+            expect(response).to have_http_status(422)
+          end
+
+          it 'renders an error' do
+            data = JSON.parse(response.body)
+            expect(data['error']).to eq('Migration target not allowed on this instance type')
+          end
+        end
+
+        context 'when migration target base product has the same identifier' do
+          let(:new_product) do
+            FactoryBot.create(
+              :product, :with_mirrored_repositories, identifier: old_product.identifier,
+              version: '999', predecessors: [ old_product ]
+              )
+          end
+
+          it 'HTTP response code is 422' do
+            expect(response).to have_http_status(422)
+          end
+
+          it 'renders an error' do
+            data = JSON.parse(response.body)
+            expect(data).to have_key('error')
+          end
+        end
+      end
     end
 
-    before { request }
-
-    context "when migration target base product doesn't have an activated successor/predecessor" do
-      let(:new_product) { FactoryBot.create(:product, :with_mirrored_repositories) }
-
-      it 'HTTP response code is 422' do
-        expect(response).to have_http_status(422)
+    context 'when system is payg' do
+      let(:system) { FactoryBot.create(:system, :payg, :with_system_information, instance_data: instance_data) }
+      let!(:old_product) { FactoryBot.create(:product, :with_mirrored_repositories, :activated, system: system) }
+      let(:payload) do
+        {
+          identifier: new_product.identifier,
+          version: new_product.version,
+          arch: new_product.arch
+        }
       end
 
-      it 'renders an error' do
-        data = JSON.parse(response.body)
-        expect(data['error']).to eq('Migration target not allowed on this instance type')
-      end
-    end
+      before { request }
 
-    context 'when migration target base product has a different identifier' do
-      let(:new_product) do
-        FactoryBot.create(
-          :product, :with_mirrored_repositories,
-          identifier: old_product.identifier + '-foo', predecessors: [ old_product ]
-        )
-      end
+      context "when migration target base product doesn't have an activated successor/predecessor" do
+        let(:new_product) { FactoryBot.create(:product, :with_mirrored_repositories) }
 
-      it 'HTTP response code is 422' do
-        expect(response).to have_http_status(422)
+        it 'HTTP response code is 422' do
+          expect(response).to have_http_status(422)
+        end
+
+        it 'renders an error' do
+          data = JSON.parse(response.body)
+          expect(data['error']).to eq('Migration target not allowed on this instance type')
+        end
       end
 
-      it 'renders an error' do
-        data = JSON.parse(response.body)
-        expect(data['error']).to eq('Migration target not allowed on this instance type')
-      end
-    end
+      context 'when migration target base product has a different identifier' do
+        let(:new_product) do
+          FactoryBot.create(
+            :product, :with_mirrored_repositories,
+            identifier: old_product.identifier + '-foo', predecessors: [ old_product ]
+            )
+        end
 
-    context 'when migration target base product has the same identifier' do
-      let(:new_product) do
-        FactoryBot.create(
-          :product, :with_mirrored_repositories, identifier: old_product.identifier,
-          version: '999', predecessors: [ old_product ]
-        )
+        it 'HTTP response code is 422' do
+          expect(response).to have_http_status(422)
+        end
+
+        it 'renders an error' do
+          data = JSON.parse(response.body)
+          expect(data['error']).to eq('Migration target not allowed on this instance type')
+        end
       end
 
-      it 'HTTP response code is 201' do
-        expect(response).to have_http_status(201)
-      end
+      context 'when migration target base product has the same identifier' do
+        let(:new_product) do
+          FactoryBot.create(
+            :product, :with_mirrored_repositories, identifier: old_product.identifier,
+            version: '999', predecessors: [ old_product ]
+            )
+        end
 
-      it "doesn't render an error" do
-        data = JSON.parse(response.body)
-        expect(data).not_to have_key('error')
+        it 'HTTP response code is 201' do
+          expect(response).to have_http_status(201)
+        end
+
+        it "doesn't render an error" do
+          data = JSON.parse(response.body)
+          expect(data).not_to have_key('error')
+        end
       end
     end
   end

--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -272,7 +272,7 @@ module SccProxy
       http.use_ssl = true
       scc_request = prepare_scc_update_request(uri.path, product, auth, mode)
       response = http.request(scc_request)
-      unless response.code_type == Net::HTTPOK
+      unless response.code_type == Net::HTTPCreated
         logger.info "Could not upgrade the system (#{system_login}), error: #{response.message} #{response.code}"
         response.message = SccProxy.parse_error(response.message) if response.message.include? 'json'
         raise ActionController::TranslatedError.new(response.body)

--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -117,7 +117,7 @@ module SccProxy
       scc_request
     end
 
-    def prepare_scc_update_request(uri_path, product, auth, mode)
+    def prepare_scc_upgrade_request(uri_path, product, auth, mode)
       scc_request = Net::HTTP::Put.new(uri_path, headers(auth, nil))
       scc_request.body = {
         identifier: product.identifier,
@@ -270,7 +270,7 @@ module SccProxy
       uri = URI.parse(SYSTEM_PRODUCTS_URL)
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true
-      scc_request = prepare_scc_update_request(uri.path, product, auth, mode)
+      scc_request = prepare_scc_upgrade_request(uri.path, product, auth, mode)
       response = http.request(scc_request)
       unless response.code_type == Net::HTTPCreated
         logger.info "Could not upgrade the system (#{system_login}), error: #{response.message} #{response.code}"
@@ -363,12 +363,6 @@ module SccProxy
               raise 'Incompatible extension product' unless @product.arch == base_prod.arch && @product.version == base_prod.version
 
               update_params_system_info mode
-              # params['hostname'] = @system.hostname
-              # params['proxy_byos_mode'] = mode
-              # params['scc_login'] = @system.login
-              # params['scc_password'] = @system.password
-              # params['hwinfo'] = JSON.parse(@system.system_information)
-              # params['instance_data'] = @system.instance_data
               announce_auth = "Token token=#{params[:token]}"
 
               response = SccProxy.announce_system_scc(announce_auth, params)


### PR DESCRIPTION
## Description

Proxy the zypper migration upgrade call to SCC when the system is BYOS
* Related Issue / Ticket / Trello card: <link reference>

## How to test 

- 15 SP3 BYOS instance
- register to RMT 2.19
- add LTSS
- update
- remove LTSS
- migrate to 15 SP4
- registercloudguest -r $LTSS_REGCODE

should work

## Change Type

*Please select the correct option.*

- [ ] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

