### PR TITLE
When migrating compare product classes

### DIFF
--- a/engines/instance_verification/lib/instance_verification/engine.rb
+++ b/engines/instance_verification/lib/instance_verification/engine.rb
@@ -122,7 +122,7 @@ module InstanceVerification
 
           activated_bases = @system.products.where(product_type: 'base')
           activated_bases.each do |base_product|
-            return true if (base_product.identifier == upgrade_product.identifier)
+            return true if base_product.product_class == upgrade_product.product_class
           end
 
           raise ActionController::TranslatedError.new('Migration target not allowed on this instance type')

--- a/engines/instance_verification/spec/requests/api/connect/v3/systems/products_controller_spec.rb
+++ b/engines/instance_verification/spec/requests/api/connect/v3/systems/products_controller_spec.rb
@@ -624,6 +624,7 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
           let(:new_product) do
             FactoryBot.create(
               :product, :with_mirrored_repositories, identifier: old_product.identifier,
+              product_class: old_product.product_class,
               version: '999', predecessors: [ old_product ]
               )
           end
@@ -667,7 +668,7 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
         context 'when migration target base product has the same identifier' do
           let(:new_product) do
             FactoryBot.create(
-              :product, :with_mirrored_repositories, identifier: old_product.identifier,
+              :product, :with_mirrored_repositories, product_class: old_product.product_class,
               version: '999', predecessors: [ old_product ]
               )
           end
@@ -732,6 +733,7 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
         let(:new_product) do
           FactoryBot.create(
             :product, :with_mirrored_repositories, identifier: old_product.identifier,
+            product_class: old_product.product_class,
             version: '999', predecessors: [ old_product ]
             )
         end


### PR DESCRIPTION
## Description

Because of the change from SLE Micro < 6.0 to SL Micro 6+ comparing the identifier no longer works when migrating

This fixes bsc#1236816

* Related Issue / Ticket / Trello card: [bsc#1236816](https://bugzilla.suse.com/show_bug.cgi?id=1236816)

## How to test 

Start a Micro 5.5 instance, run `transactional-update migration` , choose any of the available options, i.e.

```bash
Available migrations:

    1 |SUSE Linux Micro 6.1 x86_64

    2 |SUSE Linux Micro 6.0 x86_64


[num/q]: 1
```
Migration should succeed

## Change Type

*Please select the correct option.*

- [X] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

