### PR TITLE
Send the instance ID in the token for Azure

### DIFF
--- a/engines/instance_verification/lib/instance_verification/providers/example.rb
+++ b/engines/instance_verification/lib/instance_verification/providers/example.rb
@@ -27,10 +27,6 @@ class InstanceVerification::Providers::Example < InstanceVerification::ProviderB
   end
 
   def parse_instance_data
-    if @instance_data.include? '<instance_data/>'
-      return { 'instance_data' => 'parsed_instance_data' }
-    end
-
     if @instance_data.include?('SUSE')
       if @instance_data.include?('SAP')
         return { 'billingProducts' => nil, 'marketplaceProductCodes' => ['6789_SUSE_SAP'] }
@@ -48,5 +44,9 @@ class InstanceVerification::Providers::Example < InstanceVerification::ProviderB
     }
     return true if (identifier.casecmp('sles').zero? && instance_billing_info[:billing_product] == SLES_PRODUCT_IDENTIFIER)
     return true if (identifier.casecmp('sles_sap').zero? && SLES4SAP_PRODUCT_IDENTIFIER.include?(instance_billing_info[:marketplace_code]))
+  end
+
+  def instance_identifier
+    'foo'
   end
 end

--- a/engines/instance_verification/spec/requests/api/connect/v3/systems/products_controller_spec.rb
+++ b/engines/instance_verification/spec/requests/api/connect/v3/systems/products_controller_spec.rb
@@ -341,7 +341,7 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
           before do
             allow(InstanceVerification::Providers::Example).to receive(:new)
               .with(nil, nil, nil, instance_data).and_return(plugin_double)
-            allow(plugin_double).to receive(:parse_instance_data).and_return({ InstanceId: 'foo' })
+            allow(plugin_double).to receive(:instance_identifier).and_return('foo')
 
             allow(InstanceVerification).to receive(:update_cache).with('127.0.0.1', system.login, product.id)
             FactoryBot.create(:subscription, product_classes: product_classes)

--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -25,12 +25,6 @@ NET_HTTP_ERRORS = [
   Net::HTTPRetriableError
 ].freeze
 
-INSTANCE_ID_KEYS = {
-  amazon: 'instanceId',
-  google: 'instance_id',
-  microsoft: 'vmId'
-}.freeze
-
 # rubocop:disable Metrics/ModuleLength
 module SccProxy
   class << self

--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -68,9 +68,10 @@ module SccProxy
         nil,
         params['instance_data']
       )
-      instance_id_key = INSTANCE_ID_KEYS[params['hwinfo']['cloud_provider'].downcase.to_sym]
-      iid = verification_provider.parse_instance_data
-      iid[instance_id_key]
+      csp = params['hwinfo']['cloud_provider'].downcase
+      instance_id_key = INSTANCE_ID_KEYS[csp.to_sym]
+      instance_data = verification_provider.parse_instance_data
+      csp.casecmp('microsoft').zero? ? instance_data['attestedData'][instance_id_key] : instance_data[instance_id_key]
     end
 
     def prepare_scc_announce_request(uri_path, auth, params)


### PR DESCRIPTION
## Description

When activating an extension, i.e. LTSS in Azure,
the header must contain the the instance identifier

This Fixes bsc#1233314

* Related Issue / Ticket / Trello card: https://bugzilla.suse.com/show_bug.cgi?id=1233314

## How to test 

on Azure, registering LTSS extension should work

## Change Type

*Please select the correct option.*

- [X] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

