### PR TITLE
Rmt cleanup old metadata

### DIFF
--- a/lib/rmt/mirror/base.rb
+++ b/lib/rmt/mirror/base.rb
@@ -155,9 +155,9 @@ class RMT::Mirror::Base
     logger.debug("Can not remove stale metadata directory: #{e}")
   end
 
-  def move_files(glob:, destination:)
+  def move_files(glob:, destination:, clean_before: true)
     FileUtils.mkpath(destination) unless Dir.exist?(destination)
-    FileUtils.rm_rf(Dir.glob(File.join(destination, '*')))
+    FileUtils.rm_rf(Dir.glob(File.join(destination, '*'))) if clean_before
     FileUtils.mv(Dir.glob(glob), destination, force: true)
   rescue StandardError => e
     raise RMT::Mirror::Exception.new(_('Error while moving files %{glob} to %{dest}: %{error}') % {

--- a/lib/rmt/mirror/base.rb
+++ b/lib/rmt/mirror/base.rb
@@ -155,7 +155,7 @@ class RMT::Mirror::Base
     logger.debug("Can not remove stale metadata directory: #{e}")
   end
 
-  def move_files(glob:, destination:, clean_before: true)
+  def move_files(glob:, destination:, clean_before: false)
     FileUtils.mkpath(destination) unless Dir.exist?(destination)
     FileUtils.rm_rf(Dir.glob(File.join(destination, '*'))) if clean_before
     FileUtils.mv(Dir.glob(glob), destination, force: true)

--- a/lib/rmt/mirror/base.rb
+++ b/lib/rmt/mirror/base.rb
@@ -157,6 +157,7 @@ class RMT::Mirror::Base
 
   def move_files(glob:, destination:)
     FileUtils.mkpath(destination) unless Dir.exist?(destination)
+    FileUtils.rm_rf(Dir.glob(File.join(destination, '*')))
     FileUtils.mv(Dir.glob(glob), destination, force: true)
   rescue StandardError => e
     raise RMT::Mirror::Exception.new(_('Error while moving files %{glob} to %{dest}: %{error}') % {

--- a/lib/rmt/mirror/repomd.rb
+++ b/lib/rmt/mirror/repomd.rb
@@ -15,7 +15,7 @@ class RMT::Mirror::Repomd < RMT::Mirror::Base
     mirror_packages(metadata_files)
 
     glob_metadata = File.join(temp(:metadata), 'repodata', '*')
-    move_files(glob: glob_metadata, destination: repository_path('repodata'))
+    move_files(glob: glob_metadata, destination: repository_path('repodata'), clean_before: true)
   end
 
   protected

--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -13,6 +13,7 @@ Wed Oct 30 09:01:32 UTC 2024 - Natnael Getahun <natnael.getahun@suse.com>
     * Allow SLE Micro system to access SLES repositories (bsc#1230419)
   * Skip system token rotation in read-only APIs
   * Enable RMT to handle the new dl.suse.com CDN domain (bsc#1234641)
+  * Clean up RMT metadata after repo update (bsc#1233308)
 
 -------------------------------------------------------------------
 Wed Aug 21 15:28:43 UTC 2024 - Jesús Bermúdez Velázquez <jesus.bv@suse.com>

--- a/spec/lib/rmt/mirror/base_spec.rb
+++ b/spec/lib/rmt/mirror/base_spec.rb
@@ -231,17 +231,6 @@ describe RMT::Mirror::Base do
       expect { base.move_files(glob: src, destination: dest) }.to raise_exception(/Error while moving files/)
     end
 
-    it 'remove existing files in the destination directory before moving' do
-      allow(Dir).to receive(:exist?).with(dest).and_return(true)
-      allow(Dir).to receive(:glob).with(File.join(dest, '*')).and_return(%w[/destination/path/file1.txt /destination/path/file2.txt])
-      allow(Dir).to receive(:glob).with(src).and_return(%w[/source/path/newfile1.txt /source/path/newfile2.txt])
-      expect(FileUtils).not_to receive(:mkpath).with(dest)
-      expect(FileUtils).to receive(:rm_rf).with(%w[/destination/path/file1.txt /destination/path/file2.txt])
-      expect(FileUtils).to receive(:mv).with(%w[/source/path/newfile1.txt /source/path/newfile2.txt], dest, force: true)
-
-      base.move_files(glob: src, destination: dest)
-    end
-
     it 'removes existing files when destination directory is empty' do
       allow(Dir).to receive(:exist?).with(dest).and_return(false)
       allow(Dir).to receive(:glob).with(src).and_return(%w[/source/path/newfile1.txt /source/path/newfile2.txt])
@@ -250,7 +239,7 @@ describe RMT::Mirror::Base do
       expect(FileUtils).to receive(:rm_rf).with([])
       expect(FileUtils).to receive(:mv).with(%w[/source/path/newfile1.txt /source/path/newfile2.txt], dest, force: true)
 
-      base.move_files(glob: src, destination: dest)
+      base.move_files(glob: src, destination: dest, clean_before: true)
     end
 
     it 'handles errors during removal of existing files' do
@@ -261,7 +250,7 @@ describe RMT::Mirror::Base do
       allow(FileUtils).to receive(:rm_rf).with(existing_files).and_raise(StandardError.new('Remove failed'))
 
       expect do
-        base.move_files(glob: src, destination: dest)
+        base.move_files(glob: src, destination: dest, clean_before: true)
       end.to raise_exception(/Error while moving files/)
     end
 

--- a/spec/lib/rmt/mirror/base_spec.rb
+++ b/spec/lib/rmt/mirror/base_spec.rb
@@ -230,6 +230,40 @@ describe RMT::Mirror::Base do
 
       expect { base.move_files(glob: src, destination: dest) }.to raise_exception(/Error while moving files/)
     end
+
+    it 'removes existing files in the destination directory before moving' do
+      allow(Dir).to receive(:exist?).with(dest).and_return(true)
+      allow(Dir).to receive(:glob).with(File.join(dest, '*')).and_return(%w[/destination/path/file1.txt /destination/path/file2.txt])
+      allow(Dir).to receive(:glob).with(src).and_return(%w[/source/path/newfile1.txt /source/path/newfile2.txt])
+      expect(FileUtils).not_to receive(:mkpath).with(dest)
+      expect(FileUtils).to receive(:rm_rf).with(%w[/destination/path/file1.txt /destination/path/file2.txt])
+      expect(FileUtils).to receive(:mv).with(%w[/source/path/newfile1.txt /source/path/newfile2.txt], dest, force: true)
+
+      base.move_files(glob: src, destination: dest)
+    end
+
+    it 'removes existing files when destination directory is empty' do
+      allow(Dir).to receive(:exist?).with(dest).and_return(false)
+      allow(Dir).to receive(:glob).with(src).and_return(%w[/source/path/newfile1.txt /source/path/newfile2.txt])
+      allow(Dir).to receive(:glob).with(File.join(dest, '*')).and_return([])
+      expect(FileUtils).to receive(:mkpath).with(dest)
+      expect(FileUtils).to receive(:rm_rf).with([])
+      expect(FileUtils).to receive(:mv).with(%w[/source/path/newfile1.txt /source/path/newfile2.txt], dest, force: true)
+
+      base.move_files(glob: src, destination: dest)
+    end
+
+    it 'handles errors during removal of existing files' do
+      allow(Dir).to receive(:exist?).with(dest).and_return(true)
+      existing_files = ['/destination/path/file1.txt']
+
+      allow(Dir).to receive(:glob).with(File.join(dest, '*')).and_return(existing_files)
+      allow(FileUtils).to receive(:rm_rf).with(existing_files).and_raise(StandardError.new('Remove failed'))
+
+      expect do
+        base.move_files(glob: src, destination: dest)
+      end.to raise_exception(/Error while moving files/)
+    end
   end
 
   describe '#need_to_download?' do

--- a/spec/lib/rmt/mirror/base_spec.rb
+++ b/spec/lib/rmt/mirror/base_spec.rb
@@ -231,7 +231,7 @@ describe RMT::Mirror::Base do
       expect { base.move_files(glob: src, destination: dest) }.to raise_exception(/Error while moving files/)
     end
 
-    it 'removes existing files in the destination directory before moving' do
+    it 'remove existing files in the destination directory before moving' do
       allow(Dir).to receive(:exist?).with(dest).and_return(true)
       allow(Dir).to receive(:glob).with(File.join(dest, '*')).and_return(%w[/destination/path/file1.txt /destination/path/file2.txt])
       allow(Dir).to receive(:glob).with(src).and_return(%w[/source/path/newfile1.txt /source/path/newfile2.txt])

--- a/spec/lib/rmt/mirror/repomd_spec.rb
+++ b/spec/lib/rmt/mirror/repomd_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe RMT::Mirror::Repomd do
       expect(licenses).to receive(:mirror)
       expect(repomd).to receive(:mirror_metadata)
       expect(repomd).to receive(:mirror_packages)
-      expect(repomd).to receive(:move_files).with(glob: 'a/repodata/*', destination: repomd.repository_path('repodata'))
+      expect(repomd).to receive(:move_files).with(glob: 'a/repodata/*', destination: repomd.repository_path('repodata'), clean_before: true)
 
       repomd.mirror_implementation
     end
@@ -65,7 +65,7 @@ RSpec.describe RMT::Mirror::Repomd do
         expect(repomd).to receive(:create_temp_dir).with(:metadata)
         expect(repomd).to receive(:mirror_metadata)
         expect(repomd).to receive(:mirror_packages)
-        expect(repomd).to receive(:move_files).with(glob: 'a/repodata/*', destination: repomd.repository_path('repodata'))
+        expect(repomd).to receive(:move_files).with(glob: 'a/repodata/*', destination: repomd.repository_path('repodata'), clean_before: true)
 
         expect(licenses).not_to receive(:mirror)
 


### PR DESCRIPTION
## Description

This task is for cleaning up old metadata files after repository updates in the CDN.


https://trello.com/c/SznwZfr3/3662-l3-regression-rmt-doesnt-clean-up-metadata



## How to test ( locally )

```
1) Enable a repository using the command:  ` rmt-cli repos enable <repo-id>`
2) Run the mirror command:  ` rmt-cli mirror`
3) Rename any metadata file in the repodata directory (e.g., rmt/public/repo/SUSE/Products/SLE-Product-SLES/15-SP6/ppc64le/product/repodata).
4) Run the mirror command again: `   rmt-cli mirror`

Check whether it will remove the renamed metadata file from the repodata directory and download the updated one from the CDN.
```
## Change Type

*Please select the correct option.*

- [* ] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)


