### PR TITLE
Update the product serializer

### DIFF
--- a/app/serializers/v3/product_serializer.rb
+++ b/app/serializers/v3/product_serializer.rb
@@ -33,8 +33,11 @@ class V3::ProductSerializer < ApplicationSerializer
   end
 
   def free
-    # Everything is free on RMT :-)
+    # Everything is free on RMT :-) outside of the Public Cloud (i.e. LTSS)
     # Otherwise Yast and SUSEConnect will request a regcode when activating an extension
+    # FIXME
+    return object.free if defined?(SccProxy::Engine) && object.extension?
+
     true
   end
 

--- a/engines/instance_verification/spec/requests/api/connect/v3/systems/products_controller_spec.rb
+++ b/engines/instance_verification/spec/requests/api/connect/v3/systems/products_controller_spec.rb
@@ -540,6 +540,7 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
           context 'when no regcode is provided' do
             it 'activates the product' do
               data = JSON.parse(response.body)
+              expect(data['product']['free']).to eq(false)
               expect(data['id']).to eq(product.id)
             end
           end


### PR DESCRIPTION
## Description

Before LTSS, the product serializer returned true for the free field of any product

That is no longer true in the Public Cloud scenario, where LTSS is not free

This Fixes that case

## How to test 

on a PAYG SLES 15.4 (or 15.3) activate LTSS, then on the client fetch all the extensions, LTSS should show up as not free
i.e.
```bash
ip-10-3-0-101:/home/ec2-user # fetch_extensions
[{'name': 'Basesystem Module', 'free': True}, {'name': 'SUSE Linux Enterprise Server LTSS', 'free': False}]
```

## Change Type

*Please select the correct option.*

- [X] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

