### PR TITLE
Azure basic images do not get access to LTSS

### DIFF
--- a/engines/instance_verification/lib/instance_verification/providers/example.rb
+++ b/engines/instance_verification/lib/instance_verification/providers/example.rb
@@ -50,7 +50,9 @@ class InstanceVerification::Providers::Example < InstanceVerification::ProviderB
     return true if (identifier.casecmp('sles_sap').zero? && SLES4SAP_PRODUCT_IDENTIFIER.include?(instance_billing_info[:marketplace_code]))
   end
 
-  def basic?
-    false
+  def allowed_extension?
+    # method to check if a product (extension) meet the criteria
+    # to be acivated on SCC or not, i.e. LTSS in Azure Basic VM
+    true
   end
 end

--- a/engines/instance_verification/lib/instance_verification/providers/example.rb
+++ b/engines/instance_verification/lib/instance_verification/providers/example.rb
@@ -49,4 +49,8 @@ class InstanceVerification::Providers::Example < InstanceVerification::ProviderB
     return true if (identifier.casecmp('sles').zero? && instance_billing_info[:billing_product] == SLES_PRODUCT_IDENTIFIER)
     return true if (identifier.casecmp('sles_sap').zero? && SLES4SAP_PRODUCT_IDENTIFIER.include?(instance_billing_info[:marketplace_code]))
   end
+
+  def basic?
+    false
+  end
 end

--- a/engines/instance_verification/spec/requests/api/connect/v3/systems/products_controller_spec.rb
+++ b/engines/instance_verification/spec/requests/api/connect/v3/systems/products_controller_spec.rb
@@ -123,7 +123,7 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
 
       context 'when system has hw_info' do
         let(:instance_data) { 'dummy_instance_data' }
-        let(:system) { FactoryBot.create(:system, :payg, :with_system_information, instance_data: instance_data) }
+        let(:system) { FactoryBot.create(:system, :payg, :with_system_information_az, instance_data: instance_data) }
         let(:serialized_service_json) do
           V3::ServiceSerializer.new(
             product.service,
@@ -188,7 +188,7 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
         let(:instance_data) { 'dummy_instance_data' }
         let(:system) do
           FactoryBot.create(
-            :system, :payg, :with_system_information, :with_activated_product, product: base_product, instance_data: instance_data
+            :system, :payg, :with_system_information_az, :with_activated_product, product: base_product, instance_data: instance_data
           )
         end
         let(:serialized_service_json) do

--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -373,11 +373,8 @@ module SccProxy
         protected
 
         def scc_activate_product
-          if (@system.system_information &&
-              JSON.parse(@system.system_information)['cloud_provider'].casecmp('microsoft').zero? &&
-              @product.product_class.downcase.include?('ltss') &&
-              InstanceVerification.provider.new(logger, request, nil, @system.instance_data).basic?
-            )
+          product_hash = @product.attributes.symbolize_keys.slice(:identifier, :version, :arch)
+          unless InstanceVerification.provider.new(logger, request, product_hash, @system.instance_data).allowed_extension?
             error = ActionController::TranslatedError.new(N_('Product not supported for this instance'))
             error.status = :forbidden
             raise error

--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -372,6 +372,15 @@ module SccProxy
         protected
 
         def scc_activate_product
+          if (@system.system_information &&
+              JSON.parse(@system.system_information)['cloud_provider'].casecmp('microsoft').zero? &&
+              @product.product_class.downcase.include?('ltss') &&
+              InstanceVerification.provider.new(logger, request, nil, @system.instance_data).basic?
+            )
+            error = ActionController::TranslatedError.new(N_('Product not supported for this instance'))
+            error.status = :forbidden
+            raise error
+          end
           mode = find_mode
           unless mode.nil?
             # if system is byos or hybrid and there is a token

--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -307,6 +307,7 @@ module SccProxy
     end
   end
 
+  # rubocop:disable Metrics/ClassLength
   class Engine < ::Rails::Engine
     isolate_namespace SccProxy
     config.generators.api_only = true
@@ -549,5 +550,6 @@ module SccProxy
       end
     end
   end
+  # rubocop:enable Metrics/ClassLength
 end
 # rubocop:enable Metrics/ModuleLength

--- a/engines/scc_proxy/spec/requests/api/connect/v3/systems/products_controller_spec.rb
+++ b/engines/scc_proxy/spec/requests/api/connect/v3/systems/products_controller_spec.rb
@@ -349,12 +349,12 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
 
         context 'when system is connected to SCC' do
           let(:system_payg) do
-            FactoryBot.create(:system, :payg, :with_system_information, :with_activated_base_product, instance_data: instance_data,
+            FactoryBot.create(:system, :payg, :with_system_information_az, :with_activated_base_product, instance_data: instance_data,
               system_token: new_system_token)
           end
           let(:product) do
             FactoryBot.create(
-              :product, :product_sles, :extension, :with_mirrored_repositories, :with_mirrored_extensions,
+              :product, :product_sles_ltss, :extension, :with_mirrored_repositories, :with_mirrored_extensions,
               base_products: [system_payg.products.first]
               )
           end
@@ -415,7 +415,120 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
               allow(File).to receive(:directory?)
               allow(FileUtils).to receive(:mkdir_p)
               allow(FileUtils).to receive(:touch)
+              allow(InstanceVerification::Providers::Example).to receive(:new).and_return(plugin_double)
+              allow(plugin_double).to receive(:basic?).and_return(false)
+              allow(InstanceVerification).to receive(:write_cache_file).twice.with(
+                Rails.application.config.repo_cache_dir, "127.0.0.1-#{system_payg.login}-#{product.id}"
+              )
+              allow(InstanceVerification).to receive(:write_cache_file).twice.with(
+                Rails.application.config.registry_cache_dir, "127.0.0.1-#{system_payg.login}"
+                )
+              allow(plugin_double).to receive(:instance_valid?).and_return(true)
+            end
 
+            context 'when LTSS not allowed' do
+              before do
+                allow(plugin_double).to receive(:basic?).and_return(true)
+              end
+
+              it 'raises an error' do
+                stub_request(:post, scc_register_system_url)
+                  .to_return(status: 403, body: { ok: 'OK' }.to_json, headers: {})
+
+                post url, params: payload, headers: headers
+                data = JSON.parse(response.body)
+                expect(data['error']).to include('Product not supported for this instance')
+              end
+            end
+          end
+        end
+      end
+
+      context 'when system has hw_info' do
+        let(:instance_data) { '<document>{"instanceId": "dummy_instance_data"}</document>' }
+        let(:new_system_token) { 'BBBBBBBB-BBBB-4BBB-9BBB-BBBBBBBBBBBB' }
+        let(:serialized_service_json) do
+          V3::ServiceSerializer.new(
+            product.service,
+            base_url: URI::HTTP.build({ scheme: response.request.scheme, host: response.request.host }).to_s
+          ).to_json
+        end
+
+        let(:serialized_service_sap_json) do
+          V3::ServiceSerializer.new(
+            product_sap.service,
+            base_url: URI::HTTP.build({ scheme: response.request.scheme, host: response.request.host }).to_s
+          ).to_json
+        end
+
+        context 'when system is connected to SCC' do
+          let(:system_payg) do
+            FactoryBot.create(:system, :payg, :with_system_information_az, :with_activated_base_product, instance_data: instance_data,
+              system_token: new_system_token)
+          end
+          let(:product) do
+            FactoryBot.create(
+              :product, :product_sles_ltss, :extension, :with_mirrored_repositories, :with_mirrored_extensions,
+              base_products: [system_payg.products.first]
+              )
+          end
+          let(:subscription_response) do
+            {
+              id: 4206714,
+              regcode: 'bar',
+              name: 'SUSE Employee subscription for SUSE Linux Enterprise Server for SAP Applications',
+              type: 'internal',
+              status: 'ACTIVE',
+              starts_at: '2019-03-20T09:48:52.658Z',
+              expires_at: '2024-03-20T09:48:52.658Z',
+              system_limit: '100',
+              systems_count: '156',
+              virtual_count: nil,
+              product_classes: [
+                'AiO',
+                '7261',
+                'SLE-HAE-X86',
+                '7261-BETA',
+                'SLE-HAE-X86-BETA',
+                'AiO-BETA',
+                '7261-ALPHA',
+                'SLE-HAE-X86-ALPHA',
+                'AiO-ALPHA'
+              ],
+              product_ids: [
+                1959,
+                1421
+              ],
+              skus: [],
+              systems: [
+                {
+                  id: 3021957,
+                  login: 'SCC_foo',
+                  password: '5ee7273ac6ac4d7f',
+                  last_seen_at: '2019-03-20T14:01:05.424Z'
+                }
+              ]
+            }
+          end
+
+          before do
+            allow(plugin_double).to(
+              receive(:instance_valid?)
+                .and_raise(InstanceVerification::Exception, 'Custom plugin error')
+            )
+          end
+
+          context 'with a valid registration code' do
+            before do
+              stub_request(:post, scc_activate_url)
+                .to_return(
+                  status: 201,
+                  body: { id: 'bar' }.to_json,
+                  headers: {}
+                )
+              allow(File).to receive(:directory?)
+              allow(FileUtils).to receive(:mkdir_p)
+              allow(FileUtils).to receive(:touch)
               allow(InstanceVerification).to receive(:write_cache_file).twice.with(
                 Rails.application.config.repo_cache_dir, "127.0.0.1-#{system_payg.login}-#{product.id}"
               )

--- a/engines/scc_proxy/spec/requests/api/connect/v3/systems/products_controller_spec.rb
+++ b/engines/scc_proxy/spec/requests/api/connect/v3/systems/products_controller_spec.rb
@@ -444,7 +444,7 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
         end
       end
 
-      context 'when system has hw_info' do
+      context 'when system has hw info' do
         let(:instance_data) { '<document>{"instanceId": "dummy_instance_data"}</document>' }
         let(:new_system_token) { 'BBBBBBBB-BBBB-4BBB-9BBB-BBBBBBBBBBBB' }
         let(:serialized_service_json) do

--- a/engines/scc_proxy/spec/requests/api/connect/v3/systems/products_controller_spec.rb
+++ b/engines/scc_proxy/spec/requests/api/connect/v3/systems/products_controller_spec.rb
@@ -349,7 +349,7 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
 
         context 'when system is connected to SCC' do
           let(:system_payg) do
-            FactoryBot.create(:system, :payg, :with_system_information_az, :with_activated_base_product, instance_data: instance_data,
+            FactoryBot.create(:system, :payg, :with_system_information, :with_activated_base_product, instance_data: instance_data,
               system_token: new_system_token)
           end
           let(:product) do
@@ -416,7 +416,7 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
               allow(FileUtils).to receive(:mkdir_p)
               allow(FileUtils).to receive(:touch)
               allow(InstanceVerification::Providers::Example).to receive(:new).and_return(plugin_double)
-              allow(plugin_double).to receive(:basic?).and_return(false)
+              allow(plugin_double).to receive(:allowed_extension?).and_return(true)
               allow(InstanceVerification).to receive(:write_cache_file).twice.with(
                 Rails.application.config.repo_cache_dir, "127.0.0.1-#{system_payg.login}-#{product.id}"
               )
@@ -428,7 +428,7 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
 
             context 'when LTSS not allowed' do
               before do
-                allow(plugin_double).to receive(:basic?).and_return(true)
+                allow(plugin_double).to receive(:allowed_extension?).and_return(false)
               end
 
               it 'raises an error' do
@@ -463,7 +463,7 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
 
         context 'when system is connected to SCC' do
           let(:system_payg) do
-            FactoryBot.create(:system, :payg, :with_system_information_az, :with_activated_base_product, instance_data: instance_data,
+            FactoryBot.create(:system, :payg, :with_system_information, :with_activated_base_product, instance_data: instance_data,
               system_token: new_system_token)
           end
           let(:product) do

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -57,6 +57,23 @@ FactoryBot.define do
       friendly_version { '15 SP3' }
     end
 
+    trait :product_sles_ltss do
+      identifier { 'SLES-LTSS' }
+      name { 'SUSE Linux Enterprise Server LTSS' }
+      description { 'SUSE Linux Enterprise offers a comprehensive suite of products...' }
+      shortname { 'SLES15-SP3-LTSS' }
+      former_identifier { 'SLES_LTSS' }
+      product_type { 'extension' }
+      product_class { 'LTSS' }
+      release_type { nil }
+      release_stage { 'released' }
+      version { '15.3' }
+      arch { 'x86_64' }
+      free { false }
+      cpe { 'cpe:/o:suse:sles:15:sp3' }
+      friendly_version { '15 SP3' }
+    end
+
     trait :product_sles_sap do
       identifier { 'SLES_SAP' }
       name { 'SUSE Linux Enterprise Server' }

--- a/spec/factories/systems.rb
+++ b/spec/factories/systems.rb
@@ -70,19 +70,6 @@ FactoryBot.define do
       end
     end
 
-    trait :with_system_information_az do
-      system_information do
-        {
-          cpus: 2,
-          sockets: 1,
-          hypervisor: nil,
-          arch: 'x86_64',
-          uuid: SecureRandom.uuid,
-          cloud_provider: 'Microsoft'
-        }.to_json
-      end
-    end
-
     trait :with_system_token do
       sequence(:system_token) { |n| "00000000-0000-4000-9000-#{n.to_s.rjust(12, '0')}" }
     end

--- a/spec/factories/systems.rb
+++ b/spec/factories/systems.rb
@@ -70,6 +70,19 @@ FactoryBot.define do
       end
     end
 
+    trait :with_system_information_az do
+      system_information do
+        {
+          cpus: 2,
+          sockets: 1,
+          hypervisor: nil,
+          arch: 'x86_64',
+          uuid: SecureRandom.uuid,
+          cloud_provider: 'Microsoft'
+        }.to_json
+      end
+    end
+
     trait :with_system_token do
       sequence(:system_token) { |n| "00000000-0000-4000-9000-#{n.to_s.rjust(12, '0')}" }
     end


### PR DESCRIPTION
## Description

Azure basic images must not get access to LTSS product

* Related Issue / Ticket / Trello card: <link reference>

## How to test 

Running an Azure basic image, trying to activate LTSS should fail

## Change Type

*Please select the correct option.*

- [ ] **Bug Fix** (a non-breaking change which fixes an issue)
- [X] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

