### PR TITLE
Set old proxy BYOS value until we drop that column

### DIFF
--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -312,6 +312,7 @@ module SccProxy
               password: response['password'],
               hostname: params[:hostname],
               proxy_byos_mode: :byos,
+              proxy_byos: true,
               system_information: system_information,
               instance_data: instance_data
             )


### PR DESCRIPTION
## Description

Set old proxy BYOS value until we drop that column

* Related Issue / Ticket / Trello card: <link reference>

## How to test 

Register a BYOS system, it should have `proxy_byos` to `true` in the db

## Change Type

*Please select the correct option.*

- [X] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

