### PR TITLE
Refactor SUSE repo cleanup and local path generation logic supporting Akamai CDN

### DIFF
--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -21,6 +21,11 @@ class Repository < ApplicationRecord
   before_destroy :ensure_destroy_possible
 
   class << self
+
+    def remove_suse_repos_without_tokens!
+      where(auth_token: nil).where("external_url LIKE '%.suse.com%'").where(installer_updates: 0).delete_all
+    end
+
     # Mangles remote repo URL to make a nicer local path, see specs for examples
     def make_local_path(url)
       uri = URI(url)

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -21,18 +21,12 @@ class Repository < ApplicationRecord
   before_destroy :ensure_destroy_possible
 
   class << self
-
-    def remove_suse_repos_without_tokens!
-      where(auth_token: nil)
-        .where("external_url LIKE 'https://updates.suse.com%' OR external_url LIKE 'https://dl.suse.com%'")
-        .delete_all
-    end
-
     # Mangles remote repo URL to make a nicer local path, see specs for examples
     def make_local_path(url)
       uri = URI(url)
       path = uri.path.to_s
-      path.gsub!(%r{^/repo}, '') if (uri.hostname == 'updates.suse.com' || uri.hostname == 'dl.suse.com')
+      # drop '/repo' from SLE11 paths, to avoid double /repo/repo in local storage path.
+      path.gsub!(%r{^/repo/\$RCE/}, '/$RCE/')
       (path == '') ? '/' : path
     end
 

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -23,7 +23,7 @@ class Repository < ApplicationRecord
   class << self
 
     def remove_suse_repos_without_tokens!
-      where(auth_token: nil).where("external_url LIKE '%.suse.com%'").where(installer_updates: 0).delete_all
+      where(auth_token: nil).where("external_url LIKE '%.suse.com%'").where(installer_updates: 0).where.not(scc_id: nil).delete_all
     end
 
     # Mangles remote repo URL to make a nicer local path, see specs for examples

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -23,14 +23,16 @@ class Repository < ApplicationRecord
   class << self
 
     def remove_suse_repos_without_tokens!
-      where(auth_token: nil).where('external_url LIKE ?', 'https://updates.suse.com%').delete_all
+      where(auth_token: nil)
+        .where("external_url LIKE 'https://updates.suse.com%' OR external_url LIKE 'https://dl.suse.com%'")
+        .delete_all
     end
 
     # Mangles remote repo URL to make a nicer local path, see specs for examples
     def make_local_path(url)
       uri = URI(url)
       path = uri.path.to_s
-      path.gsub!(%r{^/repo}, '') if (uri.hostname == 'updates.suse.com')
+      path.gsub!(%r{^/repo}, '') if (uri.hostname == 'updates.suse.com' || uri.hostname == 'dl.suse.com')
       (path == '') ? '/' : path
     end
 

--- a/lib/rmt/scc.rb
+++ b/lib/rmt/scc.rb
@@ -24,6 +24,9 @@ class RMT::SCC
     data.each { |item| migration_paths(item) }
 
     update_repositories(scc_api_client.list_repositories)
+
+    Repository.remove_suse_repos_without_tokens!
+
     update_subscriptions(scc_api_client.list_subscriptions)
   end
 
@@ -65,6 +68,9 @@ class RMT::SCC
     data.each { |item| migration_paths(item) }
 
     update_repositories(JSON.parse(File.read(File.join(path, 'organizations_repositories.json')), symbolize_names: true))
+
+    Repository.remove_suse_repos_without_tokens!
+
     update_subscriptions(JSON.parse(File.read(File.join(path, 'organizations_subscriptions.json')), symbolize_names: true))
   end
 

--- a/lib/rmt/scc.rb
+++ b/lib/rmt/scc.rb
@@ -24,9 +24,6 @@ class RMT::SCC
     data.each { |item| migration_paths(item) }
 
     update_repositories(scc_api_client.list_repositories)
-
-    Repository.remove_suse_repos_without_tokens!
-
     update_subscriptions(scc_api_client.list_subscriptions)
   end
 
@@ -68,9 +65,6 @@ class RMT::SCC
     data.each { |item| migration_paths(item) }
 
     update_repositories(JSON.parse(File.read(File.join(path, 'organizations_repositories.json')), symbolize_names: true))
-
-    Repository.remove_suse_repos_without_tokens!
-
     update_subscriptions(JSON.parse(File.read(File.join(path, 'organizations_subscriptions.json')), symbolize_names: true))
   end
 

--- a/spec/lib/rmt/scc_spec.rb
+++ b/spec/lib/rmt/scc_spec.rb
@@ -261,7 +261,8 @@ describe RMT::SCC do
         :repository,
         :with_products,
         auth_token: nil,
-        external_url: 'https://example.com/repos/not/updates.suse.com/'
+        external_url: 'https://installer-updates.suse.com/repos/not/updates',
+        installer_updates: true
       )
     end
 
@@ -288,6 +289,10 @@ describe RMT::SCC do
 
     it 'SUSE repos with auth_tokens persist' do
       expect { suse_repo_with_token.reload }.not_to raise_error
+    end
+
+    it 'SUSE repos without auth_tokens are removed' do
+      expect { suse_repo_without_token.reload }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
     it 'other repos without auth_tokens persist' do

--- a/spec/lib/rmt/scc_spec.rb
+++ b/spec/lib/rmt/scc_spec.rb
@@ -265,6 +265,16 @@ describe RMT::SCC do
         installer_updates: true
       )
     end
+    let!(:custom_repo) do
+      FactoryBot.create(
+        :repository,
+        :with_products,
+        auth_token: nil,
+        external_url: 'http://customer.com/stuff.suse.com/x86',
+        installer_updates: false,
+        scc_id: nil
+      )
+    end
 
     before do
       # to prevent 'does not implement' verifying doubles error
@@ -297,6 +307,10 @@ describe RMT::SCC do
 
     it 'other repos without auth_tokens persist' do
       expect { other_repo_without_token.reload }.not_to raise_error
+    end
+
+    it 'custom repos without auth_tokens persist' do
+      expect { custom_repo.reload }.not_to raise_error
     end
   end
 

--- a/spec/lib/rmt/scc_spec.rb
+++ b/spec/lib/rmt/scc_spec.rb
@@ -290,10 +290,6 @@ describe RMT::SCC do
       expect { suse_repo_with_token.reload }.not_to raise_error
     end
 
-    it 'SUSE repos without auth_tokens are removed' do
-      expect { suse_repo_without_token.reload }.to raise_error(ActiveRecord::RecordNotFound)
-    end
-
     it 'other repos without auth_tokens persist' do
       expect { other_repo_without_token.reload }.not_to raise_error
     end


### PR DESCRIPTION
## Description

- Refined `make_local_path` to handle URLs from both SUSE domains (`https://updates.suse.com%` and `https://dl.suse.com%`) 
  - The method is called during repository creation and update in rmt.
  - Some repository URLs contain `/repo` in the path, such as `https://updates.suse.com/repo/$RCE/SLES10-SP4-LTSS-Updates/sles-10-x86_64/` in SCC. When synced and mirrored, these URLs would lead to incorrect directory paths locally.
  - For example, the URL `https://updates.suse.com/repo/$RCE/...` would be updated to `https://dl.suse.com/repo/$RCE/...`. Without this fix, mirrored repositories would incorrectly create local paths like `/repo/repo/...`.
  - The local path generation now correctly removes the `/repo` prefix, ensuring the correct local path structure.

- Updated `remove_suse_repos_without_tokens!` to delete repositories with URLs from both the old (`https://updates.suse.com%`) and new (`https://dl.suse.com%`) CDN domains when `auth_token` is `nil`.
  - This method is called during the sync and import workflows. Previously, only repositories with URLs starting with `https://updates.suse.com%` were cleared.
  - After the migration to the new CDN, repositories with URLs starting with `https://dl.suse.com%` are now also deleted when lacking an authentication token.



* Related Issue / Ticket / Trello card:  

https://trello.com/c/YFbHJEkq/3669-edgxit-test-migration-to-new-cdn-domain-auth-token-with-rmt

## How to test 

<!-- Describe the steps how verify your change -->

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

