### PR TITLE
Allow SLE Micro system to access free SLES repositories

### DIFF
--- a/app/controllers/api/connect/v3/systems/products_controller.rb
+++ b/app/controllers/api/connect/v3/systems/products_controller.rb
@@ -12,7 +12,13 @@ class Api::Connect::V3::Systems::ProductsController < Api::Connect::BaseControll
   end
 
   def show
-    if @system.products.include? @product
+    if @product.identifier.casecmp('sles').zero?
+      # if system has SLE Micro
+      # it should access to SLES products
+      sle_micro = @system.products.any? { |p| p.identifier.downcase.include?('sle-micro') }
+      sle_micro_same_arch = @system.products.pluck(:arch).include?(@product.arch) if sle_micro
+    end
+    if @system.products.include?(@product) || sle_micro_same_arch
       respond_with(
         @product,
         serializer: ::V3::ProductSerializer,

--- a/engines/strict_authentication/app/controllers/strict_authentication/authentication_controller.rb
+++ b/engines/strict_authentication/app/controllers/strict_authentication/authentication_controller.rb
@@ -36,6 +36,20 @@ module StrictAuthentication
       # to them or verify paths
       all_product_versions = @system.products.map { |p| Product.where(identifier: p.identifier, arch: p.arch) }.flatten
       allowed_paths = all_product_versions.map { |prod| prod.repositories.pluck(:local_path) }.flatten
+      # Allow SLE Micro to access all free SLES repositories
+      sle_micro = @system.products.any? { |p| p.identifier.downcase.include?('sle-micro') }
+      if sle_micro
+        system_products_archs = @system.products.pluck(:arch)
+        product_free_sles_modules_only = Product.where(
+          "(lower(identifier) like 'sle-module%' or lower(identifier) like 'packagehub')
+           and lower(identifier) not like '%sap%'
+           and arch = '#{system_products_archs.first}'
+           and free = 1"
+          )
+      end
+      same_arch = product_free_sles_modules_only.any? { |p| system_products_archs.include?(p.arch) } if product_free_sles_modules_only.present?
+      allowed_paths += product_free_sles_modules_only.map { |prod| prod.repositories.pluck(:local_path) }.flatten if same_arch
+
       # for the SUMa PAYG offers, RMT access verification code allows access
       # to the SUMa Client Tools channels and SUMa Proxy channels
       # when product is SUMA_Server and PAYG or SUMA_Server and used as SCC proxy

--- a/engines/strict_authentication/spec/requests/strict_authentication/authentication_controller_spec.rb
+++ b/engines/strict_authentication/spec/requests/strict_authentication/authentication_controller_spec.rb
@@ -5,7 +5,7 @@ module StrictAuthentication
   RSpec.describe AuthenticationController, type: :request do
     subject { response }
 
-    let(:system) { FactoryBot.create(:system, :with_activated_product) }
+    let(:system) { FactoryBot.create(:system, :with_activated_product_sle_micro) }
 
     describe '#check' do
       context 'without authentication' do
@@ -35,6 +35,36 @@ module StrictAuthentication
 
           context 'when requested path is not activated' do
             let(:requested_uri) { '/repo/some/uri' }
+
+            its(:code) { is_expected.to eq '403' }
+          end
+
+          context 'when requesting a file in an activated SLES repo on a SLE Micro system' do
+            let(:free_product) do
+              prod = FactoryBot.create(
+                :product, :module, :with_mirrored_repositories
+                )
+              prod.identifier = 'sle-module-foo'
+              prod.arch = system.products.first.arch
+              prod.save!
+              prod
+            end
+            let(:requested_uri) { '/repo' + free_product.repositories.first[:local_path] + '/repodata/repomd.xml' }
+
+            its(:code) { is_expected.to eq '200' }
+          end
+
+          context 'when requesting a file in an activated SLES SAP repo on a SLE Micro system' do
+            let(:free_product) do
+              prod = FactoryBot.create(
+                :product, :module, :with_mirrored_repositories
+                )
+              prod.identifier = 'sle-module-foo-sap'
+              prod.arch = system.products.first.arch
+              prod.save!
+              prod
+            end
+            let(:requested_uri) { '/repo' + free_product.repositories.first[:local_path] + '/repodata/repomd.xml' }
 
             its(:code) { is_expected.to eq '403' }
           end

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -73,6 +73,22 @@ FactoryBot.define do
       friendly_version { '15 SP3' }
     end
 
+    trait :product_sle_micro do
+      identifier { 'SLE-Micro' }
+      name { 'SUSE Linux Enterprise Server' }
+      description { 'SUSE Linux Enterprise offers a comprehensive suite of products...' }
+      shortname { 'SLES15-SP6' }
+      former_identifier { 'SUSE_SLES_MICRO' }
+      product_type { :base }
+      release_type { nil }
+      release_stage { 'released' }
+      version { '15.6' }
+      arch { 'x86_64' }
+      free { false }
+      cpe { 'cpe:/o:suse:sles_sap:15:sp6' }
+      friendly_version { '15 SP6' }
+    end
+
     trait :extension do
       product_type { 'extension' }
     end

--- a/spec/factories/systems.rb
+++ b/spec/factories/systems.rb
@@ -57,6 +57,17 @@ FactoryBot.define do
       end
     end
 
+    trait :with_activated_product_sle_micro do
+      transient do
+        product { create(:product, :product_sle_micro, :with_mirrored_repositories) }
+        subscription { nil }
+      end
+
+      after :create do |system, evaluator|
+        create(:activation, system: system, service: evaluator.product.service, subscription: evaluator.subscription)
+      end
+    end
+
     trait :with_system_information do
       system_information do
         {

--- a/spec/requests/api/connect/v3/systems/products_controller_spec.rb
+++ b/spec/requests/api/connect/v3/systems/products_controller_spec.rb
@@ -246,6 +246,33 @@ RSpec.describe Api::Connect::V3::Systems::ProductsController do
       end
     end
 
+    context 'when SLE Micro product is activated' do
+      let(:system) { FactoryBot.create(:system, :with_activated_product_sle_micro) }
+      let(:product) { FactoryBot.create(:product, :product_sles, :with_mirrored_repositories) }
+      let(:payload) do
+        {
+          identifier: product.identifier,
+          version: product.version,
+          arch: system.products.first.arch
+        }
+      end
+      let(:serialized_json) do
+        V3::ProductSerializer.new(
+          product,
+          base_url: URI::HTTP.build({ scheme: response.request.scheme, host: response.request.host }).to_s
+        ).to_json
+      end
+
+      describe 'response' do
+        subject { response }
+
+        before { get url, headers: headers, params: payload }
+
+        its(:code) { is_expected.to eq('200') }
+        its(:body) { is_expected.to eq(serialized_json) }
+      end
+    end
+
     context 'with eula_url' do
       subject { response }
 


### PR DESCRIPTION
## Description

A SLE Micro system must have access to all free SLES repositories

This Fixes bsc#1230419

* Related Issue / Ticket / Trello card: https://bugzilla.suse.com/show_bug.cgi?id=1230419

## How to test 

On a SLE Micro PAYG instance, configured according to the documentation to use Podman,
running `zypper lr` inside the container should show `SLES` repositories

On a SUMA 5.0 instance, activating SUMA 4.3 should also activate the recommended SLES repositories 

## Change Type

*Please select the correct option.*

- [ ] **Bug Fix** (a non-breaking change which fixes an issue)
- [X] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

