### PR TITLE
Check for Micro for 6.0 and 6.1

### DIFF
--- a/app/controllers/api/connect/v3/systems/products_controller.rb
+++ b/app/controllers/api/connect/v3/systems/products_controller.rb
@@ -16,7 +16,7 @@ class Api::Connect::V3::Systems::ProductsController < Api::Connect::BaseControll
     if @product.identifier.casecmp?('sles')
       # if system has SLE Micro
       # it should access to SLES products
-      sle_micro = @system.products.any? { |p| p.identifier.downcase.include?('sle-micro') }
+      sle_micro = @system.products.any? { |p| p.identifier.downcase.include?('micro') }
       sle_micro_same_arch = @system.products.pluck(:arch).include?(@product.arch) if sle_micro
     end
     if @system.products.include?(@product) || sle_micro_same_arch

--- a/engines/strict_authentication/app/controllers/strict_authentication/authentication_controller.rb
+++ b/engines/strict_authentication/app/controllers/strict_authentication/authentication_controller.rb
@@ -40,7 +40,7 @@ module StrictAuthentication
       all_product_versions = @system.products.map { |p| Product.where(identifier: p.identifier, arch: p.arch) }.flatten
       allowed_paths = all_product_versions.map { |prod| prod.repositories.pluck(:local_path) }.flatten
       # Allow SLE Micro to access all free SLES repositories
-      sle_micro = @system.products.any? { |p| p.identifier.downcase.include?('sle-micro') }
+      sle_micro = @system.products.any? { |p| p.identifier.downcase.include?('micro') }
       if sle_micro
         system_products_archs = @system.products.pluck(:arch)
         product_free_sles_modules_only = Product.where(
@@ -59,7 +59,7 @@ module StrictAuthentication
       manager_prod = @system.products.any? do |p|
         manager = p.identifier.downcase.include?('manager-server')
         # SUMA 5.0 must have access to SUMA 4.3, 4.2 and so on
-        micro = p.identifier.downcase.include?('sle-micro')
+        micro = p.identifier.downcase.include?('micro')
         instance_id_header = headers.fetch('X-Instance-Identifier', '').casecmp('suse-manager-server').zero?
         instance_version_header = headers.fetch('X-Instance-Version', '0').split('.')[0] >= '5'
         manager || (micro && instance_id_header && instance_version_header)


### PR DESCRIPTION
## Description

As Micro 6.0 and 6.1 have 'SL-Micro' as identifier adjust the check to Micro to keep it working
for SUMA and for bsc#1230419

* Related Issue / Ticket / Trello card: <link reference>

## How to test 

Start a PAYG SL-Micro instance for 6.0 or 6.1 , it should register without issues
 
## Change Type

*Please select the correct option.*

- [X] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

