### PR TITLE
Move verify_instance from ZypperAuth to InstanceVerification class

### DIFF
--- a/engines/instance_verification/lib/instance_verification/engine.rb
+++ b/engines/instance_verification/lib/instance_verification/engine.rb
@@ -78,7 +78,7 @@ module InstanceVerification
     base_product = system.products.find_by(product_type: 'base')
     return false unless base_product
 
-    # check the cache for the system (20 min)
+    # check the cache for the system
     cache_key = InstanceVerification.build_cache_entry(request.remote_ip, system.login, system.pubcloud_reg_code, system.proxy_byos_mode, base_product)
     if InstanceVerification.reg_code_in_cache?(cache_key, system.proxy_byos_mode)
       # only update registry cache key

--- a/engines/registry/lib/registry/engine.rb
+++ b/engines/registry/lib/registry/engine.rb
@@ -15,7 +15,7 @@ module Registry
         before_action :refresh_auth_cache, only: %w[index], if: -> { request.headers['X-Instance-Data'] }
 
         def refresh_auth_cache
-          unless ZypperAuth.verify_instance(request, logger, @system)
+          unless InstanceVerification.verify_instance(request, logger, @system)
             render(xml: { error: 'Instance verification failed' }, status: :forbidden)
           end
         end

--- a/engines/registry/spec/requests/api/connect/v3/systems/activations_controller_spec.rb
+++ b/engines/registry/spec/requests/api/connect/v3/systems/activations_controller_spec.rb
@@ -33,7 +33,7 @@ describe Api::Connect::V3::Systems::ActivationsController, type: :request do
               receive(:instance_valid?)
                 .and_raise(InstanceVerification::Exception, 'Custom plugin error')
               )
-            allow(ZypperAuth).to receive(:verify_instance).and_call_original
+            allow(InstanceVerification).to receive(:verify_instance).and_call_original
             get '/connect/systems/activations', headers: headers
             expect(response.body).to include('Instance verification failed')
             expect(InstanceVerification).not_to receive(:update_cache)
@@ -48,7 +48,7 @@ describe Api::Connect::V3::Systems::ActivationsController, type: :request do
         before do
           allow(File).to receive(:join).and_call_original
           allow(InstanceVerification).to receive(:update_cache)
-          allow(ZypperAuth).to receive(:verify_instance).and_call_original
+          allow(InstanceVerification).to receive(:verify_instance).and_call_original
           headers['X-Instance-Data'] = 'IMDS'
         end
 
@@ -98,7 +98,7 @@ describe Api::Connect::V3::Systems::ActivationsController, type: :request do
             receive(:instance_valid?).and_return(true)
             )
           allow(InstanceVerification).to receive(:update_cache)
-          allow(ZypperAuth).to receive(:verify_instance).and_call_original
+          allow(InstanceVerification).to receive(:verify_instance).and_call_original
           stub_request(:get, scc_systems_activations_url).to_return(status: 200, body: [body_active].to_json, headers: {})
           headers['X-Instance-Data'] = 'IMDS'
         end
@@ -255,7 +255,7 @@ describe Api::Connect::V3::Systems::ActivationsController, type: :request do
               )
             allow(InstanceVerification).to receive(:reg_code_in_cache?).and_return(nil)
             stub_request(:get, scc_systems_activations_url).to_return(status: 200, body: [body_active].to_json, headers: {})
-            allow(ZypperAuth).to receive(:verify_instance).and_call_original
+            allow(InstanceVerification).to receive(:verify_instance).and_call_original
             expect(InstanceVerification).to receive(:update_cache).with("#{system.pubcloud_reg_code}-#{product_triplet}-active", 'byos')
             get '/connect/systems/activations', headers: headers
 
@@ -292,7 +292,7 @@ describe Api::Connect::V3::Systems::ActivationsController, type: :request do
               )
             allow(InstanceVerification).to receive(:reg_code_in_cache?).and_return(nil)
             allow(SccProxy).to receive(:scc_check_subscription_expiration).and_return(scc_response)
-            allow(ZypperAuth).to receive(:verify_instance).and_call_original
+            allow(InstanceVerification).to receive(:verify_instance).and_call_original
             expect(InstanceVerification).to receive(:update_cache).with("#{system.pubcloud_reg_code}-#{product_triplet}-inactive", 'byos')
             get '/connect/systems/activations', headers: headers
 

--- a/engines/zypper_auth/lib/zypper_auth/engine.rb
+++ b/engines/zypper_auth/lib/zypper_auth/engine.rb
@@ -6,53 +6,6 @@ module ZypperAuth
       Thread.current[:logger]
     end
 
-    def verify_instance(request, logger, system)
-      return false unless request.headers['X-Instance-Data']
-
-      base_product = system.products.find_by(product_type: 'base')
-      return false unless base_product
-
-      # check the cache for the system (20 min)
-      cache_key = InstanceVerification.build_cache_entry(request.remote_ip, system.login, system.pubcloud_reg_code, system.proxy_byos_mode, base_product)
-      if InstanceVerification.reg_code_in_cache?(cache_key, system.proxy_byos_mode)
-        # only update registry cache key
-        InstanceVerification.update_cache(cache_key, system.proxy_byos_mode, registry: true)
-        return true
-      end
-
-      verification_provider = InstanceVerification.provider.new(
-        logger,
-        request,
-        base_product.attributes.symbolize_keys.slice(:identifier, :version, :arch, :release_type),
-        Base64.decode64(request.headers['X-Instance-Data'].to_s) # instance data
-      )
-
-      is_valid = verification_provider.instance_valid?
-      # update repository and registry cache
-      InstanceVerification.update_cache(cache_key, system.proxy_byos_mode)
-      is_valid
-    rescue InstanceVerification::Exception => e
-      if system.byos?
-        result = SccProxy.scc_check_subscription_expiration(request.headers, system, base_product.product_class)
-        if result[:is_active]
-          # update the cache for the base product
-          InstanceVerification.update_cache(cache_key, 'byos')
-          return true
-        end
-        # if can not get the activations, set the cache inactive
-        InstanceVerification.set_cache_inactive(cache_key, system.proxy_byos_mode)
-      end
-      ZypperAuth.zypper_auth_message(request, system, verification_provider, e.message)
-      false
-    rescue StandardError => e
-      logger.error('Unexpected instance verification error has occurred:')
-      logger.error(e.message)
-      logger.error("System login: #{system.login}, IP: #{request.remote_ip}")
-      logger.error('Backtrace:')
-      logger.error(e.backtrace)
-      false
-    end
-
     def zypper_auth_message(request, system, verification_provider, message)
       details = [ "System login: #{system.login}", "IP: #{request.remote_ip}" ]
       details << "Instance ID: #{verification_provider.instance_id}" if verification_provider.instance_id
@@ -124,7 +77,7 @@ module ZypperAuth
         # additional validation for zypper service XML controller
         before_action :verify_instance
         def verify_instance
-          unless ZypperAuth.verify_instance(request, logger, @system)
+          unless InstanceVerification.verify_instance(request, logger, @system)
             render(xml: { error: 'Instance verification failed' }, status: 403)
           end
         end
@@ -140,7 +93,7 @@ module ZypperAuth
 
           return true if @system.byos?
 
-          instance_verified = ZypperAuth.verify_instance(request, logger, @system)
+          instance_verified = InstanceVerification.verify_instance(request, logger, @system)
           DataExport.handler.new(@system, request, params, logger).export_rmt_data if instance_verified
 
           instance_verified


### PR DESCRIPTION
## Description

As agreed, the verify_instance method should be in the InstanceVerification class

Update tests

* Related Issue / Ticket / Trello card: <link reference>

## How to test 

Zypper operations should keep the same behaviour 

## Change Type

*Please select the correct option.*

- [ ] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

