### PR TITLE
Add cache check 

### DIFF
--- a/engines/instance_verification/config/environments/test.rb
+++ b/engines/instance_verification/config/environments/test.rb
@@ -5,6 +5,12 @@
 
 Rails.application.configure do
   config.cache_config_file = Rails.root.join('engines/registry/spec/data/rmt-cache-trim.sh')
-  config.repo_cache_dir = 'repo/cache'
+  config.repo_payg_cache_dir = 'repo/payg/cache'
+  config.repo_byos_cache_dir = 'repo/byos/cache'
+  config.repo_hybrid_cache_dir = 'repo/hybrid/cache'
   config.registry_cache_dir = 'registry/cache'
+  config.expire_repo_payg_cache = 20
+  config.expire_repo_byos_cache = 1440 # 24h in minutes
+  config.expire_repo_hybrid_cache = 1440 # 24h in minutes
+  config.expire_registry_cache = 840 # 8h in minutes
 end

--- a/engines/instance_verification/lib/instance_verification/engine.rb
+++ b/engines/instance_verification/lib/instance_verification/engine.rb
@@ -1,25 +1,75 @@
+require 'base64'
 require 'fileutils'
 
 module InstanceVerification
-  def self.update_cache(remote_ip, system_login, product_id, registry: false)
-    # TODO: BYOS scenario
-    # to be addressed on a different PR
+  def self.update_cache(cache_entry, mode, registry: false)
     unless registry
-      InstanceVerification.write_cache_file(
-        Rails.application.config.repo_cache_dir,
-        [remote_ip, system_login, product_id].join('-')
-      )
+      cache_path = InstanceVerification.get_cache_path(mode)
+      InstanceVerification.write_cache_file(cache_path, cache_entry)
     end
 
+    # update the registry cache every time
     InstanceVerification.write_cache_file(
-      Rails.application.config.registry_cache_dir,
-      [remote_ip, system_login].join('-')
+      InstanceVerification.get_cache_path('registry'),
+      cache_entry
     )
+  end
+
+  def self.build_cache_entry(remote_ip, system_login, encoded_reg_code, mode, product)
+    if mode == 'payg'
+      [remote_ip, system_login, product.id].join('-')
+    elsif mode == 'registry'
+      [remote_ip, system_login].join('-')
+    else
+      # for byos or hybrid cache
+      product_hash = product.attributes.symbolize_keys.slice(:identifier, :version, :arch)
+      product_triplet = "#{product_hash[:identifier]}_#{product_hash[:version]}_#{product_hash[:arch]}"
+      "#{encoded_reg_code}-#{product_triplet}-active"
+    end
   end
 
   def self.write_cache_file(cache_dir, cache_key)
     FileUtils.mkdir_p(cache_dir)
     FileUtils.touch(File.join(cache_dir, cache_key))
+    Rails.logger.info "#{cache_dir} updated for #{cache_key}"
+  end
+
+  def self.get_cache_path(mode)
+    if mode == 'byos'
+      Rails.application.config.repo_byos_cache_dir
+    elsif mode == 'hybrid'
+      Rails.application.config.repo_hybrid_cache_dir
+    elsif mode == 'payg'
+      Rails.application.config.repo_payg_cache_dir
+    else
+      Rails.application.config.registry_cache_dir
+    end
+  end
+
+  def self.get_cache_entries(mode)
+    cache_path = InstanceVerification.get_cache_path(mode)
+    Dir.children(cache_path)
+  rescue SystemCallError
+    Rails.logger.info "#{cache_path} does not exist"
+    []
+  end
+
+  def self.reg_code_in_cache?(cache_key, mode)
+    cache_entries = InstanceVerification.get_cache_entries(mode)
+    cache_entries.find { |cache_entry| cache_entry.include?(cache_key) }
+  end
+
+  def self.remove_entry_from_cache(cache_key, mode)
+    cache_path = InstanceVerification.get_cache_path(mode)
+    full_path_cache_key = File.join(cache_path, cache_key)
+    File.unlink(full_path_cache_key) if File.exist?(full_path_cache_key)
+  end
+
+  def self.set_cache_inactive(cache_key, mode)
+    InstanceVerification.remove_entry_from_cache(cache_key, mode)
+    *all, _ = cache_key.split('-')
+    cache_key = [all, 'inactive'].join('-')
+    InstanceVerification.update_cache(cache_key, mode)
   end
 
   class Engine < ::Rails::Engine
@@ -100,7 +150,8 @@ module InstanceVerification
             )
           end
           logger.info "Product #{@product.product_string} available for this instance"
-          InstanceVerification.update_cache(request.remote_ip, @system.login, product.id)
+          cache_key = InstanceVerification.build_cache_entry(request.remote_ip, @system.login, nil, 'payg', product)
+          InstanceVerification.update_cache(cache_key, 'payg')
         end
 
         def verify_base_product_activation(product)
@@ -112,7 +163,16 @@ module InstanceVerification
           )
 
           raise 'Unspecified error' unless verification_provider.instance_valid?
-          InstanceVerification.update_cache(request.remote_ip, @system.login, product.id)
+
+          encoded_reg_code = @system.pubcloud_reg_code
+          # we use the token sent from the client if present
+          # instead of the value stored in the DB
+          encoded_reg_code = Base64.strict_encode64(params[:token]) if params[:token].present?
+
+          cache_key = InstanceVerification.build_cache_entry(
+            request.remote_ip, @system.login, encoded_reg_code, @system.proxy_byos_mode, product
+          )
+          InstanceVerification.update_cache(cache_key, @system.proxy_byos_mode)
         end
 
         # Verify that the base product doesn't change in the offline migration

--- a/engines/instance_verification/spec/requests/api/connect/v3/systems/products_controller_spec.rb
+++ b/engines/instance_verification/spec/requests/api/connect/v3/systems/products_controller_spec.rb
@@ -1,3 +1,4 @@
+require 'base64'
 require 'rails_helper'
 
 # rubocop:disable RSpec/NestedGroups
@@ -10,11 +11,19 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
   let(:product) { FactoryBot.create(:product, :product_sles, :with_mirrored_repositories, :with_mirrored_extensions) }
   let(:product_sap) { FactoryBot.create(:product, :product_sles_sap, :with_mirrored_repositories, :with_mirrored_extensions) }
   let(:scc_activate_url) { 'https://scc.suse.com/connect/systems/products' }
-  let(:payload) do
+  let(:expected_payload) do
     {
       identifier: product.identifier,
       version: product.version,
       arch: product.arch
+    }
+  end
+  let(:payload) do
+    {
+      identifier: product.identifier,
+      version: product.version,
+      arch: product.arch,
+      token: 'super_reg_code'
     }
   end
 
@@ -38,11 +47,38 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
 
         it 'class instance verification provider' do
           expect(InstanceVerification::Providers::Example).to receive(:new)
-            .with(be_a(ActiveSupport::Logger), be_a(ActionDispatch::Request), payload, nil).and_call_original.at_least(:once)
-          allow(File).to receive(:directory?)
+            .with(be_a(ActiveSupport::Logger), be_a(ActionDispatch::Request), expected_payload, nil).and_call_original.at_least(:once)
           allow(Dir).to receive(:mkdir)
           allow(FileUtils).to receive(:touch)
           post url, params: payload, headers: headers
+        end
+      end
+
+      context "when system doesn't have hw_info and cache is inactive" do
+        let(:system) { FactoryBot.create(:system, :byos, pubcloud_reg_code: Base64.strict_encode64('super_token')) }
+
+        before do
+          stub_request(:post, 'https://scc.suse.com/connect/systems/products')
+            .to_return(
+              status: 201,
+              body: { ok: 'ok' }.to_json,
+              headers: {}
+            )
+        end
+
+        it 'class instance verification provider' do
+          expect(InstanceVerification::Providers::Example).to receive(:new)
+            .with(be_a(ActiveSupport::Logger), be_a(ActionDispatch::Request), expected_payload, nil).and_call_original.at_least(:once)
+          allow(File).to receive(:directory?)
+          allow(Dir).to receive(:mkdir)
+          allow(Dir).to receive(:children)
+          allow(FileUtils).to receive(:touch)
+          allow(InstanceVerification).to receive(:reg_code_in_cache?).and_return(
+            "#{system.pubcloud_reg_code}-inactive"
+          )
+          post url, params: payload, headers: headers
+          expect(response.body).to include('Subscription inactive')
+          expect(response).to have_http_status(403)
         end
       end
 
@@ -94,10 +130,14 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
 
         context 'when verification provider raises an unhandled exception' do
           before do
+            allow(plugin_double).to receive(:allowed_extension?).and_return(true)
+            expect(InstanceVerification::Providers::Example).to receive(:new).and_return(plugin_double)
+            expect(plugin_double).to receive(:instance_valid?).and_return(false)
+            allow(InstanceVerification).to receive(:set_cache_inactive).and_return(nil)
             stub_request(:post, scc_activate_url)
             .to_return(
               status: 422,
-              body: { error: 'Unexpected instance verification error has occurred' }.to_json,
+              body: { error: 'aUnexpected instance verification error has occurred' }.to_json,
               headers: {}
             )
 
@@ -118,7 +158,7 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
 
         it 'class instance verification provider' do
           expect(InstanceVerification::Providers::Example).to receive(:new)
-            .with(be_a(ActiveSupport::Logger), be_a(ActionDispatch::Request), payload, nil).and_call_original.at_least(:once)
+            .with(be_a(ActiveSupport::Logger), be_a(ActionDispatch::Request), expected_payload, nil).and_call_original.at_least(:once)
           allow(File).to receive(:directory?)
           allow(Dir).to receive(:mkdir)
           allow(FileUtils).to receive(:touch)
@@ -146,7 +186,7 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
         context 'when verification provider returns false' do
           before do
             expect(InstanceVerification::Providers::Example).to receive(:new)
-              .with(be_a(ActiveSupport::Logger), be_a(ActionDispatch::Request), payload, instance_data).and_return(plugin_double).at_least(:once)
+              .with(be_a(ActiveSupport::Logger), be_a(ActionDispatch::Request), expected_payload, instance_data).and_return(plugin_double).at_least(:once)
             expect(plugin_double).to receive(:instance_valid?).and_return(false)
             allow(plugin_double).to receive(:allowed_extension?).and_return(true)
             post url, params: payload, headers: headers
@@ -161,7 +201,7 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
         context 'when verification provider raises an unhandled exception' do
           before do
             expect(InstanceVerification::Providers::Example).to receive(:new)
-              .with(be_a(ActiveSupport::Logger), be_a(ActionDispatch::Request), payload, instance_data).and_return(plugin_double).at_least(:once)
+              .with(be_a(ActiveSupport::Logger), be_a(ActionDispatch::Request), expected_payload, instance_data).and_return(plugin_double).at_least(:once)
             expect(plugin_double).to receive(:instance_valid?).and_raise('Custom plugin error')
             allow(plugin_double).to receive(:allowed_extension?).and_return(true)
             post url, params: payload, headers: headers
@@ -178,7 +218,7 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
 
           before do
             expect(InstanceVerification::Providers::Example).to receive(:new)
-              .with(be_a(ActiveSupport::Logger), be_a(ActionDispatch::Request), payload, instance_data).and_return(plugin_double).at_least(:once)
+              .with(be_a(ActiveSupport::Logger), be_a(ActionDispatch::Request), expected_payload, instance_data).and_return(plugin_double).at_least(:once)
             expect(plugin_double).to receive(:instance_valid?).and_raise(InstanceVerification::Exception, 'Custom plugin error')
             allow(plugin_double).to receive(:allowed_extension?).and_return(true)
             post url, params: payload, headers: headers
@@ -276,7 +316,13 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
         let(:instance_data) { 'dummy_instance_data' }
         let(:system) do
           FactoryBot.create(
-            :system, :payg, :with_system_information, :with_activated_product, product: base_product, instance_data: instance_data
+            :system,
+            :payg,
+            :with_system_information,
+            :with_activated_product,
+            product: base_product,
+            instance_data: instance_data,
+            pubcloud_reg_code: Base64.strict_encode64('super_token_different')
           )
         end
         let(:serialized_service_json) do
@@ -287,7 +333,7 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
         end
         let(:scc_activate_url) { 'https://scc.suse.com/connect/systems/products' }
         let(:plugin_double) { instance_double('InstanceVerification::Providers::Example') }
-        let(:payload_no_token) do
+        let(:payload_token) do
           {
             identifier: product.identifier,
             version: product.version,
@@ -344,6 +390,11 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
               'User-Agent' => 'Ruby'
             }
           end
+          let(:cache_entry) do
+            product_hash = product.attributes.symbolize_keys.slice(:identifier, :version, :arch)
+            product_triplet = "#{product_hash[:identifier]}_#{product_hash[:version]}_#{product_hash[:arch]}"
+            "#{Base64.strict_encode64(payload_token[:token])}-#{product_triplet}-active"
+          end
 
           before do
             allow(InstanceVerification::Providers::Example).to receive(:new).and_return(plugin_double)
@@ -351,7 +402,10 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
             allow(plugin_double).to receive(:parse_instance_data).and_return({ InstanceId: 'foo' })
             allow(plugin_double).to receive(:allowed_extension?).and_return(true)
 
-            allow(InstanceVerification).to receive(:update_cache).with('127.0.0.1', system.login, product.id)
+            allow(InstanceVerification).to receive(:update_cache).with("127.0.0.1-#{system.login}-#{product.id}", 'payg')
+            allow(InstanceVerification).to receive(:get_cache_entries).and_return(
+              [File.join(Rails.application.config.repo_hybrid_cache_dir, cache_entry)]
+            )
             FactoryBot.create(:subscription, product_classes: product_classes)
             stub_request(:post, scc_activate_url)
               .to_return(
@@ -365,14 +419,18 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
               .with({ headers: scc_announce_headers, body: scc_annouce_body.to_json })
               .to_return(status: 201, body: scc_response_body, headers: {})
 
-            expect(InstanceVerification).to receive(:update_cache).with('127.0.0.1', system.login, product.id)
+            expect(InstanceVerification).to receive(:update_cache).with(cache_entry, 'hybrid')
 
-            post url, params: payload_no_token, headers: headers
+            post url, params: payload_token, headers: headers
           end
 
           context 'when regcode is provided' do
             it 'returns service JSON' do
               expect(response.body).to eq(serialized_service_json)
+              updated_system = System.find_by(login: system.login)
+              expect(updated_system.pubcloud_reg_code).to include(',')
+              expect(updated_system.pubcloud_reg_code).to include(Base64.strict_encode64(payload_token[:token]).to_s)
+              expect(updated_system.pubcloud_reg_code).to include(system.pubcloud_reg_code)
             end
           end
         end
@@ -392,7 +450,7 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
             allow(plugin_double).to receive(:parse_instance_data).and_return({ InstanceId: 'foo' })
             allow(plugin_double).to receive(:allowed_extension?).and_return(true)
 
-            allow(InstanceVerification).to receive(:update_cache).with('127.0.0.1', system.login, product.id)
+            allow(InstanceVerification).to receive(:update_cache).with("127.0.0.1-#{system.login}-#{product.id}", 'foo')
             FactoryBot.create(:subscription, product_classes: product_classes)
             stub_request(:post, scc_activate_url)
               .to_return(
@@ -405,9 +463,9 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
             stub_request(:post, 'https://scc.suse.com/connect/subscriptions/systems')
               .to_return(status: 201, body: scc_response_body, headers: {})
 
-            expect(InstanceVerification).not_to receive(:update_cache).with('127.0.0.1', system.login, product.id)
+            expect(InstanceVerification).not_to receive(:update_cache) # .with('127.0.0.1', system.login, product.id)
             allow(plugin_double).to receive(:allowed_extension?).and_return(true)
-            post url, params: payload_no_token, headers: headers
+            post url, params: payload_token, headers: headers
           end
 
           it 'returns service JSON' do
@@ -455,7 +513,7 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
         context 'when verification provider returns false' do
           before do
             expect(InstanceVerification::Providers::Example).to receive(:new)
-              .with(be_a(ActiveSupport::Logger), be_a(ActionDispatch::Request), payload, instance_data).and_return(plugin_double).at_least(:once)
+              .with(be_a(ActiveSupport::Logger), be_a(ActionDispatch::Request), expected_payload, instance_data).and_return(plugin_double).at_least(:once)
             allow(plugin_double).to receive(:allowed_extension?).and_return(true)
             expect(plugin_double).to receive(:instance_valid?).and_return(false)
             post url, params: payload, headers: headers
@@ -470,7 +528,7 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
         context 'when verification provider raises an unhandled exception' do
           before do
             expect(InstanceVerification::Providers::Example).to receive(:new)
-              .with(be_a(ActiveSupport::Logger), be_a(ActionDispatch::Request), payload, instance_data).and_return(plugin_double).at_least(:once)
+              .with(be_a(ActiveSupport::Logger), be_a(ActionDispatch::Request), expected_payload, instance_data).and_return(plugin_double).at_least(:once)
             allow(plugin_double).to receive(:allowed_extension?).and_return(true)
             expect(plugin_double).to receive(:instance_valid?).and_raise('Custom plugin error')
             post url, params: payload, headers: headers

--- a/engines/instance_verification/spec/requests/api/connect/v3/systems/products_controller_spec.rb
+++ b/engines/instance_verification/spec/requests/api/connect/v3/systems/products_controller_spec.rb
@@ -137,7 +137,7 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
             stub_request(:post, scc_activate_url)
             .to_return(
               status: 422,
-              body: { error: 'aUnexpected instance verification error has occurred' }.to_json,
+              body: { error: 'Unexpected instance verification error has occurred' }.to_json,
               headers: {}
             )
 

--- a/engines/registry/lib/registry/engine.rb
+++ b/engines/registry/lib/registry/engine.rb
@@ -1,10 +1,8 @@
 module Registry
+  # rubocop:disable Lint/EmptyClass
   class << self
-    def remove_auth_cache(registry_cache_key)
-      cache_path = File.join(Rails.application.config.registry_cache_dir, registry_cache_key)
-      File.unlink(cache_path) if File.exist?(cache_path)
-    end
   end
+  # rubocop:enable Lint/EmptyClass
 
   class Engine < ::Rails::Engine
     isolate_namespace Registry
@@ -27,8 +25,8 @@ module Registry
         before_action :remove_auth_cache, only: %w[deregister]
 
         def remove_auth_cache
-          registry_cache_key = [request.remote_ip, @system.login].join('-')
-          Registry.remove_auth_cache(registry_cache_key)
+          registry_cache_key = InstanceVerification.build_cache_entry(request.remote_ip, @system.login, @system.pubcloud_reg_code, 'registry', nil)
+          InstanceVerification.remove_entry_from_cache(registry_cache_key, 'registry')
         end
       end
     end

--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -133,6 +133,10 @@ module SccProxy
       scc_request = prepare_scc_request(uri.path, product, auth, params, mode)
       response = http.request(scc_request)
       unless response.code_type == Net::HTTPCreated
+        # if product can not be activated
+        # set the registration code as invalid in the cache
+        cache_key = InstanceVerification.build_cache_entry(nil, nil, Base64.strict_encode64(params[:token]), mode, product)
+        InstanceVerification.set_cache_inactive(cache_key, mode)
         error = JSON.parse(response.body)
         Rails.logger.info "Could not activate #{product.product_string}, error: #{error['error']} #{response.code}"
         error['error'] = SccProxy.parse_error(error['error']) if error['error'].include? 'json'
@@ -325,6 +329,7 @@ module SccProxy
 
         protected
 
+        # rubocop:disable Metrics/PerceivedComplexity
         def scc_activate_product
           product_hash = @product.attributes.symbolize_keys.slice(:identifier, :version, :arch)
           unless InstanceVerification.provider.new(logger, request, product_hash, @system.instance_data).allowed_extension?
@@ -334,22 +339,42 @@ module SccProxy
           end
           mode = find_mode
           unless mode.nil?
-            # if system is byos or hybrid and there is a token
-            # make a request to SCC
-            logger.info "Activating product #{@product.product_string} to SCC"
-            logger.info 'No token provided' if params[:token].blank?
-            SccProxy.scc_activate_product(
-              @system, @product, request.headers['HTTP_AUTHORIZATION'], params, mode
+            # check cache first
+            encoded_reg_code = Base64.strict_encode64(params[:token])
+            cache_entry = InstanceVerification.build_cache_entry(
+              request.remote_ip, @system.login, encoded_reg_code, mode, @product
             )
-            # if the system is PAYG and the registration code is valid for the extension,
-            # then the system is hybrid
-            # update the system to HYBRID mode if HYBRID MODE and system not HYBRID already
-            @system.hybrid! if mode == 'hybrid' && @system.payg?
-
-            logger.info "Product #{@product.product_string} successfully activated with SCC"
-            InstanceVerification.update_cache(request.remote_ip, @system.login, @product.id)
+            found_cache_entry = InstanceVerification.reg_code_in_cache?(cache_entry, mode)
+            if found_cache_entry.present? && found_cache_entry.include?('-inactive')
+              error = ActionController::TranslatedError.new(N_('Subscription inactive'))
+              error.status = :forbidden
+              raise error
+            elsif found_cache_entry.blank?
+              # if system is byos or hybrid and
+              # there is a token
+              # and not found in the cache
+              # make a request to SCC
+              logger.info "Activating product #{@product.product_string} to SCC"
+              logger.info 'No token provided' if params[:token].blank?
+              SccProxy.scc_activate_product(
+                @system, @product, request.headers['HTTP_AUTHORIZATION'], params, mode
+              )
+              logger.info "Product #{@product.product_string} successfully activated with SCC"
+              # if the system is PAYG and the registration code is valid for the extension,
+              # then the system is hybrid
+              # update the system to HYBRID mode if HYBRID MODE and system not HYBRID already
+              @system.hybrid! if mode == 'hybrid' && @system.payg?
+            end
+            InstanceVerification.update_cache(cache_entry, mode)
+            if @system.pubcloud_reg_code.present? && @system.pubcloud_reg_code != encoded_reg_code
+              combination_reg_code = @system.pubcloud_reg_code + ',' + encoded_reg_code
+              @system.update(pubcloud_reg_code: combination_reg_code)
+            elsif @system.pubcloud_reg_code.nil?
+              @system.update(pubcloud_reg_code: encoded_reg_code)
+            end
           end
         end
+        # rubocop:enable Metrics/PerceivedComplexity
 
         def find_mode
           if @system.byos?

--- a/engines/strict_authentication/spec/requests/services_controller_spec.rb
+++ b/engines/strict_authentication/spec/requests/services_controller_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe ServicesController, type: :request do
   describe '#show' do
-    let(:system) { FactoryBot.create(:system) }
+    let(:system) { FactoryBot.create(:system, :payg) }
     let(:service) { FactoryBot.create(:service, :with_repositories) }
     let(:activated_service) do
       service = FactoryBot.create(:service, :with_repositories)
@@ -61,6 +61,7 @@ RSpec.describe ServicesController, type: :request do
             allow(File).to receive(:directory?)
             allow(Dir).to receive(:mkdir)
             allow(FileUtils).to receive(:touch)
+            allow(InstanceVerification).to receive(:reg_code_in_cache?).and_return(nil)
             allow(InstanceVerification).to receive(:update_cache)
             get "/services/#{activated_service.id}", headers: headers
           end
@@ -80,6 +81,7 @@ RSpec.describe ServicesController, type: :request do
         allow(File).to receive(:directory?)
         allow(Dir).to receive(:mkdir)
         allow(FileUtils).to receive(:touch)
+        allow(InstanceVerification).to receive(:reg_code_in_cache?).and_return(nil)
         allow(InstanceVerification).to receive(:update_cache)
         get "/services/#{activated_service.id}", headers: headers
       end

--- a/engines/strict_authentication/spec/requests/strict_authentication/authentication_controller_spec.rb
+++ b/engines/strict_authentication/spec/requests/strict_authentication/authentication_controller_spec.rb
@@ -26,6 +26,7 @@ module StrictAuthentication
             allow_any_instance_of(InstanceVerification::Providers::Example).to(
               receive(:instance_valid?).and_return(true)
             )
+            allow(InstanceVerification).to receive(:reg_code_in_cache?).and_return(nil)
             allow(InstanceVerification).to receive(:update_cache)
             get '/api/auth/check', headers: auth_header.merge({ 'X-Original-URI': requested_uri, 'X-Instance-Data': 'IMDS' })
             allow(File).to receive(:directory?)

--- a/engines/zypper_auth/spec/requests/api/connect/v3/systems/activations_controller_spec.rb
+++ b/engines/zypper_auth/spec/requests/api/connect/v3/systems/activations_controller_spec.rb
@@ -1,46 +1,121 @@
 require 'rails_helper'
 
-describe Api::Connect::V3::Systems::ActivationsController, type: :request do
+describe ServicesController do
   include_context 'auth header', :system, :login, :password
-  include_context 'version header', 3
 
-  describe '#activations' do
+  before { Rails.cache.clear }
+
+  describe '#show' do
+    subject(:xml_urls) do
+      doc = Nokogiri::XML::Document.parse(response.body)
+      repo_items = doc.xpath('/repoindex/repo')
+      repo_items.map { |r| r.attr(:url) }
+    end
+
     let(:system) { FactoryBot.create(:system, :with_activated_product) }
-    let(:headers) { auth_header.merge(version_header) }
+    let(:service) { system.products.first.service }
 
-    before do
-      allow_any_instance_of(InstanceVerification::Providers::Example).to receive(:instance_valid?).and_return(true)
-      allow(InstanceVerification).to receive(:update_cache)
-      get '/connect/systems/activations', headers: headers
-    end
+    context 'without X-Instance-Data header' do
+      let(:headers) { auth_header }
 
-    context 'without X-Instance-Data headers or hw_info' do
-      it 'has service URLs with HTTP scheme' do
-        data = JSON.parse(response.body)
-        expect(data[0]['service']['url']).to match(%r{^plugin:/susecloud})
-        expect_any_instance_of(InstanceVerification::Providers::Example).not_to receive(:instance_valid?)
-        expect(InstanceVerification).not_to receive(:update_cache)
+      before do
+        Thread.current[:logger] = RMT::Logger.new('/dev/null')
+        allow(File).to receive(:directory?)
+        allow(FileUtils).to receive(:mkdir_p)
+        allow(FileUtils).to receive(:touch)
+        get "/services/#{service.id}", headers: headers
+      end
+
+      it 'repo URLs have http scheme' do
+        expect(xml_urls).to all(match(%r{^http://}))
       end
     end
 
-    context 'with instance_data in hw_info' do
-      let(:system) { FactoryBot.create(:system, :with_activated_product, :with_system_information, instance_data: '<repoformat>plugin:susecloud</repoformat>') }
+    context 'with X-Instance-Data header' do
+      let(:headers) { auth_header.merge('X-Instance-Data' => 'test') }
 
-      it 'has service URLs with HTTP scheme' do
-        data = JSON.parse(response.body)
-        expect(data[0]['service']['url']).to match(%r{^plugin:/susecloud})
-        expect_any_instance_of(InstanceVerification::Providers::Example).not_to receive(:instance_valid?)
-        expect(InstanceVerification).not_to receive(:update_cache)
+      context 'when instance verification succeeds' do
+        before do
+          expect_any_instance_of(InstanceVerification::Providers::Example).to receive(:instance_valid?).and_return(true)
+          allow(InstanceVerification).to receive(:reg_code_in_cache?).and_return(nil)
+          allow(InstanceVerification).to receive(:update_cache)
+          allow(File).to receive(:directory?)
+          allow(Dir).to receive(:mkdir)
+          allow(FileUtils).to receive(:touch)
+          get "/services/#{service.id}", headers: headers
+        end
+
+        it 'request succeeds' do
+          expect(response).to have_http_status(200)
+        end
+
+        it 'XML has all product repos' do
+          expect(xml_urls.size).to eq(system.products.first.repositories.size - 1)
+        end
+
+        it 'repo URLs have plugin:/susecloud scheme' do
+          expect(xml_urls).to all(match(%r{^plugin:/susecloud}))
+        end
       end
-    end
 
-    context 'with X-Instance-Data headers' do
-      let(:headers) { auth_header.merge(version_header).merge({ 'X-Instance-Data' => 'instance_data' }) }
+      context 'when instance verification returns false' do
+        before do
+          expect_any_instance_of(InstanceVerification::Providers::Example).to receive(:instance_valid?).and_return(false)
+          allow(InstanceVerification).to receive(:update_cache)
+          allow(InstanceVerification).to receive(:reg_code_in_cache?).and_return(nil)
+          allow(File).to receive(:directory?)
+          allow(Dir).to receive(:mkdir)
+          allow(FileUtils).to receive(:touch)
+          get "/services/#{service.id}", headers: headers
+        end
 
-      it 'has service URLs with HTTP scheme' do
-        allow(File).to receive(:exist?).and_return(true)
-        data = JSON.parse(response.body)
-        expect(data[0]['service']['url']).to match(%r{^plugin:/susecloud})
+        it 'request fails with 403' do
+          expect(response).to have_http_status(403)
+        end
+
+        it 'reports an error' do
+          expect(response.body).to match(/Instance verification failed/)
+        end
+      end
+
+      context 'when instance verification raises StandardError' do
+        before do
+          expect_any_instance_of(InstanceVerification::Providers::Example).to receive(:instance_valid?).and_raise('Test')
+          allow(InstanceVerification).to receive(:update_cache)
+          allow(InstanceVerification).to receive(:reg_code_in_cache?).and_return(nil)
+          allow(File).to receive(:directory?)
+          allow(Dir).to receive(:mkdir)
+          allow(FileUtils).to receive(:touch)
+          get "/services/#{service.id}", headers: headers
+        end
+
+        it 'request fails with 403' do
+          expect(response).to have_http_status(403)
+        end
+
+        it 'reports an error' do
+          expect(response.body).to match(/Instance verification failed/)
+        end
+      end
+
+      context 'when instance verification raises InstanceVerification::Exception' do
+        before do
+          expect_any_instance_of(InstanceVerification::Providers::Example).to receive(:instance_valid?).and_raise(InstanceVerification::Exception, 'Test')
+          allow(File).to receive(:directory?).twice
+          allow(InstanceVerification).to receive(:reg_code_in_cache?).and_return(nil)
+          allow(File).to receive(:directory?)
+          allow(Dir).to receive(:mkdir)
+          allow(FileUtils).to receive(:touch)
+          get "/services/#{service.id}", headers: headers
+        end
+
+        it 'request fails with 403' do
+          expect(response).to have_http_status(403)
+        end
+
+        it 'reports an error' do
+          expect(response.body).to match(/Instance verification failed/)
+        end
       end
     end
   end

--- a/engines/zypper_auth/spec/requests/services_controller_spec.rb
+++ b/engines/zypper_auth/spec/requests/services_controller_spec.rb
@@ -37,6 +37,7 @@ describe ServicesController do
       context 'when instance verification succeeds' do
         before do
           expect_any_instance_of(InstanceVerification::Providers::Example).to receive(:instance_valid?).and_return(true)
+          allow(InstanceVerification).to receive(:reg_code_in_cache?).and_return(nil)
           allow(InstanceVerification).to receive(:update_cache)
           allow(File).to receive(:directory?)
           allow(Dir).to receive(:mkdir)
@@ -61,6 +62,7 @@ describe ServicesController do
         before do
           expect_any_instance_of(InstanceVerification::Providers::Example).to receive(:instance_valid?).and_return(false)
           allow(InstanceVerification).to receive(:update_cache)
+          allow(InstanceVerification).to receive(:reg_code_in_cache?).and_return(nil)
           allow(File).to receive(:directory?)
           allow(Dir).to receive(:mkdir)
           allow(FileUtils).to receive(:touch)
@@ -80,6 +82,7 @@ describe ServicesController do
         before do
           expect_any_instance_of(InstanceVerification::Providers::Example).to receive(:instance_valid?).and_raise('Test')
           allow(InstanceVerification).to receive(:update_cache)
+          allow(InstanceVerification).to receive(:reg_code_in_cache?).and_return(nil)
           allow(File).to receive(:directory?)
           allow(Dir).to receive(:mkdir)
           allow(FileUtils).to receive(:touch)
@@ -99,6 +102,7 @@ describe ServicesController do
         before do
           expect_any_instance_of(InstanceVerification::Providers::Example).to receive(:instance_valid?).and_raise(InstanceVerification::Exception, 'Test')
           allow(File).to receive(:directory?).twice
+          allow(InstanceVerification).to receive(:reg_code_in_cache?).and_return(nil)
           allow(File).to receive(:directory?)
           allow(Dir).to receive(:mkdir)
           allow(FileUtils).to receive(:touch)

--- a/engines/zypper_auth/spec/requests/strict_authentication/authentication_controller_spec.rb
+++ b/engines/zypper_auth/spec/requests/strict_authentication/authentication_controller_spec.rb
@@ -37,6 +37,7 @@ describe StrictAuthentication::AuthenticationController, type: :request do
         let(:headers) { auth_header.merge({ 'X-Original-URI': requested_uri, 'X-Instance-Data': 'test' }) }
 
         before do
+          allow(InstanceVerification).to receive(:reg_code_in_cache?).and_return(nil)
           Rails.cache.clear
           expect_any_instance_of(InstanceVerification::Providers::Example).to receive(:instance_valid?).and_return(false)
           allow(File).to receive(:directory?)
@@ -278,6 +279,7 @@ describe StrictAuthentication::AuthenticationController, type: :request do
         before do
           Rails.cache.clear
           expect_any_instance_of(InstanceVerification::Providers::Example).to receive(:instance_valid?).and_return(true)
+          allow(InstanceVerification).to receive(:reg_code_in_cache?).and_return(nil)
           allow(InstanceVerification).to receive(:update_cache)
           allow(DataExport::Handlers::Example).to receive(:new).and_return(data_export_double)
           allow(File).to receive(:directory?)
@@ -501,6 +503,7 @@ describe StrictAuthentication::AuthenticationController, type: :request do
             let(:data_export_double) { instance_double('DataExport::Handlers::Example') }
 
             before do
+              allow(InstanceVerification).to receive(:reg_code_in_cache?).and_return(nil)
               allow(DataExport::Handlers::Example).to receive(:new).and_return(data_export_double)
               expect_any_instance_of(InstanceVerification::Providers::Example).to receive(:instance_valid?).and_return(true)
               expect(data_export_double).to receive(:export_rmt_data)


### PR DESCRIPTION
## Description

When a BYOS or HYBRID system activates a product with SCC we check first if the registration code use for that activation is in the cache for that product

If there is a match in the cache and the registration code is active we do not reach to SCC, update the cache and update the system pubcloud_reg_code if reg code is new or different

If there is no match in the cache we call SCC, update the cache and update the system pubcloud_reg_code if it's new or different

If the registration code is inactive, we do not follow with the activation

There is also the registry cache handling logic included

* Related Issue / Ticket / Trello card: <link reference>

## How to test 

Trying to activate a product on a BYOS instance within the cache being valid should not reach to SCC
Trying to activate a product on a BYOS instance when the cache expired should reach to SCC

## Change Type

*Please select the correct option.*

- [ ] **Bug Fix** (a non-breaking change which fixes an issue)
- [X] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

