### PR TITLE
Configure SUMA product tree base URL

### DIFF
--- a/config/rmt.yml
+++ b/config/rmt.yml
@@ -31,6 +31,7 @@ scc:
 mirroring:
   mirror_src: false
   dedup_method: hardlink
+  suma_product_tree_base_url: <%= ENV['SUMA_PRODUCT_TREE_BASE_URL'] %>
 
 http_client:
   verbose: false

--- a/lib/rmt.rb
+++ b/lib/rmt.rb
@@ -1,5 +1,5 @@
 module RMT
-  VERSION ||= '2.20'.freeze
+  VERSION ||= '2.21'.freeze
 
   DEFAULT_USER = '_rmt'.freeze
   DEFAULT_GROUP = 'nginx'.freeze

--- a/lib/rmt/mirror/suma_product_tree.rb
+++ b/lib/rmt/mirror/suma_product_tree.rb
@@ -3,9 +3,9 @@ class RMT::Mirror::SumaProductTree
 
   attr_reader :mirroring_base_dir, :url, :logger
 
-  def initialize(logger:, mirroring_base_dir:, url: FILE_URL)
+  def initialize(logger:, mirroring_base_dir:, url: nil)
     @mirroring_base_dir = mirroring_base_dir
-    @url = url
+    @url = url || Settings.try(:mirroring).try(:suma_product_tree_base_url) || FILE_URL
     @logger = logger
   end
 

--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -1,3 +1,9 @@
+Mon Dec 23 14:07:00 UTC 2024 - Luís Caparroz <lcaparroz@suse.com>
+
+- Version 2.21
+- Allow users to configure the SUMA product tree base URL to download
+  'product_tree.json' from host other than 'scc.suse.com'.
+
 -------------------------------------------------------------------
 Mon Dec 23 08:03:56 UTC 2024 - Parag Jain <parag.jain@suse.com>
 

--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -1,8 +1,8 @@
 Mon Dec 23 14:07:00 UTC 2024 - Luís Caparroz <lcaparroz@suse.com>
 
 - Version 2.21
-- Allow users to configure the SUMA product tree base URL to download
-  'product_tree.json' from host other than 'scc.suse.com'.
+* Allow users to configure the SUMA product tree base URL to download
+  'product_tree.json' from host other than 'scc.suse.com'. (bsc#1234844)
 
 -------------------------------------------------------------------
 Mon Dec 23 08:03:56 UTC 2024 - Parag Jain <parag.jain@suse.com>

--- a/package/obs/rmt-server.spec
+++ b/package/obs/rmt-server.spec
@@ -34,7 +34,7 @@
 %undefine _find_debuginfo_dwz_opts
 
 Name:           rmt-server
-Version:        2.20
+Version:        2.21
 Release:        0
 Summary:        Repository mirroring tool and registration proxy for SCC
 License:        GPL-2.0-or-later


### PR DESCRIPTION
## Description

Allow user to configure the SUMA product tree base URL in RMT's config file `mirroring.suma_product_tree_base_url` attribute. The configured value takes precedence over the default (https://scc.suse.com/suma/).

* Related Issue / Ticket / Trello card: https://trello.com/c/Fv5zbDoj/3694-rgs-configure-suma-product-tree-base-url-in-rmt

## How to test 

On your local setup, change the attribute `mirroring.suma_product_tree_base_url` on `config/rmt.local.yml` to point to a custom URL (the URL must be reachable and respond to `<custom URL>/product_tree.json`, e.g.:

```yaml
mirroring:
  mirror_src: false
  verify_rpm_checksums: false
  dedup_method: hardlink
  suma_product_tree_base_url: <custom URL>/suma/
```

Then, run `bin/rmt-cli mirror`, and verify that the log output shows that the mirroring process has finished without any errors regarding the SUMA product tree.

## Change Type

*Please select the correct option.*

- [ ] **Bug Fix** (a non-breaking change which fixes an issue)
- [X] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [X] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

