### PR TITLE
Update Zypper auth check

### DIFF
--- a/engines/instance_verification/spec/requests/api/connect/v3/systems/products_controller_spec.rb
+++ b/engines/instance_verification/spec/requests/api/connect/v3/systems/products_controller_spec.rb
@@ -601,7 +601,6 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
 
       context 'when SCC upgrade success' do
         before do
-          # pp headers
           stub_request(:put, scc_systems_products_url)
             .with({ headers: scc_headers, body: payload.merge({ byos_mode: 'byos' }) })
             .and_return(status: 201, body: '', headers: {})

--- a/engines/registry/spec/requests/api/connect/v3/systems/activations_controller_spec.rb
+++ b/engines/registry/spec/requests/api/connect/v3/systems/activations_controller_spec.rb
@@ -1,67 +1,130 @@
+# rubocop:disable RSpec/NestedGroups
 describe Api::Connect::V3::Systems::ActivationsController, type: :request do
   include_context 'auth header', :system, :login, :password
   include_context 'version header', 3
 
   describe '#activations' do
-    let(:system) { FactoryBot.create(:system, :payg, :with_activated_product) }
-    let(:headers) { auth_header.merge(version_header) }
+    context 'payg' do
+      let(:system) { FactoryBot.create(:system, :payg, :with_activated_product) }
+      let(:headers) { auth_header.merge(version_header) }
 
-    context 'without valid repository cache' do
-      context 'without X-Instance-Data headers or hw_info' do
-        it 'does not update InstanceVerification cache' do
-          get '/connect/systems/activations', headers: headers
-          data = JSON.parse(response.body)
-          expect(data[0]['service']['url']).to match(%r{^plugin:/susecloud})
-          expect(InstanceVerification).not_to receive(:update_cache)
+      context 'without valid repository cache' do
+        context 'without X-Instance-Data headers or hw_info' do
+          it 'does not update InstanceVerification cache' do
+            get '/connect/systems/activations', headers: headers
+            data = JSON.parse(response.body)
+            expect(data[0]['service']['url']).to match(%r{^plugin:/susecloud})
+            expect(InstanceVerification).not_to receive(:update_cache)
+          end
+        end
+
+        context 'with X-Instance-Data headers and bad metadata' do
+          let(:plugin_double) { instance_double('InstanceVerification::Providers::Example') }
+
+          before do
+            headers['X-Instance-Data'] = 'IMDS'
+            Thread.current[:logger] = RMT::Logger.new('/dev/null')
+          end
+
+          it 'does not update InstanceVerification cache' do
+            allow(plugin_double).to(
+              receive(:instance_valid?)
+                .and_raise(InstanceVerification::Exception, 'Custom plugin error')
+              )
+            allow(ZypperAuth).to receive(:verify_instance).and_call_original
+            get '/connect/systems/activations', headers: headers
+            expect(response.body).to include('Instance verification failed')
+            expect(InstanceVerification).not_to receive(:update_cache)
+          end
         end
       end
 
-      context 'with X-Instance-Data headers and bad metadata' do
-        let(:plugin_double) { instance_double('InstanceVerification::Providers::Example') }
+      context 'with repository cache valid' do
+        let(:cache_name) { "repo/cache/127.0.0.1-#{system.login}-#{system.products.first.id}" }
 
         before do
-          headers['X-Instance-Data'] = 'IMDS'
-          Thread.current[:logger] = RMT::Logger.new('/dev/null')
-        end
-
-        it 'does not update InstanceVerification cache' do
-          allow(plugin_double).to(
-            receive(:instance_valid?)
-              .and_raise(InstanceVerification::Exception, 'Custom plugin error')
-            )
+          allow(File).to receive(:join).and_call_original
+          allow(InstanceVerification).to receive(:update_cache)
           allow(ZypperAuth).to receive(:verify_instance).and_call_original
+          headers['X-Instance-Data'] = 'IMDS'
+        end
+
+        it 'refreshes registry cache key only' do
+          FileUtils.mkdir_p('repo/cache')
+          FileUtils.touch(cache_name)
+          expect(InstanceVerification).to receive(:update_cache).with('127.0.0.1', system.login, nil, registry: true)
           get '/connect/systems/activations', headers: headers
-          expect(response.body).to include('Instance verification failed')
-          expect(InstanceVerification).not_to receive(:update_cache)
+          FileUtils.rm_rf('repo/cache')
+          data = JSON.parse(response.body)
+          expect(data[0]['service']['url']).to match(%r{^plugin:/susecloud})
+        end
+      end
+
+      context 'system is hybrid' do
+        let(:system) { FactoryBot.create(:system, :hybrid, :with_activated_product) }
+        let(:plugin_double) { instance_double('InstanceVerification::Providers::Example') }
+        let(:cache_name) { "repo/cache/127.0.0.1-#{system.login}-#{system.products.first.id}" }
+        let(:scc_systems_activations_url) { 'https://scc.suse.com/connect/systems/activations' }
+        let(:body_active) do
+          {
+            id: 1,
+            regcode: '631dc51f',
+            name: 'Subscription 1',
+            type: 'FULL',
+            status: 'ACTIVE',
+            starts_at: 'null',
+            expires_at: '2014-03-14T13:10:21.164Z',
+            system_limit: 6,
+            systems_count: 1,
+            service: {
+              product: {
+                id: system.activations.first.product.id
+              }
+            }
+          }
+        end
+
+        before do
+          allow(InstanceVerification::Providers::Example).to receive(:new).and_return(plugin_double)
+
+          allow(plugin_double).to(
+            receive(:instance_valid?).and_return(true)
+            )
+          allow(File).to receive(:join).and_call_original
+          allow(InstanceVerification).to receive(:update_cache)
+          allow(ZypperAuth).to receive(:verify_instance).and_call_original
+          stub_request(:get, scc_systems_activations_url).to_return(status: 200, body: [body_active].to_json, headers: {})
+          headers['X-Instance-Data'] = 'IMDS'
+        end
+
+        context 'no registry' do
+          it 'refreshes registry cache key only' do
+            FileUtils.mkdir_p('repo/cache')
+            expect(InstanceVerification).to receive(:update_cache).with('127.0.0.1', system.login, system.activations.first.product.id)
+            get '/connect/systems/activations', headers: headers
+            FileUtils.rm_rf('repo/cache')
+            data = JSON.parse(response.body)
+            expect(data[0]['service']['url']).to match(%r{^plugin:/susecloud})
+          end
+        end
+
+        context 'registry' do
+          it 'refreshes registry cache key only' do
+            FileUtils.mkdir_p('repo/cache')
+            FileUtils.touch(cache_name)
+            expect(InstanceVerification).to receive(:update_cache).with('127.0.0.1', system.login, nil, registry: true)
+            get '/connect/systems/activations', headers: headers
+            FileUtils.rm_rf('repo/cache')
+            data = JSON.parse(response.body)
+            expect(data[0]['service']['url']).to match(%r{^plugin:/susecloud})
+          end
         end
       end
     end
 
-    context 'with repository cache valid' do
-      let(:cache_name) { "repo/cache/127.0.0.1-#{system.login}-#{system.products.first.id}" }
-
-      before do
-        allow(File).to receive(:join).and_call_original
-        allow(InstanceVerification).to receive(:update_cache)
-        allow(ZypperAuth).to receive(:verify_instance).and_call_original
-        headers['X-Instance-Data'] = 'IMDS'
-      end
-
-      it 'refreshes registry cache key only' do
-        FileUtils.mkdir_p('repo/cache')
-        FileUtils.touch(cache_name)
-        expect(InstanceVerification).to receive(:update_cache).with('127.0.0.1', system.login, nil, registry: true)
-        get '/connect/systems/activations', headers: headers
-        FileUtils.rm_rf('repo/cache')
-        data = JSON.parse(response.body)
-        expect(data[0]['service']['url']).to match(%r{^plugin:/susecloud})
-      end
-    end
-
-    context 'system is hybrid' do
-      let(:system) { FactoryBot.create(:system, :hybrid, :with_activated_product) }
-      let(:plugin_double) { instance_double('InstanceVerification::Providers::Example') }
-      let(:cache_name) { "repo/cache/127.0.0.1-#{system.login}-#{system.products.first.id}" }
+    context 'byos' do
+      let(:system) { FactoryBot.create(:system, :byos, :with_activated_product) }
+      let(:headers) { auth_header.merge(version_header) }
       let(:scc_systems_activations_url) { 'https://scc.suse.com/connect/systems/activations' }
       let(:body_active) do
         {
@@ -76,49 +139,125 @@ describe Api::Connect::V3::Systems::ActivationsController, type: :request do
           systems_count: 1,
           service: {
             product: {
-              id: system.activations.first.product.id
+              id: system.products.find_by(product_type: 'base').id, # activations.joins(:product).where(products: { free: false, product_type: :extension }).first.product.id, # rubocop:disable Layout/LineLength
+              product_class: system.products.find_by(product_type: 'base').product_class # activations.joins(:product).where(products: { free: false, product_type: :extension }).first.product.product_class # rubocop:disable Layout/LineLength
+            }
+          }
+        }
+      end
+      let(:body_active_byos_paid_extension) do
+        {
+          id: 1,
+          regcode: '631dc51f',
+          name: 'Subscription 1',
+          type: 'FULL',
+          status: 'ACTIVE',
+          starts_at: 'null',
+          expires_at: '2014-03-14T13:10:21.164Z',
+          system_limit: 6,
+          systems_count: 1,
+          service: {
+            product: {
+              id: system_byos.activations.joins(:product).where(products: { free: false, product_type: :extension }).first.product.id,
+              product_class: system_byos.activations.joins(:product).where(products: { free: false, product_type: :extension }).first.product.product_class
             }
           }
         }
       end
 
-      before do
-        allow(InstanceVerification::Providers::Example).to receive(:new).and_return(plugin_double)
-
-        allow(plugin_double).to(
-          receive(:instance_valid?).and_return(true)
-        )
-        allow(File).to receive(:join).and_call_original
-        allow(InstanceVerification).to receive(:update_cache)
-        allow(ZypperAuth).to receive(:verify_instance).and_call_original
-        stub_request(:get, scc_systems_activations_url).to_return(status: 200, body: [body_active].to_json, headers: {})
-        headers['X-Instance-Data'] = 'IMDS'
+      let(:body_expired) do
+        {
+          id: 1,
+          regcode: '631dc51f',
+          name: 'Subscription 1',
+          type: 'FULL',
+          status: 'EXPIRED',
+          starts_at: 'null',
+          expires_at: '2014-03-14T13:10:21.164Z',
+          system_limit: 6,
+          systems_count: 1,
+          service: {
+            product: {
+              id: system_byos.activations.first.product.id,
+              product_class: system_byos.activations.first.product.product_class
+            }
+          }
+        }
+      end
+      let(:body_not_activated) do
+        {
+          id: 1,
+          regcode: '631dc51f',
+          name: 'Subscription 1',
+          type: 'FULL',
+          status: 'ACTIVE',
+          starts_at: 'null',
+          expires_at: '2014-03-14T13:10:21.164Z',
+          system_limit: 6,
+          systems_count: 1,
+          service: {
+            product: {
+              id: 0o0000,
+              product_class: 'foo'
+            }
+          }
+        }
+      end
+      let(:body_unknown_status) do
+        {
+          id: 1,
+          regcode: '631dc51f',
+          name: 'Subscription 1',
+          type: 'FULL',
+          status: 'FOO',
+          starts_at: 'null',
+          expires_at: '2014-03-14T13:10:21.164Z',
+          system_limit: 6,
+          systems_count: 1,
+          service: {
+            product: {
+              id: 0o0000,
+              product_class: 'bar'
+            }
+          }
+        }
       end
 
-      context 'no registry' do
-        it 'refreshes registry cache key only' do
-          FileUtils.mkdir_p('repo/cache')
-          expect(InstanceVerification).to receive(:update_cache).with('127.0.0.1', system.login, system.activations.first.product.id)
-          get '/connect/systems/activations', headers: headers
-          FileUtils.rm_rf('repo/cache')
-          data = JSON.parse(response.body)
-          expect(SccProxy).not_to receive(:product_path_access)
-          expect(data[0]['service']['url']).to match(%r{^plugin:/susecloud})
-        end
-      end
+      context 'without valid repository cache' do
+        context 'with X-Instance-Data headers and bad metadata and good subscription on SCC' do
+          let(:plugin_double) { instance_double('InstanceVerification::Providers::Example') }
+          let(:scc_response) do
+            {
+              is_active: true
+            }
+          end
 
-      context 'registry' do
-        it 'refreshes registry cache key only' do
-          FileUtils.mkdir_p('repo/cache')
-          FileUtils.touch(cache_name)
-          expect(InstanceVerification).to receive(:update_cache).with('127.0.0.1', system.login, nil, registry: true)
-          get '/connect/systems/activations', headers: headers
-          FileUtils.rm_rf('repo/cache')
-          data = JSON.parse(response.body)
-          expect(SccProxy).not_to receive(:product_path_access)
-          expect(data[0]['service']['url']).to match(%r{^plugin:/susecloud})
+          before do
+            allow(InstanceVerification).to receive(:update_cache)
+            headers['X-Instance-Data'] = 'IMDS'
+            Thread.current[:logger] = RMT::Logger.new('/dev/null')
+          end
+
+          it 'does update InstanceVerification cache' do
+            allow(plugin_double).to(
+              receive(:instance_valid?)
+                .and_raise(InstanceVerification::Exception, 'Custom plugin error')
+              )
+            stub_request(:get, scc_systems_activations_url).to_return(status: 200, body: [body_active].to_json, headers: {})
+            allow(ZypperAuth).to receive(:verify_instance).and_call_original
+            expect(InstanceVerification).to receive(:update_cache).with('127.0.0.1', system.login, system.activations.first.product.id)
+            get '/connect/systems/activations', headers: headers
+
+            data = JSON.parse(response.body)
+            expect(data[0]['service']['url']).to match(%r{^plugin:/susecloud})
+            expect(data[0]['service']['id']).to match(system.activations.first.service_id)
+            expect(data[0]['service']['product']['id']).to match(system.activations.first.service_id)
+            expect(data[0]['id']).to match(system.activations.first.id)
+            expect(data[0]['system_id']).to match(system.activations.first.system_id)
+          end
         end
       end
     end
   end
 end
+# rubocop:enable RSpec/NestedGroups

--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -264,7 +264,7 @@ module SccProxy
       status_products_classes = if system.byos?
                                   scc_systems_activations.map do |act|
                                     product = act['service']['product']
-                                    if product['product_class'] == product_class && (product['free'] || (!act['status'].nil? && act['status'].casecmp('active').zero?))
+                                    if product['product_class'] == product_class && (product['free'] || (!act['status'].nil? && act['status'].casecmp('active').zero?)) # rubocop:disable Layout/LineLength
                                       # free module or (paid extension or base product))
                                       true
                                     end

--- a/engines/strict_authentication/app/controllers/strict_authentication/authentication_controller.rb
+++ b/engines/strict_authentication/app/controllers/strict_authentication/authentication_controller.rb
@@ -33,7 +33,6 @@ module StrictAuthentication
       return true if found_path.present? && @system.payg?
 
       if @system.hybrid? || @system.byos?
-        path_in_repos = false
         # check if the path is paid for hybrid or byos instances
         base_product = @system.products.find_by(product_type: 'base')
         verification_provider = InstanceVerification.provider.new(
@@ -47,7 +46,6 @@ module StrictAuthentication
           repos_paths = paid_extension.repositories.pluck(:local_path)
           repos_paths.each do |repo_path|
             if found_path == repo_path
-              path_in_repos = true
               logger.info "verifying paid extension #{paid_extension.identifier}"
               result = SccProxy.scc_check_subscription_expiration(request.headers, @system, paid_extension.product_class)
               Rails.logger.info "Result from check subscription with SCC #{result}"

--- a/engines/strict_authentication/app/controllers/strict_authentication/authentication_controller.rb
+++ b/engines/strict_authentication/app/controllers/strict_authentication/authentication_controller.rb
@@ -25,7 +25,59 @@ module StrictAuthentication
       has_sles11 = @system.products.where(identifier: 'SUSE_SLES').first
       return true if (has_sles11 && (path =~ %r{/12/} || path =~ %r{/12-SP1/}))
 
-      all_allowed_paths(headers).find { |allowed_path| path =~ /^#{Regexp.escape(allowed_path)}/ }
+      found_path = all_allowed_paths(headers).find { |allowed_path| path =~ /^#{Regexp.escape(allowed_path)}/ }
+      return true if found_path.present? && @system.payg?
+
+      if found_path.present? && (@system.hybrid? || @system.byos?)
+        path_in_repos = false
+        # check if the path is paid for hybrid or byos instances
+        base_product = @system.products.find_by(product_type: 'base')
+        verification_provider = InstanceVerification.provider.new(
+          logger,
+          request,
+          base_product.attributes.symbolize_keys.slice(:identifier, :version, :arch, :release_type),
+          Base64.decode64(request.headers['X-Instance-Data'].to_s) # instance data
+        )
+        paid_extensions = @system.products.select { |prod| prod if !prod.free && prod.product_type == 'extension' }
+        paid_extensions.each do |paid_extension|
+          repos_paths = paid_extension.repositories.pluck(:local_path)
+          repos_paths.each do |repo_path|
+            if found_path == repo_path
+              path_in_repos = true
+              logger.info "verifying paid extension #{paid_extension.identifier}"
+              result = SccProxy.scc_check_subscription_expiration(request.headers, @system, paid_extension.product_class)
+              Rails.logger.info "Result from check subscription with SCC #{result}"
+              return true if result[:is_active]
+
+              # if the paid extension is not on SCC
+              # and the system is hybrid, we return true for the path
+              # to check if it is included in the system
+              # with the instance metadata
+              # i.e. Live Patching in SLES4SAP
+              return true if result[:message] == 'Product not activated.' && @system.hybrid?
+
+              ZypperAuth.zypper_auth_message(request, @system, verification_provider, result[:message])
+              return false
+            end
+          end
+        end
+        if @system.byos?
+          result = SccProxy.scc_check_subscription_expiration(request.headers, @system, base_product.product_class)
+          Rails.logger.info "Result from check subscription with SCC #{result}"
+          return true if result[:is_active]
+
+          ZypperAuth.zypper_auth_message(request, @system, verification_provider, result[:message])
+          false
+        else
+          # system is hybrid but the path is not a paid extension
+          # or path is in not free and belongs to the base product repositories
+          # i.e. HA for SAP
+          # check if it belongs to the free products repositories list
+          true
+        end
+      elsif found_path.blank?
+        false
+      end
     end
 
     # rubocop:disable Metrics/CyclomaticComplexity

--- a/engines/strict_authentication/app/controllers/strict_authentication/authentication_controller.rb
+++ b/engines/strict_authentication/app/controllers/strict_authentication/authentication_controller.rb
@@ -28,9 +28,11 @@ module StrictAuthentication
       return true if (has_sles11 && (path =~ %r{/12/} || path =~ %r{/12-SP1/}))
 
       found_path = all_allowed_paths(headers).find { |allowed_path| path =~ /^#{Regexp.escape(allowed_path)}/ }
+      return false if found_path.blank?
+
       return true if found_path.present? && @system.payg?
 
-      if found_path.present? && (@system.hybrid? || @system.byos?)
+      if @system.hybrid? || @system.byos?
         path_in_repos = false
         # check if the path is paid for hybrid or byos instances
         base_product = @system.products.find_by(product_type: 'base')
@@ -77,8 +79,6 @@ module StrictAuthentication
           # check if it belongs to the free products repositories list
           true
         end
-      elsif found_path.blank?
-        false
       end
     end
     # rubocop:enable Metrics/CyclomaticComplexity

--- a/engines/strict_authentication/app/controllers/strict_authentication/authentication_controller.rb
+++ b/engines/strict_authentication/app/controllers/strict_authentication/authentication_controller.rb
@@ -14,6 +14,8 @@ module StrictAuthentication
 
     protected
 
+    # rubocop:disable Metrics/CyclomaticComplexity
+    # rubocop:disable Metrics/PerceivedComplexity
     def path_allowed?(headers)
       path = headers['X-Original-URI']
       return false if path.blank?
@@ -79,6 +81,8 @@ module StrictAuthentication
         false
       end
     end
+    # rubocop:enable Metrics/CyclomaticComplexity
+    # rubocop:enable Metrics/PerceivedComplexity
 
     # rubocop:disable Metrics/CyclomaticComplexity
     # rubocop:disable Metrics/PerceivedComplexity

--- a/engines/strict_authentication/spec/requests/strict_authentication/authentication_controller_spec.rb
+++ b/engines/strict_authentication/spec/requests/strict_authentication/authentication_controller_spec.rb
@@ -5,7 +5,7 @@ module StrictAuthentication
   RSpec.describe AuthenticationController, type: :request do
     subject { response }
 
-    let(:system) { FactoryBot.create(:system, :with_activated_product_sle_micro) }
+    let(:system) { FactoryBot.create(:system, :payg, :with_activated_product_sle_micro) }
 
     describe '#check' do
       context 'without authentication' do
@@ -101,7 +101,7 @@ module StrictAuthentication
               )
             end
 
-            let(:system) { FactoryBot.create(:system, :with_activated_product, product: product) }
+            let(:system) { FactoryBot.create(:system, :payg, :with_activated_product, product: product) }
             let(:requested_uri) { '/repo/$path/*with/.funky/(characters)/repodata/repomd.xml' }
 
             its(:code) { is_expected.to eq '200' }
@@ -164,7 +164,7 @@ module StrictAuthentication
                 identifier: 'SUSE-Manager-Server', version: '15', arch: 'x86_64'
                 )
             end
-            let(:system) { FactoryBot.create(:system, :with_activated_product, product: my_product) }
+            let(:system) { FactoryBot.create(:system, :payg, :with_activated_product, product: my_product) }
 
             let(:suma_prod_id) do
               system.products.find do |p|

--- a/engines/zypper_auth/lib/zypper_auth/engine.rb
+++ b/engines/zypper_auth/lib/zypper_auth/engine.rb
@@ -6,7 +6,7 @@ module ZypperAuth
       Thread.current[:logger]
     end
 
-    def verify_instance(request, logger, system, params_product_id = nil)
+    def verify_instance(request, logger, system)
       return false unless request.headers['X-Instance-Data']
 
       base_product = system.products.find_by(product_type: 'base')

--- a/engines/zypper_auth/lib/zypper_auth/engine.rb
+++ b/engines/zypper_auth/lib/zypper_auth/engine.rb
@@ -35,7 +35,10 @@ module ZypperAuth
     rescue InstanceVerification::Exception => e
       if system.byos?
         result = SccProxy.scc_check_subscription_expiration(request.headers, system, base_product.product_class)
-        return true if result[:is_active]
+        if result[:is_active]
+          InstanceVerification.update_cache(request.remote_ip, system.login, base_product.id)
+          return true
+        end
       end
 
       ZypperAuth.zypper_auth_message(request, system, verification_provider, e.message)

--- a/engines/zypper_auth/lib/zypper_auth/engine.rb
+++ b/engines/zypper_auth/lib/zypper_auth/engine.rb
@@ -6,7 +6,7 @@ module ZypperAuth
       Thread.current[:logger]
     end
 
-    def verify_instance(request, logger, system)
+    def verify_instance(request, logger, system, _params_product_id = nil)
       return false unless request.headers['X-Instance-Data']
 
       base_product = system.products.find_by(product_type: 'base')

--- a/engines/zypper_auth/lib/zypper_auth/engine.rb
+++ b/engines/zypper_auth/lib/zypper_auth/engine.rb
@@ -6,7 +6,7 @@ module ZypperAuth
       Thread.current[:logger]
     end
 
-    def verify_instance(request, logger, system, _params_product_id = nil)
+    def verify_instance(request, logger, system)
       return false unless request.headers['X-Instance-Data']
 
       base_product = system.products.find_by(product_type: 'base')
@@ -123,7 +123,7 @@ module ZypperAuth
         # additional validation for zypper service XML controller
         before_action :verify_instance
         def verify_instance
-          unless ZypperAuth.verify_instance(request, logger, @system, params.fetch('id', nil))
+          unless ZypperAuth.verify_instance(request, logger, @system)
             render(xml: { error: 'Instance verification failed' }, status: 403)
           end
         end

--- a/engines/zypper_auth/lib/zypper_auth/engine.rb
+++ b/engines/zypper_auth/lib/zypper_auth/engine.rb
@@ -29,13 +29,13 @@ module ZypperAuth
       )
 
       is_valid = verification_provider.instance_valid?
-      return false if is_valid && system.hybrid? && !handle_scc_subscription(request, system, verification_provider, params_product_id)
+      return false if is_valid && system.hybrid? && !has_active_subscription?(request, system, verification_provider, params_product_id)
 
       # update repository and registry cache
       InstanceVerification.update_cache(request.remote_ip, system.login, base_product.id)
       is_valid
     rescue InstanceVerification::Exception => e
-      return handle_scc_subscription(request, system, verification_provider, params_product_id) if system.byos?
+      return has_active_subscription?(request, system, verification_provider, params_product_id) if system.byos?
 
       ZypperAuth.zypper_auth_message(request, system, verification_provider, e.message)
       false
@@ -48,7 +48,7 @@ module ZypperAuth
       false
     end
 
-    def handle_scc_subscription(request, system, verification_provider, params_product_id = nil)
+    def has_active_subscription?(request, system, verification_provider, params_product_id = nil)
       if params_product_id.present?
         product_class = Product.find_by(id: params_product_id).product_class
         result = SccProxy.scc_check_subscription_expiration(request.headers, system, product_class)

--- a/engines/zypper_auth/spec/requests/strict_authentication/authentication_controller_spec.rb
+++ b/engines/zypper_auth/spec/requests/strict_authentication/authentication_controller_spec.rb
@@ -69,8 +69,8 @@ describe StrictAuthentication::AuthenticationController, type: :request do
             systems_count: 1,
             service: {
               product: {
-                id: system_byos.products.find_by(product_type: 'base').id, # activations.joins(:product).where(products: { free: false, product_type: :extension }).first.product.id,
-                product_class: system_byos.products.find_by(product_type: 'base').product_class # activations.joins(:product).where(products: { free: false, product_type: :extension }).first.product.product_class
+                id: system_byos.products.find_by(product_type: 'base').id, # activations.joins(:product).where(products: { free: false, product_type: :extension }).first.product.id, # rubocop:disable Layout/LineLength
+                product_class: system_byos.products.find_by(product_type: 'base').product_class # activations.joins(:product).where(products: { free: false, product_type: :extension }).first.product.product_class # rubocop:disable Layout/LineLength
               }
             }
           }
@@ -432,7 +432,8 @@ describe StrictAuthentication::AuthenticationController, type: :request do
               service: {
                 product: {
                   id: system_hybrid.activations.joins(:product).where(products: { free: false, product_type: :extension }).first.product.id,
-                  product_class: system_hybrid.activations.joins(:product).where(products: { free: false, product_type: :extension }).first.product.product_class
+                  product_class: system_hybrid.activations.joins(:product).where(products: { free: false,
+                                                                                             product_type: :extension }).first.product.product_class
                 }
               }
             }
@@ -482,7 +483,8 @@ describe StrictAuthentication::AuthenticationController, type: :request do
               service: {
                 product: {
                   id: system_hybrid.activations.joins(:product).where(products: { free: false, product_type: :extension }).first.product.id,
-                  product_class: system_hybrid.activations.joins(:product).where(products: { free: false, product_type: :extension }).first.product.product_class
+                  product_class: system_hybrid.activations.joins(:product).where(products: { free: false,
+                                                                                             product_type: :extension }).first.product.product_class
                 }
               }
             }

--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -1,10 +1,19 @@
+-------------------------------------------------------------------
 Fri Jan 03 10:44:00 UTC 2025 - Luís Caparroz <lcaparroz@suse.com>
 
 - Version 2.21
   * Allow users to configure the SUMA product tree base URL to download
     'product_tree.json' from host other than 'scc.suse.com'. (bsc#1234844)
+<<<<<<< HEAD
   * Update Micro check due to Micro 6.0 and 6.1 identifier to keep bsc#1230419 in place
   * Remove obsolete repositories and associations from rmt during SCC sync (bsc#1232808)
+  * Do not re-download repomd metadata if already exists and be the latest version
+  * rmt-server-pubcloud
+=======
+  * rmt-server-pubcloud:
+>>>>>>> 82a34d00 (Add pubcloud section to changelog)
+    * Update Micro check due to Micro 6.0 and 6.1 identifier to keep bsc#1230419 in place
+    * Update Zypper path allowing check to handle paid extensions (i.e. LTSS) (bsc#1230157)
 
 -------------------------------------------------------------------
 Mon Dec 23 08:03:56 UTC 2024 - Parag Jain <parag.jain@suse.com>

--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -4,14 +4,10 @@ Fri Jan 03 10:44:00 UTC 2025 - Luís Caparroz <lcaparroz@suse.com>
 - Version 2.21
   * Allow users to configure the SUMA product tree base URL to download
     'product_tree.json' from host other than 'scc.suse.com'. (bsc#1234844)
-<<<<<<< HEAD
   * Update Micro check due to Micro 6.0 and 6.1 identifier to keep bsc#1230419 in place
   * Remove obsolete repositories and associations from rmt during SCC sync (bsc#1232808)
   * Do not re-download repomd metadata if already exists and be the latest version
-  * rmt-server-pubcloud
-=======
   * rmt-server-pubcloud:
->>>>>>> 82a34d00 (Add pubcloud section to changelog)
     * Update Micro check due to Micro 6.0 and 6.1 identifier to keep bsc#1230419 in place
     * Update Zypper path allowing check to handle paid extensions (i.e. LTSS) (bsc#1230157)
 

--- a/spec/factories/systems.rb
+++ b/spec/factories/systems.rb
@@ -57,6 +57,21 @@ FactoryBot.define do
       end
     end
 
+    trait :with_activated_paid_extension do
+      transient do
+        product_base { create(:product, :with_mirrored_repositories, free: true) }
+        paid_product { create(:product, :with_mirrored_repositories, free: false, product_type: :extension) }
+        free_product { create(:product, :with_mirrored_repositories, free: true, product_type: :extension) }
+        subscription { nil }
+      end
+
+      after :create do |system, evaluator|
+        create(:activation, system: system, service: evaluator.product_base.service, subscription: evaluator.subscription)
+        create(:activation, system: system, service: evaluator.paid_product.service, subscription: evaluator.subscription)
+        create(:activation, system: system, service: evaluator.free_product.service, subscription: evaluator.subscription)
+      end
+    end
+
     trait :with_activated_product_sle_micro do
       transient do
         product { create(:product, :product_sle_micro, :with_mirrored_repositories) }


### PR DESCRIPTION
## Description

When a hybrid system runs zypper command, the check
needs to take care of the subscription verification

Currently, the check lacks paid extension ID, resulting in
an unsuccessful verification

This change fixes that

If system is hybrid, and the path being accessed belongs to a paid extension,
we check that the paid extension subscription is active

if the repository path belongs to a free repository or no matches with paid extensions,
no need to check the subscription

if ZypperAuth handle_scc_subscription method gets called without a product id,
the method will check _all_ non free products suscriptions to be active, if any

This fixes bsc#1230157
* Related Issue / Ticket / Trello card: https://bugzilla.suse.com/show_bug.cgi?id=1230157

## How to test 

Start an Azure instance, register LTSS, wait > 20 min for the cache to get expired
run `zypper ref` should work

## Change Type

*Please select the correct option.*

- [X] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

