### PR TITLE
Check only extensions for SCC activations

### DIFF
--- a/engines/registry/app/models/access_scope.rb
+++ b/engines/registry/app/models/access_scope.rb
@@ -87,7 +87,7 @@ class AccessScope
     allowed_product_classes = (active_product_classes & access_policies_yml.keys)
     if system && system.hybrid?
       # if the system is hybrid => check if the non free product subscription is still valid for accessing images
-      allowed_non_free_product_classes = allowed_product_classes.map { |s| s unless Product.find_by(product_class: s).free? }
+      allowed_non_free_product_classes = allowed_product_classes.map { |s| s unless Product.find_by(product_class: s, product_type: 'extension').free? }.compact
       unless allowed_non_free_product_classes.empty?
         auth_header = {
           'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Basic.encode_credentials(system.login, system.password)

--- a/engines/registry/spec/app/models/access_scope_spec.rb
+++ b/engines/registry/spec/app/models/access_scope_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe AccessScope, type: :model do
           system
         end
         let(:product1) do
-          product = FactoryBot.create(:product, :with_mirrored_repositories)
+          product = FactoryBot.create(:product, :with_mirrored_repositories, :extension)
           product.repositories.where(enabled: false).update(mirroring_enabled: false)
           product.update(product_class: 'SLES15-SP4-LTSS-X86')
           product


### PR DESCRIPTION
## Description

When checking the registry access if system is hybrid, the check with SCC for the state of its activations should be done only with non free extensions, as base product is not free

This Fixes that scenario

## How to test 

on a PYG 15.4 system, register LTSS and run podman search
the result should include base product + LTSS

```bash
ip-10-3-0-101:/home/ec2-user # podman search registry-ec2.susecloud.net/
NAME                                                               DESCRIPTION
registry-ec2.susecloud.net/suse/hpc/warewulf4-x86_64/sle-hpc-node  
registry-ec2.susecloud.net/suse/ltss/sle15.4/bci-base              
registry-ec2.susecloud.net/suse/ltss/sle15.4/bci-base-fips         
registry-ec2.susecloud.net/suse/ltss/sle15.4/sle15                 
ip-10-3-0-101:/home/ec2-user # 
```
## Change Type

*Please select the correct option.*

- [X] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

