### PR TITLE
Check if repository metadata already exists (is cached)

### DIFF
--- a/lib/rmt/mirror/repomd.rb
+++ b/lib/rmt/mirror/repomd.rb
@@ -28,7 +28,7 @@ class RMT::Mirror::Repomd < RMT::Mirror::Base
 
     metadata_files = RepomdParser::RepomdXmlParser.new.parse_file(repomd_xml.local_path)
       .map do |reference|
-        ref = RMT::Mirror::FileReference.build_from_metadata(reference, base_dir: temp(:metadata), base_url: repomd_xml.base_url)
+        ref = RMT::Mirror::FileReference.build_from_metadata(reference, base_dir: temp(:metadata), base_url: repomd_xml.base_url, cache_dir: repository_path)
         enqueue ref
         ref
       end

--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -5,6 +5,7 @@ Fri Jan 03 10:44:00 UTC 2025 - Luís Caparroz <lcaparroz@suse.com>
     'product_tree.json' from host other than 'scc.suse.com'. (bsc#1234844)
   * Update Micro check due to Micro 6.0 and 6.1 identifier to keep bsc#1230419 in place
   * Remove obsolete repositories and associations from rmt during SCC sync (bsc#1232808)
+  * Do not re-download repomd metadata if already exists and be the latest version
 
 -------------------------------------------------------------------
 Mon Dec 23 08:03:56 UTC 2024 - Parag Jain <parag.jain@suse.com>


### PR DESCRIPTION
Instead of re-downloading repomd metadata, check if the files are already exists in the "cache" (repository_path).

**How to review:**

```
$ git checkout master
$ bundle exec bin/rmt-cli repos enable 6301
$ bundle exec bin/rmt-cli mirror repository 6301
$ bundle exec bin/rmt-cli mirror repository 6301
# expect: See that the metadata is re-downloaded (↓ instead of →)

$ git checkout fix-non-cached-metadata
$ bundle exec bin/rmt-cli mirror repository 6301
# expect: See that the metadata is NOT re-downloaded (→ instead of ↓)
```

**Note:** Why is there no test for this? The logic of when to download what is in `downloader.rb` rather then `repomd.rb`. If you insist I add a test checking if `cache_dir:` is set? Needed?

**Thank you for reviewing!**

cheers,
