### PR TITLE
Do not log FATAL when routing error

### DIFF
--- a/config/initializers/routing_error_logger.rb
+++ b/config/initializers/routing_error_logger.rb
@@ -1,0 +1,13 @@
+module ActionDispatch
+  class DebugExceptions
+    alias old_log_error log_error
+
+    def log_error(request, wrapper)
+      if wrapper.exception.is_a? ActionController::RoutingError
+        logger(request).send(:warn, "[404] ActionController::RoutingError (#{wrapper.exception.message})")
+      else
+        old_log_error request, wrapper
+      end
+    end
+  end
+end

--- a/engines/strict_authentication/spec/requests/strict_authentication/authentication_controller_spec.rb
+++ b/engines/strict_authentication/spec/requests/strict_authentication/authentication_controller_spec.rb
@@ -190,6 +190,30 @@ module StrictAuthentication
           end
         end
       end
+
+      context 'wrong url' do
+        let(:my_exception) { ActionController::RoutingError.new('foo') }
+        let(:request) { ActionDispatch::TestRequest.new('a') }
+
+        it 'logs a warning' do
+          ActionDispatch::DebugExceptions.new('foo').log_error(request, my_exception)
+        end
+      end
+
+      context 'OK url' do
+        let(:request) { ActionDispatch::TestRequest.new('a') }
+        let(:my_exception) { ActionController::ParameterMissing.new('standard') }
+        let(:wrapper) do
+          ActionDispatch::ExceptionWrapper.new(
+            request.get_header('action_dispatch.backtrace_cleaner'),
+            my_exception
+          )
+        end
+
+        it 'logs error' do
+          ActionDispatch::DebugExceptions.new('foo').log_error(request, wrapper)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Description

This Fixes #1300

* Related Issue / Ticket / Trello card: #1300 

## How to test 

Try a non existing route and the RMT log should not have FATAL for that query

## Change Type

*Please select the correct option.*

- [ ] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

