### PR TITLE
Make SccProxy method responsible for handling the SCC request response

### DIFF
--- a/engines/scc_proxy/spec/requests/api/connect/v3/systems/products_controller_spec.rb
+++ b/engines/scc_proxy/spec/requests/api/connect/v3/systems/products_controller_spec.rb
@@ -486,14 +486,13 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
                   )
                 stub_request(:post, scc_register_system_url)
                   .to_return(status: 201, body: { ok: 'OK' }.to_json, headers: {})
-
-                post url, params: payload, headers: headers
               end
 
               it 'renders an error with exception details' do
+                expect(Rails.logger).to receive(:info).with(error_message)
+                post url, params: payload, headers: headers
                 data = JSON.parse(response.body)
                 expect(data['error']).to eq('Could not de-register system')
-                expect(Rails.logger).to(have_received(:info).with(error_message)) # rubocop:disable RSpec/MessageSpies
               end
             end
           end

--- a/engines/scc_proxy/spec/requests/api/connect/v3/systems/products_controller_spec.rb
+++ b/engines/scc_proxy/spec/requests/api/connect/v3/systems/products_controller_spec.rb
@@ -474,7 +474,10 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
             end
 
             context 'when de-register system from SCC fails' do
+              let(:error_message) { "Could not activate #{product.product_string}, error: No product found on SCC for: foo bar x86_64 json api 401" }
+
               before do
+                allow(Rails.logger).to receive(:info)
                 stub_request(:delete, scc_systems_url)
                   .to_return(
                     status: 401,
@@ -490,6 +493,7 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
               it 'renders an error with exception details' do
                 data = JSON.parse(response.body)
                 expect(data['error']).to eq('Could not de-register system')
+                expect(Rails.logger).to(have_received(:info).with(error_message)) # rubocop:disable RSpec/MessageSpies
               end
             end
           end


### PR DESCRIPTION
## Description

When calling SccProxy scc_activate_product method, the response should be handled in that method as well

This helps reducing duplication and better responsibility separation

Also, new method to announce hybrid system to SCC

Update tests to reflect the changes

## How to test 

Activate a product from RMT to SCC , it should work as before

## Change Type

*Please select the correct option.*

- [ ] **Bug Fix** (a non-breaking change which fixes an issue)
- [X] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

