### PR TITLE
Fix hardcoded suma tree url

### DIFF
--- a/lib/rmt.rb
+++ b/lib/rmt.rb
@@ -1,5 +1,5 @@
 module RMT
-  VERSION ||= '2.20.1'.freeze
+  VERSION ||= '2.21'.freeze
 
   DEFAULT_USER = '_rmt'.freeze
   DEFAULT_GROUP = 'nginx'.freeze

--- a/lib/rmt.rb
+++ b/lib/rmt.rb
@@ -1,5 +1,5 @@
 module RMT
-  VERSION ||= '2.20'.freeze
+  VERSION ||= '2.20.1'.freeze
 
   DEFAULT_USER = '_rmt'.freeze
   DEFAULT_GROUP = 'nginx'.freeze

--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -1,3 +1,9 @@
+Fri Jan 03 10:44:00 UTC 2025 - Luís Caparroz <lcaparroz@suse.com>
+
+- Version 2.20.1
+- Fix bug that hardcoded the SUMA product tree URL to 'scc.suse.com' even if a
+  different host was specified in the RMT configuration file. (bsc#1234844)
+
 -------------------------------------------------------------------
 Mon Dec 23 08:03:56 UTC 2024 - Parag Jain <parag.jain@suse.com>
 

--- a/package/obs/rmt-server.spec
+++ b/package/obs/rmt-server.spec
@@ -34,7 +34,7 @@
 %undefine _find_debuginfo_dwz_opts
 
 Name:           rmt-server
-Version:        2.20.1
+Version:        2.21
 Release:        0
 Summary:        Repository mirroring tool and registration proxy for SCC
 License:        GPL-2.0-or-later

--- a/package/obs/rmt-server.spec
+++ b/package/obs/rmt-server.spec
@@ -34,7 +34,7 @@
 %undefine _find_debuginfo_dwz_opts
 
 Name:           rmt-server
-Version:        2.20
+Version:        2.20.1
 Release:        0
 Summary:        Repository mirroring tool and registration proxy for SCC
 License:        GPL-2.0-or-later

--- a/package/obs/rmt.conf
+++ b/package/obs/rmt.conf
@@ -15,7 +15,7 @@ scc:
   metrics:
     enabled: false
     job_name: rmt
-    
+
 mirroring:
   mirror_src: false
   dedup_method: hardlink

--- a/spec/lib/rmt/mirror/suma_product_tree_spec.rb
+++ b/spec/lib/rmt/mirror/suma_product_tree_spec.rb
@@ -3,48 +3,92 @@ require 'rails_helper'
 RSpec.describe RMT::Mirror::SumaProductTree do
   subject(:suma) { described_class.new(**suma_mirror_configuration) }
 
-  let(:suma_mirror_configuration) do
-    {
-      logger: RMT::Logger.new('/dev/null'),
-      mirroring_base_dir: base_dir
-    }
-  end
-  let(:ref_configuration) do
-    {
-      relative_path: 'product_tree.json',
-      base_url: described_class::FILE_URL,
-      cache_dir: nil,
-      base_dir: File.join(base_dir, '/suma/')
-    }
-  end
+  let(:mirroring_base_dir) { '/tmp' }
+  let(:base_dir) { File.join(mirroring_base_dir, '/suma/') }
 
-  let(:base_dir) { '/tmp' }
-  let(:downloader) { instance_double RMT::Downloader }
+  shared_examples 'mirror SUMA product tree' do
+    it 'mirrors the product_tree file' do
+      expect(downloader).to receive(:download_multi).with(
+        [
+          have_attributes(
+            relative_path: 'product_tree.json',
+            base_url: base_url,
+            base_dir: base_dir
+          )
+        ]
+      )
+
+      suma.mirror
+    end
+
+    context 'when an error occurs downloading the file' do
+      it 'raises a proper exception' do
+        expect(downloader).to receive(:download_multi).and_raise(RMT::Downloader::Exception, 'Network issues')
+
+        expect { suma.mirror }.to raise_error(RMT::Mirror::Exception, /Could not mirror SUSE Manager/)
+      end
+    end
+  end
 
   describe '#mirror' do
     before do
       allow(RMT::Downloader).to receive(:new).and_return downloader
     end
 
-    it 'mirrors the product_tree file' do
-      expect(RMT::Mirror::FileReference).to receive(:new).with(**ref_configuration)
-      expect(downloader).to receive(:download_multi)
-      suma.mirror
+    let(:downloader) { instance_double RMT::Downloader }
+
+    context "when 'scc.host' is not set on the configuration file" do
+      before do
+        allow(Settings).to receive(:try).with(:scc).and_return(nil)
+      end
+
+      it_behaves_like 'mirror SUMA product tree' do
+        let(:suma_mirror_configuration) do
+          {
+            logger: RMT::Logger.new('/dev/null'),
+            mirroring_base_dir: mirroring_base_dir
+          }
+        end
+        let(:base_url) { 'https://scc.suse.com/suma/' }
+      end
     end
 
-    it 'fails to mirror the product file' do
-      expect(downloader).to receive(:download_multi).and_raise(RMT::Downloader::Exception, 'Network issues')
-      expect { suma.mirror }.to raise_error(RMT::Mirror::Exception, /Could not mirror SUSE Manager/)
+    context "when 'scc.host' is set on the configuration file" do
+      before do
+        allow(Settings).to receive(:try).with(:scc).and_return(scc_config)
+        allow(scc_config).to receive(:try).with(:host).and_return('http://local.scc/connect')
+      end
+
+      let(:scc_config) { instance_double(Config::Options) }
+
+      it_behaves_like 'mirror SUMA product tree' do
+        let(:suma_mirror_configuration) do
+          {
+            logger: RMT::Logger.new('/dev/null'),
+            mirroring_base_dir: mirroring_base_dir
+          }
+        end
+        let(:base_url) { 'http://local.scc/suma/' }
+      end
     end
 
-    context 'with default mirror dir' do
-      let(:updated_base_dir) { File.expand_path(File.join(RMT::DEFAULT_MIRROR_DIR, '/../')) }
-      let(:base_dir) { File.join(updated_base_dir, '/suma/') }
+    context "when an URL is passed as an argument and 'scc.host' is set" do
+      before do
+        allow(Settings).to receive(:try).with(:scc).and_return(scc_config)
+        allow(scc_config).to receive(:try).with(:host).and_return('http://local-scc.com/connect')
+      end
 
-      it 'alters the default mirroring path' do
-        expect(RMT::Mirror::FileReference).to receive(:new).with(**ref_configuration)
-        expect(downloader).to receive(:download_multi)
-        suma.mirror
+      let(:scc_config) { instance_double(Config::Options) }
+
+      it_behaves_like 'mirror SUMA product tree' do
+        let(:suma_mirror_configuration) do
+          {
+            logger: RMT::Logger.new('/dev/null'),
+            mirroring_base_dir: mirroring_base_dir,
+            url: base_url
+          }
+        end
+        let(:base_url) { 'http://custom-scc.com:3000/suma/' }
       end
     end
   end


### PR DESCRIPTION
## Description

Fix bug that hardcoded the SUMA product tree URL to 'scc.suse.com' even if a different host was specified in the RMT configuration file.

* Related Issue / Ticket / Trello card: https://bugzilla.suse.com/show_bug.cgi?id=1234844

## How to test 

1. Edit `config/rmt.local.yml` and change `scc.host` to point to a different host than `https://scc.suse.com/connect`, e.g.: `http://localhost:3000/connect`
1. On the project root directory, run `bin/rmt-cli mirror --debug`. If the command succeeds in downloading the SUMA product tree, it should print a similar output:

    ```log
    I, [2025-01-03T12:19:11.738742 #1623]  INFO -- : Mirroring SUSE Manager product tree to <...>/rmt/public/suma/
    D, [2025-01-03T12:19:11.741255 #1623] DEBUG -- : HTTP request for: http://localhost:3000/suma/product_tree.json
    I, [2025-01-03T12:19:13.112999 #1623]  INFO -- : ↓ product_tree.json
    D, [2025-01-03T12:19:13.113127 #1623] DEBUG -- :   (new mtime: 2025-01-03 11:19:13 UTC)
    ```

1. Verify that the output shows the SUMA product tree is downloaded from the same host as specified in the RMT configuraion file.

## Change Type

*Please select the correct option.*

- [X] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [X] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

