### PR TITLE
remove repo after sync

### DIFF
--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jan 03 13:06:20 UTC 2025 - Parag Jain <parag.jain@suse.com>
+
+- Version 2.21
+  * Fix: Remove obsolete repositories from rmt during SCC sync (bsc#1232808)
+
+-------------------------------------------------------------------
 Mon Dec 23 08:03:56 UTC 2024 - Parag Jain <parag.jain@suse.com>
 
 - Version 2.20


### PR DESCRIPTION
## Description

When there is a repository removed in SCC from a product, it should also get removed from the product in RMT.


* Related Issue / Ticket / Trello card: https://trello.com/c/cE60CTyL/5369-rmt-properly-sync-repository-removal?filter=rmt

## How to test 

Glue : Remove repository from any product using rails console.
```
- rails c
- repository = Repository.find(id)
- repository.destroy
```

In Rmt : Do sync

`- bin/rmt-cli sync
`
Expected behaviour

The sync process will remove any repositories that:

- Are not present in the current SCC data
- Have a non-null scc_id
- Custom repositories (null scc_id) will be preserved
- Logs will show the number of repositories removed 

## Change Type

*Please select the correct option.*

- [ ] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [ ] I have reviewed my own code and believe that it's ready for an external review.
- [ ] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

