### PR TITLE
skip rotation for read Apis

### DIFF
--- a/app/controllers/api/connect/base_controller.rb
+++ b/app/controllers/api/connect/base_controller.rb
@@ -49,7 +49,9 @@ class Api::Connect::BaseController < ApplicationController
   end
 
   def refresh_system_token
-    @system.update(system_token: SecureRandom.uuid)
-    system_token_header
+    if system_tokens_enabled?
+      @system.update(system_token: SecureRandom.uuid)
+      system_token_header
+    end
   end
 end

--- a/app/controllers/api/connect/base_controller.rb
+++ b/app/controllers/api/connect/base_controller.rb
@@ -44,4 +44,12 @@ class Api::Connect::BaseController < ApplicationController
     end
   end
 
+  def system_token_header
+    headers[SYSTEM_TOKEN_HEADER] = @system.system_token
+  end
+
+  def refresh_system_token
+    @system.update(system_token: SecureRandom.uuid)
+    system_token_header
+  end
 end

--- a/app/controllers/api/connect/v3/systems/products_controller.rb
+++ b/app/controllers/api/connect/v3/systems/products_controller.rb
@@ -5,6 +5,7 @@ class Api::Connect::V3::Systems::ProductsController < Api::Connect::BaseControll
   before_action :check_product_service_and_repositories, only: %i[show activate]
   before_action :load_subscription, only: %i[activate upgrade]
   before_action :check_base_product_dependencies, only: %i[activate upgrade show]
+  after_action :refresh_system_token, only: %i[activate upgrade], if: -> { request.headers.key?(SYSTEM_TOKEN_HEADER) }
 
   def activate
     create_product_activation

--- a/app/controllers/api/connect/v3/systems/systems_controller.rb
+++ b/app/controllers/api/connect/v3/systems/systems_controller.rb
@@ -1,6 +1,7 @@
 class Api::Connect::V3::Systems::SystemsController < Api::Connect::BaseController
 
   before_action :authenticate_system
+  after_action :refresh_system_token, only: [:update], if: -> { request.headers.key?(SYSTEM_TOKEN_HEADER) }
 
   def update
     if params[:online_at].present?

--- a/app/controllers/api/connect/v4/systems/products_controller.rb
+++ b/app/controllers/api/connect/v4/systems/products_controller.rb
@@ -1,5 +1,6 @@
 class Api::Connect::V4::Systems::ProductsController < Api::Connect::V3::Systems::ProductsController
 
+  after_action :refresh_system_token, only: %i[synchronize destroy], if: -> { request.headers.key?(SYSTEM_TOKEN_HEADER) }
   def destroy
     if @product.base?
       raise ActionController::TranslatedError.new(N_('The product "%s" is a base product and cannot be deactivated'), @product.name)

--- a/app/controllers/api/connect/v4/systems/products_controller.rb
+++ b/app/controllers/api/connect/v4/systems/products_controller.rb
@@ -1,6 +1,6 @@
 class Api::Connect::V4::Systems::ProductsController < Api::Connect::V3::Systems::ProductsController
 
-  after_action :refresh_system_token, only: %i[synchronize destroy], if: -> { request.headers.key?(SYSTEM_TOKEN_HEADER) }
+  after_action :refresh_system_token, only: %i[activate upgrade synchronize destroy], if: -> { request.headers.key?(SYSTEM_TOKEN_HEADER) }
   def destroy
     if @product.base?
       raise ActionController::TranslatedError.new(N_('The product "%s" is a base product and cannot be deactivated'), @product.name)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -24,7 +24,7 @@ class ApplicationController < ActionController::API
         # that supports this feature.
         if system_tokens_enabled? && request.headers.key?(SYSTEM_TOKEN_HEADER)
           @system.update(last_seen_at: Time.zone.now)
-          headers[SYSTEM_TOKEN_HEADER] = @system.system_token
+          system_token_header
         # only update last_seen_at each 3 minutes,
         # so that a system that calls SCC every second doesn't write + lock the database row
         elsif !@system.last_seen_at || @system.last_seen_at < 3.minutes.ago

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,11 +21,11 @@ class ApplicationController < ActionController::API
         update_user_agent
 
         # If SYSTEM_TOKEN_HEADER is present, RMT assumes the client uses a SUSEConnect version
-        # that supports this feature. In this case, refresh the token and include it in the response.
+        # that supports this feature.
         if system_tokens_enabled? && request.headers.key?(SYSTEM_TOKEN_HEADER)
-          @system.update(last_seen_at: Time.zone.now, system_token: SecureRandom.uuid)
+          @system.update(last_seen_at: Time.zone.now)
           headers[SYSTEM_TOKEN_HEADER] = @system.system_token
-        # only update last_seen_at each 3 minutes,
+          # only update last_seen_at each 3 minutes,
         # so that a system that calls SCC every second doesn't write + lock the database row
         elsif !@system.last_seen_at || @system.last_seen_at < 3.minutes.ago
           @system.touch(:last_seen_at)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,7 +25,7 @@ class ApplicationController < ActionController::API
         if system_tokens_enabled? && request.headers.key?(SYSTEM_TOKEN_HEADER)
           @system.update(last_seen_at: Time.zone.now)
           headers[SYSTEM_TOKEN_HEADER] = @system.system_token
-          # only update last_seen_at each 3 minutes,
+        # only update last_seen_at each 3 minutes,
         # so that a system that calls SCC every second doesn't write + lock the database row
         elsif !@system.last_seen_at || @system.last_seen_at < 3.minutes.ago
           @system.touch(:last_seen_at)

--- a/spec/requests/api/connect/base_controller_spec.rb
+++ b/spec/requests/api/connect/base_controller_spec.rb
@@ -65,7 +65,6 @@ RSpec.describe Api::Connect::BaseController, type: :controller do
 
   shared_examples 'creates a duplicate system' do
     it 'creates a new System (duplicate)' do
-
       expect { get :service, params: { id: 1 } }
         .to change { System.get_by_credentials(system.login, system.password).count }
         .by(1)
@@ -182,7 +181,6 @@ RSpec.describe Api::Connect::BaseController, type: :controller do
 
         include_examples 'does not create a duplicate system'
         include_examples "does not update the old system's token"
-
       end
 
       context 'when the system has a token and the header is blank' do

--- a/spec/requests/api/connect/base_controller_spec.rb
+++ b/spec/requests/api/connect/base_controller_spec.rb
@@ -55,15 +55,6 @@ RSpec.describe Api::Connect::BaseController, type: :controller do
     end
   end
 
-  shared_examples 'updates the system token' do
-    it 'updates the system token' do
-      allow(SecureRandom).to receive(:uuid).and_return(new_system_token)
-
-      expect { get :service, params: { id: 1 } }
-        .to change { system.reload.system_token }
-        .from(current_system_token).to(new_system_token)
-    end
-  end
 
   shared_examples "does not update the old system's token" do
     it 'does not update the system token' do
@@ -74,7 +65,6 @@ RSpec.describe Api::Connect::BaseController, type: :controller do
 
   shared_examples 'creates a duplicate system' do
     it 'creates a new System (duplicate)' do
-      allow(SecureRandom).to receive(:uuid).and_return(new_system_token)
 
       expect { get :service, params: { id: 1 } }
         .to change { System.get_by_credentials(system.login, system.password).count }
@@ -85,7 +75,6 @@ RSpec.describe Api::Connect::BaseController, type: :controller do
       expect(duplicate_system).not_to eq(system)
       expect(duplicate_system.activations.count).to eq(system.activations.count)
       expect(duplicate_system.system_token).not_to eq(system.system_token)
-      expect(duplicate_system.system_token).to eq(new_system_token)
     end
   end
 
@@ -182,8 +171,7 @@ RSpec.describe Api::Connect::BaseController, type: :controller do
         let(:system) { create(:system, hostname: 'system') }
 
         include_examples 'does not create a duplicate system'
-        include_examples 'updates the system token'
-        include_examples 'responds with a new token'
+        include_examples "does not update the old system's token"
       end
 
       context 'when the system has a token and the header matches it' do
@@ -193,8 +181,8 @@ RSpec.describe Api::Connect::BaseController, type: :controller do
         let(:system) { create(:system, hostname: 'system', system_token: current_system_token) }
 
         include_examples 'does not create a duplicate system'
-        include_examples 'updates the system token'
-        include_examples 'responds with a new token'
+        include_examples "does not update the old system's token"
+
       end
 
       context 'when the system has a token and the header is blank' do
@@ -208,7 +196,6 @@ RSpec.describe Api::Connect::BaseController, type: :controller do
 
         include_examples "does not update the old system's token"
         include_examples 'creates a duplicate system'
-        include_examples 'responds with a new token'
       end
 
       context 'when the system has a token and the header does not match it' do

--- a/spec/requests/api/connect/v3/systems/activations_controller_spec.rb
+++ b/spec/requests/api/connect/v3/systems/activations_controller_spec.rb
@@ -69,5 +69,28 @@ RSpec.describe Api::Connect::V3::Systems::ActivationsController do
         expect(system.scc_synced_at).to be_nil
       end
     end
+
+    context 'system token header' do
+      context 'when system token header is present in request' do
+        let(:token_headers) do
+          authenticated_headers.merge({ 'System-Token' => 'some_token' })
+        end
+
+        it 'sets system token in response headers' do
+          get url, headers: token_headers
+          expect(response.code).to eq '200'
+          expect(response.headers).to include('System-Token')
+          expect(response.headers['System-Token']).not_to be_nil
+          expect(response.headers['System-Token']).not_to be_empty
+        end
+
+        it 'does not set system token header if no system token header in request' do
+          get url, headers: authenticated_headers
+
+          expect(response.code).to eq '200'
+          expect(response.headers).not_to include('System-Token')
+        end
+      end
+    end
   end
 end

--- a/spec/requests/api/connect/v3/systems/products_controller_spec.rb
+++ b/spec/requests/api/connect/v3/systems/products_controller_spec.rb
@@ -135,6 +135,26 @@ RSpec.describe Api::Connect::V3::Systems::ProductsController do
         end
       end
 
+      shared_context 'activate with token in request headers' do
+        let(:payload) do
+          {
+            identifier: product.identifier,
+            version: product.version,
+            arch: product.arch,
+            token: regcode
+          }
+        end
+
+        before { post url, headers: { 'System-Token' => 'existing_token' }.merge(headers), params: payload }
+        subject do
+          Struct.new(:body, :code, :headers).new(
+            JSON.parse(response.body, symbolize_names: true),
+            response.status,
+            response.headers
+          )
+        end
+      end
+
       context 'unknown subscription' do
         include_context 'with subscriptions'
         let(:regcode) { 'NOT-EXISTING-SUBSCRIPTION' }
@@ -172,6 +192,17 @@ RSpec.describe Api::Connect::V3::Systems::ProductsController do
           activation = Activation.find_by(subscription: subscription)
           expect(activation.product).to eq(product)
         end
+      end
+
+      context 'token update after activation is success' do
+        let(:subscription) { create :subscription, :with_products }
+        let(:product) { subscription.products.first }
+        let(:regcode) { subscription.regcode }
+
+        include_context 'activate with token in request headers'
+        its(:code) { is_expected.to eq(201) }
+        its(:headers) { is_expected.to include('System-Token') }
+        its(:headers['System-Token']) { is_expected.not_to eq('existing_token') }
       end
     end
   end
@@ -223,6 +254,18 @@ RSpec.describe Api::Connect::V3::Systems::ProductsController do
 
         its(:code) { is_expected.to eq('200') }
         its(:body) { is_expected.to eq(serialized_json) }
+      end
+
+      describe 'response header should contain token' do
+        subject { response }
+
+        let(:token_headers) do
+          headers.merge({ 'System-Token' => 'some_token' })
+        end
+
+        before { get url, headers: token_headers, params: payload }
+        its(:code) { is_expected.to eq('200') }
+        its(:headers) { is_expected.to include('System-Token') }
       end
 
       describe 'response with "-" in version' do
@@ -339,6 +382,18 @@ RSpec.describe Api::Connect::V3::Systems::ProductsController do
       system.reload
     end
 
+    it 'calls refresh_system_token after upgrade action when system token header is present' do
+      put url, headers: headers.merge('System-Token' => 'test_token'), params: payload
+      expect(response.code).to eq('201')
+      expect(response.headers).to include('System-Token')
+      expect(response.headers['System-Token']).not_to eq('test_token')
+    end
+
+    it 'No update in token after upgrade action when system token header is absent' do
+      put url, headers: headers, params: payload
+      expect(response.code).to eq('201')
+      expect(response.headers).not_to include('System-Token')
+    end
     context 'new product' do
       its(:code) { is_expected.to eq('201') }
       its(:body) { is_expected.to eq(serialized_json) }

--- a/spec/requests/api/connect/v3/systems/systems_controller_spec.rb
+++ b/spec/requests/api/connect/v3/systems/systems_controller_spec.rb
@@ -125,6 +125,25 @@ RSpec.describe Api::Connect::V3::Systems::SystemsController do
         expect(system.reload.system_information_hash[:user_agent]).to be_nil
       end
     end
+
+    context 'response header should contain token' do
+      let(:headers) { auth_header.merge('System-Token': 'existing-token') }
+
+      it 'contains refreshed token in response' do
+        update_action
+        expect(response.headers).to include('System-Token')
+        expect(response.headers['System-Token']).not_to equal('existing-token')
+      end
+    end
+
+    context 'response header should not contain token' do
+      let(:headers) { auth_header }
+
+      it 'contains refreshed token in response' do
+        update_action
+        expect(response.headers).not_to include('System-Token')
+      end
+    end
   end
 
   describe '#deregister' do


### PR DESCRIPTION
## Description

This PR targets to only rotate the token on calls to  PUT/POST/DELETE in system namespace

* Related Issue / Ticket / Trello card: https://trello.com/c/bimNtIHi/3647-repct-skip-system-token-rotation-in-read-only-apis

## How to test 

1. Show that calls to systems/ APIs don't rotate the token, only to [PUT/POST /systems/*](https://scc.suse.com/connect/v4/documentation#/systems/put_systems):

2. PUT /systems , PUT/POST/DELETE /systems/products

3. POST /systems/products/synchronize

4. Show that the current token gets returned in the response header

5. ~~Have it well documented in swagger~~ (RMT has no swagger)

```
> docker run --network=host --rm -ti registry.suse.com/suse/sle15:15.5 /bin/bash
$ zypper rm -y container-suseconnect
$ zypper in -y suseconnect-ng
$ suseconnect --url http://localhost:4224
$ cat /etc/zypp/credentials.d/SCCcredentials # see that token got set
$ suseconnect --keepalive
$ cat /etc/zypp/credentials.d/SCCcredentials # see that token updated
$ suseconnect -d -p sle-module-python3/15.5/x86_64
$ cat /etc/zypp/credentials.d/SCCcredentials # see that token updated
$ suseconnect --rollback
$ cat /etc/zypp/credentials.d/SCCcredentials # see that token updated
$ suseconnect --list-extensions
$ cat /etc/zypp/credentials.d/SCCcredentials # see that token _not_ updated
$ suseconnect --status
$ cat /etc/zypp/credentials.d/SCCcredentials # see that token _not_ updated
 /systems/activations doesn't rotate token: 
>curl -u <credentials from system above> -H "System-Token: <token from system above>" -I "http://localhost:4224/connect/systems/activations"

```


## Change Type

*Please select the correct option.*

- [ 8] **New Feature** (a non-breaking change which adds new functionality)



## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

