### PR TITLE
Update cache key

### DIFF
--- a/engines/instance_verification/config/environments/development.rb
+++ b/engines/instance_verification/config/environments/development.rb
@@ -2,8 +2,11 @@
 module InstanceVerification
   class Application < Rails::Application
     config.cache_config_file = Rails.root.join('engines/registry/spec/data/rmt-cache-trim.sh')
-    config.repo_cache_dir = 'repo/cache'
-    config.registry_cache_dir = 'registry/cache'
+    repo_cache_base_dir = 'tmp/cache/repository'
+    config.repo_payg_cache_dir = Rails.root.join("#{repo_cache_base_dir}/payg")
+    config.repo_byos_cache_dir = Rails.root.join("#{repo_cache_base_dir}/byos")
+    config.repo_hybrid_cache_dir = Rails.root.join("#{repo_cache_base_dir}/hybrid")
+    config.registry_cache_dir = Rails.root.join('tmp/cache/registry')
   end
 end
 # :nocov:

--- a/engines/instance_verification/lib/instance_verification/engine.rb
+++ b/engines/instance_verification/lib/instance_verification/engine.rb
@@ -119,7 +119,7 @@ module InstanceVerification
 
     is_valid = verification_provider.instance_valid?
     # update repository and registry cache
-    InstanceVerification.update_cache(cache_key, system.proxy_byos_mode)
+    InstanceVerification.set_cache_active(cache_key, system.proxy_byos_mode)
     is_valid
   rescue InstanceVerification::Exception => e
     if system.byos?
@@ -247,7 +247,7 @@ module InstanceVerification
           end
           logger.info "Product #{@product.product_string} available for this instance"
           cache_key = InstanceVerification.build_cache_entry(request.remote_ip, @system.login, nil, 'payg', product)
-          InstanceVerification.update_cache(cache_key, 'payg')
+          InstanceVerification.set_cache_active(cache_key, 'payg')
         end
 
         def verify_base_product_activation(product)

--- a/engines/instance_verification/spec/requests/api/connect/v3/systems/products_controller_spec.rb
+++ b/engines/instance_verification/spec/requests/api/connect/v3/systems/products_controller_spec.rb
@@ -56,45 +56,6 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
         end
       end
 
-# <<<<<<< HEAD
-# =======
-#       context "when system doesn't have hw_info and cache is inactive" do
-#         let(:system) do
-#           FactoryBot.create(
-#             :system,
-#             :byos,
-#             pubcloud_reg_code: Base64.strict_encode64('super_token'),
-#             instance_data: 'dummy_instance_data'
-#           )
-#         end
-
-#         before do
-#           stub_request(:post, 'https://scc.suse.com/connect/systems/products')
-#             .to_return(
-#               status: 201,
-#               body: { ok: 'ok' }.to_json,
-#               headers: {}
-#             )
-#         end
-
-#         it 'class instance verification provider' do
-#           expect(InstanceVerification::Providers::Example).to(
-#             receive(:new).and_call_original.at_least(:once)
-#           )
-#           allow(File).to receive(:directory?)
-#           allow(Dir).to receive(:mkdir)
-#           allow(Dir).to receive(:children)
-#           allow(FileUtils).to receive(:touch)
-#           allow(InstanceVerification).to receive(:reg_code_in_cache?).and_return(
-#             "#{system.pubcloud_reg_code}-inactive"
-#           )
-#           post url, params: payload, headers: headers
-#           expect(response.body).to include('Subscription inactive')
-#           expect(response).to have_http_status(403)
-#         end
-#       end
-
-# >>>>>>> a9d2b4b9 (Fix linter offenses)
       context 'when system has hw_info' do
         let(:instance_data) { 'dummy_instance_data' }
         let(:system) { FactoryBot.create(:system, :byos, :with_system_information, instance_data: instance_data) }

--- a/engines/instance_verification/spec/requests/api/connect/v3/systems/products_controller_spec.rb
+++ b/engines/instance_verification/spec/requests/api/connect/v3/systems/products_controller_spec.rb
@@ -382,6 +382,8 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
           let(:active_cache_entry) { cache_entry + '-active' }
           let(:headers) { auth_header.merge('X-Instance-Data' => 'dummy_instance_data') }
 
+          let(:headers) { auth_header.merge('X-Instance-Data' => 'dummy_instance_data') }
+
           before do
             allow(InstanceVerification::Providers::Example).to receive(:new).and_return(plugin_double)
             allow(plugin_double).to receive(:instance_identifier).and_return('foo')

--- a/engines/instance_verification/spec/requests/api/connect/v3/systems/products_controller_spec.rb
+++ b/engines/instance_verification/spec/requests/api/connect/v3/systems/products_controller_spec.rb
@@ -421,8 +421,6 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
           let(:active_cache_entry) { cache_entry + '-active' }
           let(:headers) { auth_header.merge('X-Instance-Data' => 'dummy_instance_data') }
 
-          let(:headers) { auth_header.merge('X-Instance-Data' => 'dummy_instance_data') }
-
           before do
             allow(InstanceVerification::Providers::Example).to receive(:new).and_return(plugin_double)
             allow(plugin_double).to receive(:instance_identifier).and_return('foo')

--- a/engines/instance_verification/spec/requests/api/connect/v3/systems/products_controller_spec.rb
+++ b/engines/instance_verification/spec/requests/api/connect/v3/systems/products_controller_spec.rb
@@ -404,9 +404,9 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
               .with({ headers: scc_announce_headers, body: scc_annouce_body.to_json })
               .to_return(status: 201, body: scc_response_body, headers: {})
 
-             expect(InstanceVerification).to receive(:update_cache).with(active_cache_entry, 'hybrid', registry: false)
+            expect(InstanceVerification).to receive(:update_cache).with(active_cache_entry, 'hybrid', registry: false)
 
-             headers['X-Instance-Data'] = instance_data
+            headers['X-Instance-Data'] = instance_data
             post url, params: payload_token, headers: headers
           end
 

--- a/engines/instance_verification/spec/requests/api/connect/v3/systems/products_controller_spec.rb
+++ b/engines/instance_verification/spec/requests/api/connect/v3/systems/products_controller_spec.rb
@@ -56,6 +56,45 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
         end
       end
 
+# <<<<<<< HEAD
+# =======
+#       context "when system doesn't have hw_info and cache is inactive" do
+#         let(:system) do
+#           FactoryBot.create(
+#             :system,
+#             :byos,
+#             pubcloud_reg_code: Base64.strict_encode64('super_token'),
+#             instance_data: 'dummy_instance_data'
+#           )
+#         end
+
+#         before do
+#           stub_request(:post, 'https://scc.suse.com/connect/systems/products')
+#             .to_return(
+#               status: 201,
+#               body: { ok: 'ok' }.to_json,
+#               headers: {}
+#             )
+#         end
+
+#         it 'class instance verification provider' do
+#           expect(InstanceVerification::Providers::Example).to(
+#             receive(:new).and_call_original.at_least(:once)
+#           )
+#           allow(File).to receive(:directory?)
+#           allow(Dir).to receive(:mkdir)
+#           allow(Dir).to receive(:children)
+#           allow(FileUtils).to receive(:touch)
+#           allow(InstanceVerification).to receive(:reg_code_in_cache?).and_return(
+#             "#{system.pubcloud_reg_code}-inactive"
+#           )
+#           post url, params: payload, headers: headers
+#           expect(response.body).to include('Subscription inactive')
+#           expect(response).to have_http_status(403)
+#         end
+#       end
+
+# >>>>>>> a9d2b4b9 (Fix linter offenses)
       context 'when system has hw_info' do
         let(:instance_data) { 'dummy_instance_data' }
         let(:system) { FactoryBot.create(:system, :byos, :with_system_information, instance_data: instance_data) }

--- a/engines/registry/lib/registry/engine.rb
+++ b/engines/registry/lib/registry/engine.rb
@@ -25,7 +25,7 @@ module Registry
         before_action :remove_auth_cache, only: %w[deregister]
 
         def remove_auth_cache
-          registry_cache_key = InstanceVerification.build_cache_entry(request.remote_ip, @system.login, @system.pubcloud_reg_code, 'registry', nil)
+          registry_cache_key = InstanceVerification.build_cache_entry(request.remote_ip, @system.login, {}, 'registry', nil)
           InstanceVerification.remove_entry_from_cache(registry_cache_key, 'registry')
         end
       end

--- a/engines/registry/spec/requests/api/connect/v3/systems/activations_controller_spec.rb
+++ b/engines/registry/spec/requests/api/connect/v3/systems/activations_controller_spec.rb
@@ -60,7 +60,6 @@ describe Api::Connect::V3::Systems::ActivationsController, type: :request do
             expect(response.body).to include('Instance verification failed')
             expect(InstanceVerification).not_to receive(:update_cache)
           end
-
         end
       end
 

--- a/engines/scc_proxy/spec/requests/api/connect/v3/systems/products_controller_spec.rb
+++ b/engines/scc_proxy/spec/requests/api/connect/v3/systems/products_controller_spec.rb
@@ -105,12 +105,14 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
               ]
             }
           end
+          let(:headers) { auth_header.merge('X-Instance-Data' => 'dummy_instance_data') }
 
           before do
             allow(plugin_double).to(
               receive(:instance_valid?)
                 .and_raise(InstanceVerification::Exception, 'Custom plugin error')
             )
+            allow(plugin_double).to receive(:instance_identifier).and_return('foo')
           end
 
           context 'with a valid registration code' do
@@ -126,11 +128,12 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
               allow(FileUtils).to receive(:touch)
 
               allow(InstanceVerification).to receive(:write_cache_file).with(
-                Rails.application.config.repo_byos_cache_dir, "#{Base64.strict_encode64(payload_byos[:token])}-#{product_triplet}-active"
+                Rails.application.config.repo_byos_cache_dir,
+                "#{Base64.strict_encode64(payload_byos[:token])}-foo-#{product_triplet}-active"
               )
               allow(InstanceVerification).to receive(:write_cache_file).with(
                 Rails.application.config.registry_cache_dir,
-                "#{Base64.strict_encode64(payload_byos[:token])}-#{product_triplet}-active"
+                "#{Base64.strict_encode64(payload_byos[:token])}-foo-#{product_triplet}-active"
               )
             end
 

--- a/engines/strict_authentication/app/controllers/strict_authentication/authentication_controller.rb
+++ b/engines/strict_authentication/app/controllers/strict_authentication/authentication_controller.rb
@@ -23,8 +23,11 @@ module StrictAuthentication
       return true if path =~ %r{/product\.license/}
 
       path = '/' + path.gsub(/^#{RMT::DEFAULT_MIRROR_URL_PREFIX}/, '')
+      # pp "PATH #{path}"
       # Allow access to SLES 12 and 12-SP1 repos for systems migrating from SLES 11
       has_sles11 = @system.products.where(identifier: 'SUSE_SLES').first
+      # pp "SLEEE #{has_sles11}"
+      # pp has_sles11 && (path =~ %r{/12/} || path =~ %r{/12-SP1/})
       return true if (has_sles11 && (path =~ %r{/12/} || path =~ %r{/12-SP1/}))
 
       found_path = all_allowed_paths(headers).find { |allowed_path| path =~ /^#{Regexp.escape(allowed_path)}/ }

--- a/engines/strict_authentication/app/controllers/strict_authentication/authentication_controller.rb
+++ b/engines/strict_authentication/app/controllers/strict_authentication/authentication_controller.rb
@@ -23,11 +23,8 @@ module StrictAuthentication
       return true if path =~ %r{/product\.license/}
 
       path = '/' + path.gsub(/^#{RMT::DEFAULT_MIRROR_URL_PREFIX}/, '')
-      # pp "PATH #{path}"
       # Allow access to SLES 12 and 12-SP1 repos for systems migrating from SLES 11
       has_sles11 = @system.products.where(identifier: 'SUSE_SLES').first
-      # pp "SLEEE #{has_sles11}"
-      # pp has_sles11 && (path =~ %r{/12/} || path =~ %r{/12-SP1/})
       return true if (has_sles11 && (path =~ %r{/12/} || path =~ %r{/12-SP1/}))
 
       found_path = all_allowed_paths(headers).find { |allowed_path| path =~ /^#{Regexp.escape(allowed_path)}/ }

--- a/engines/strict_authentication/app/controllers/strict_authentication/authentication_controller.rb
+++ b/engines/strict_authentication/app/controllers/strict_authentication/authentication_controller.rb
@@ -72,7 +72,7 @@ module StrictAuthentication
           false
         else
           # system is hybrid but the path is not a paid extension
-          # or path is in not free and belongs to the base product repositories
+          # or path is not free and belongs to the base product repositories
           # i.e. HA for SAP
           # check if it belongs to the free products repositories list
           true

--- a/engines/zypper_auth/spec/requests/api/connect/v3/systems/activations_controller_spec.rb
+++ b/engines/zypper_auth/spec/requests/api/connect/v3/systems/activations_controller_spec.rb
@@ -5,12 +5,13 @@ describe Api::Connect::V3::Systems::ActivationsController, type: :request do
   include_context 'version header', 3
 
   describe '#activations' do
-    let(:system) { FactoryBot.create(:system, :with_activated_product) }
+    let(:system) { FactoryBot.create(:system, :payg, :with_activated_product) }
     let(:headers) { auth_header.merge(version_header) }
+    let(:plugin_double) { instance_double('InstanceVerification::Providers::Example') }
 
     before do
       allow_any_instance_of(InstanceVerification::Providers::Example).to receive(:instance_valid?).and_return(true)
-      allow(InstanceVerification).to receive(:reg_code_in_cache?).and_return(nil)
+      allow(InstanceVerification).to receive(:reg_code_in_cache?).and_return('foo')
       allow(InstanceVerification).to receive(:update_cache)
       get '/connect/systems/activations', headers: headers
     end
@@ -19,7 +20,7 @@ describe Api::Connect::V3::Systems::ActivationsController, type: :request do
       it 'has service URLs with HTTP scheme' do
         data = JSON.parse(response.body)
         expect(data[0]['service']['url']).to match(%r{^plugin:/susecloud})
-        expect_any_instance_of(InstanceVerification::Providers::Example).not_to receive(:instance_valid?)
+        expect(plugin_double).not_to receive(:instance_valid?)
         expect(InstanceVerification).not_to receive(:update_cache)
       end
     end
@@ -39,9 +40,9 @@ describe Api::Connect::V3::Systems::ActivationsController, type: :request do
       let(:headers) { auth_header.merge(version_header).merge({ 'X-Instance-Data' => 'instance_data' }) }
 
       it 'has service URLs with HTTP scheme' do
-        allow(File).to receive(:exist?).and_return(true)
         data = JSON.parse(response.body)
         expect(data[0]['service']['url']).to match(%r{^plugin:/susecloud})
+        expect(plugin_double).not_to receive(:instance_identifier) # system is PAYG, no need for IID
       end
     end
   end

--- a/engines/zypper_auth/spec/requests/api/connect/v3/systems/activations_controller_spec.rb
+++ b/engines/zypper_auth/spec/requests/api/connect/v3/systems/activations_controller_spec.rb
@@ -31,7 +31,7 @@ describe Api::Connect::V3::Systems::ActivationsController, type: :request do
       it 'has service URLs with HTTP scheme' do
         data = JSON.parse(response.body)
         expect(data[0]['service']['url']).to match(%r{^plugin:/susecloud})
-        expect_any_instance_of(InstanceVerification::Providers::Example).not_to receive(:instance_valid?)
+        expect(plugin_double).not_to receive(:instance_valid?)
         expect(InstanceVerification).not_to receive(:update_cache)
       end
     end

--- a/engines/zypper_auth/spec/requests/services_controller_spec.rb
+++ b/engines/zypper_auth/spec/requests/services_controller_spec.rb
@@ -33,15 +33,13 @@ describe ServicesController do
 
     context 'with X-Instance-Data header' do
       let(:headers) { auth_header.merge('X-Instance-Data' => 'test') }
+      let(:plugin_double) { instance_double('InstanceVerification::Providers::Example') }
 
       context 'when instance verification succeeds' do
+        let(:data_export_double) { instance_double('DataExport::Handlers::Example') }
+
         before do
-          expect_any_instance_of(InstanceVerification::Providers::Example).to receive(:instance_valid?).and_return(true)
-          allow(InstanceVerification).to receive(:reg_code_in_cache?).and_return(nil)
-          allow(InstanceVerification).to receive(:update_cache)
-          allow(File).to receive(:directory?)
-          allow(Dir).to receive(:mkdir)
-          allow(FileUtils).to receive(:touch)
+          allow(InstanceVerification).to receive(:verify_instance).and_return(true)
           get "/services/#{service.id}", headers: headers
         end
 
@@ -60,52 +58,6 @@ describe ServicesController do
 
       context 'when instance verification returns false' do
         before do
-          expect_any_instance_of(InstanceVerification::Providers::Example).to receive(:instance_valid?).and_return(false)
-          allow(InstanceVerification).to receive(:update_cache)
-          allow(InstanceVerification).to receive(:reg_code_in_cache?).and_return(nil)
-          allow(File).to receive(:directory?)
-          allow(Dir).to receive(:mkdir)
-          allow(FileUtils).to receive(:touch)
-          get "/services/#{service.id}", headers: headers
-        end
-
-        it 'request fails with 403' do
-          expect(response).to have_http_status(403)
-        end
-
-        it 'reports an error' do
-          expect(response.body).to match(/Instance verification failed/)
-        end
-      end
-
-      context 'when instance verification raises StandardError' do
-        before do
-          expect_any_instance_of(InstanceVerification::Providers::Example).to receive(:instance_valid?).and_raise('Test')
-          allow(InstanceVerification).to receive(:update_cache)
-          allow(InstanceVerification).to receive(:reg_code_in_cache?).and_return(nil)
-          allow(File).to receive(:directory?)
-          allow(Dir).to receive(:mkdir)
-          allow(FileUtils).to receive(:touch)
-          get "/services/#{service.id}", headers: headers
-        end
-
-        it 'request fails with 403' do
-          expect(response).to have_http_status(403)
-        end
-
-        it 'reports an error' do
-          expect(response.body).to match(/Instance verification failed/)
-        end
-      end
-
-      context 'when instance verification raises InstanceVerification::Exception' do
-        before do
-          expect_any_instance_of(InstanceVerification::Providers::Example).to receive(:instance_valid?).and_raise(InstanceVerification::Exception, 'Test')
-          allow(File).to receive(:directory?).twice
-          allow(InstanceVerification).to receive(:reg_code_in_cache?).and_return(nil)
-          allow(File).to receive(:directory?)
-          allow(Dir).to receive(:mkdir)
-          allow(FileUtils).to receive(:touch)
           get "/services/#{service.id}", headers: headers
         end
 

--- a/engines/zypper_auth/spec/requests/services_controller_spec.rb
+++ b/engines/zypper_auth/spec/requests/services_controller_spec.rb
@@ -58,10 +58,6 @@ describe ServicesController do
 
       context 'when instance verification returns false' do
         before do
-# <<<<<<< HEAD
-# =======
-#           expect(InstanceVerification).to receive(:verify_instance).and_return(false)
-# >>>>>>> a9d2b4b9 (Fix linter offenses)
           get "/services/#{service.id}", headers: headers
         end
 

--- a/engines/zypper_auth/spec/requests/services_controller_spec.rb
+++ b/engines/zypper_auth/spec/requests/services_controller_spec.rb
@@ -58,6 +58,10 @@ describe ServicesController do
 
       context 'when instance verification returns false' do
         before do
+# <<<<<<< HEAD
+# =======
+#           expect(InstanceVerification).to receive(:verify_instance).and_return(false)
+# >>>>>>> a9d2b4b9 (Fix linter offenses)
           get "/services/#{service.id}", headers: headers
         end
 

--- a/engines/zypper_auth/spec/requests/strict_authentication/authentication_controller_spec.rb
+++ b/engines/zypper_auth/spec/requests/strict_authentication/authentication_controller_spec.rb
@@ -501,6 +501,7 @@ describe StrictAuthentication::AuthenticationController, type: :request do
 
           context 'the path to check is free' do
             let(:data_export_double) { instance_double('DataExport::Handlers::Example') }
+            let(:plugin_double) { instance_double('InstanceVerification::Providers::Example') }
 
             before do
               allow(InstanceVerification).to receive(:verify_instance).and_return(true)

--- a/engines/zypper_auth/spec/requests/strict_authentication/authentication_controller_spec.rb
+++ b/engines/zypper_auth/spec/requests/strict_authentication/authentication_controller_spec.rb
@@ -503,9 +503,8 @@ describe StrictAuthentication::AuthenticationController, type: :request do
             let(:data_export_double) { instance_double('DataExport::Handlers::Example') }
 
             before do
-              allow(InstanceVerification).to receive(:reg_code_in_cache?).and_return(nil)
+              allow(InstanceVerification).to receive(:verify_instance).and_return(true)
               allow(DataExport::Handlers::Example).to receive(:new).and_return(data_export_double)
-              expect_any_instance_of(InstanceVerification::Providers::Example).to receive(:instance_valid?).and_return(true)
               expect(data_export_double).to receive(:export_rmt_data)
               get '/api/auth/check', headers: headers
             end

--- a/spec/factories/systems.rb
+++ b/spec/factories/systems.rb
@@ -83,6 +83,10 @@ FactoryBot.define do
       end
     end
 
+    # trait :with_instance_data do
+    #   instance_data { '<document>foo</document>' }
+    # end
+
     trait :with_system_information do
       system_information do
         {

--- a/spec/factories/systems.rb
+++ b/spec/factories/systems.rb
@@ -83,10 +83,6 @@ FactoryBot.define do
       end
     end
 
-    # trait :with_instance_data do
-    #   instance_data { '<document>foo</document>' }
-    # end
-
     trait :with_system_information do
       system_information do
         {


### PR DESCRIPTION
## Description

We need to update the cache key to add a unique identifier
for systems running Zypper operations if we want to find them in the cache

As some workflows check a part/half the cache key not the whole cache key

The unique identifer is the instance id, unique and present across all CSPs

* Related Issue / Ticket / Trello card: <link reference>

## How to test 

When registering a system or running a zypper operation, the cache entry must include the instance id of that system

## Change Type

*Please select the correct option.*

- [ ] **Bug Fix** (a non-breaking change which fixes an issue)
- [X] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

