### PR TITLE
Add subscription check cache

### DIFF
--- a/engines/instance_verification/lib/instance_verification/engine.rb
+++ b/engines/instance_verification/lib/instance_verification/engine.rb
@@ -245,7 +245,7 @@ module InstanceVerification
               'The product is not available for this instance'
             )
           end
-          logger.info "Product #{@product.product_string} available for this instance"
+          logger.info "Product #{product.product_string} available for this instance"
           cache_key = InstanceVerification.build_cache_entry(request.remote_ip, @system.login, nil, 'payg', product)
           InstanceVerification.update_cache(cache_key, 'payg')
         end

--- a/engines/instance_verification/lib/instance_verification/engine.rb
+++ b/engines/instance_verification/lib/instance_verification/engine.rb
@@ -30,9 +30,7 @@ module InstanceVerification
               ''
             end
       encoded_reg_code = Base64.strict_encode64(params.fetch(:token, ''))
-      product_hash = product.attributes.symbolize_keys.slice(:identifier, :version, :arch)
-      product_triplet = "#{product_hash[:identifier]}_#{product_hash[:version]}_#{product_hash[:arch]}"
-      "#{encoded_reg_code}-#{iid}-#{product_triplet}"
+      "#{encoded_reg_code}-#{iid}-#{product.product_class}"
     end
   end
 
@@ -123,7 +121,9 @@ module InstanceVerification
     is_valid
   rescue InstanceVerification::Exception => e
     if system.byos?
-      result = SccProxy.scc_check_subscription_expiration(request.headers, system, base_product.product_class)
+      result = SccProxy.scc_check_subscription_expiration(
+        request.headers, system, request.remote_ip, false, base_product
+      )
       if result[:is_active]
         # update the cache for the base product
         InstanceVerification.set_cache_active(cache_key, 'byos')
@@ -247,7 +247,7 @@ module InstanceVerification
           end
           logger.info "Product #{@product.product_string} available for this instance"
           cache_key = InstanceVerification.build_cache_entry(request.remote_ip, @system.login, nil, 'payg', product)
-          InstanceVerification.set_cache_active(cache_key, 'payg')
+          InstanceVerification.update_cache(cache_key, 'payg')
         end
 
         def verify_base_product_activation(product)

--- a/engines/instance_verification/spec/requests/api/connect/v3/systems/products_controller_spec.rb
+++ b/engines/instance_verification/spec/requests/api/connect/v3/systems/products_controller_spec.rb
@@ -113,6 +113,7 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
               headers: {}
               )
             allow(InstanceVerification::Providers::Example).to receive(:new).and_return(plugin_double)
+            allow(plugin_double).to receive(:instance_identifier).and_return('foo')
             allow(plugin_double).to receive(:allowed_extension?).and_return(true)
             allow(plugin_double).to receive(:instance_valid?).and_return(false)
             post url, params: payload, headers: headers
@@ -126,9 +127,10 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
 
         context 'when verification provider raises an unhandled exception' do
           before do
-            expect(InstanceVerification::Providers::Example).to receive(:new).and_return(plugin_double)
+            expect(InstanceVerification::Providers::Example).to receive(:new).and_return(plugin_double).at_least(:once)
             allow(plugin_double).to receive(:allowed_extension?).and_return(true)
             allow(plugin_double).to receive(:instance_valid?).and_raise('not expected')
+            allow(plugin_double).to receive(:instance_identifier).and_return('foo')
             allow(InstanceVerification).to receive(:set_cache_inactive).and_return(nil)
             stub_request(:post, scc_activate_url)
             .to_return(

--- a/engines/registry/app/controllers/registry/registry_controller.rb
+++ b/engines/registry/app/controllers/registry/registry_controller.rb
@@ -13,7 +13,7 @@ module Registry
     # AuthZ will validate which of the requested scope policies are fulfilled
     # with the current login access and prepare the token to be sent back to the client
     def authorize
-      token = AccessToken.new(@client&.account, params['service'], @requested_scopes.map { |s| s.granted(client: @client) }).token
+      token = AccessToken.new(@client&.account, params['service'], @requested_scopes.map { |s| s.granted(request.remote_ip, client: @client) }).token
       render json: { token: token }, status: :ok
     rescue StandardError => e
       Rails.logger.error "Could not authorize: #{e.message}"
@@ -27,7 +27,7 @@ module Registry
       raise RegistryAuthError, 'Could not find system with current credentials' unless @client && @client.account
 
       access_scope = AccessScope.parse('registry:catalog:*')
-      repos = access_scope.allowed_paths(System.find_by(login: @client&.account))
+      repos = access_scope.allowed_paths(System.find_by(login: @client&.account), request.remote_ip)
       logger.debug("Returning #{repos.size} repos for client #{@client}")
 
       response.set_header('Docker-Distribution-Api-Version', REGISTRY_API_VERSION)

--- a/engines/registry/spec/app/models/access_scope_spec.rb
+++ b/engines/registry/spec/app/models/access_scope_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe AccessScope, type: :model do
           File.write('engines/registry/spec/data/access_policy_yaml.yml', YAML.dump(data))
           allow_any_instance_of(RegistryCatalogService).to receive(:repos).and_return(['suse/sles/super_repo'])
           allow(File).to receive(:read).and_return(File.read('engines/registry/spec/data/access_policy_yaml.yml'))
-          possible_access = access_scope.granted(client: client)
+          possible_access = access_scope.granted('127.0.0.1', client: client)
 
           expect(possible_access).to eq(
             {
@@ -176,7 +176,7 @@ RSpec.describe AccessScope, type: :model do
 
         context 'when client is null' do
           it 'returns no actions allowed' do
-            possible_access = access_scope.granted
+            possible_access = access_scope.granted('127.0.0.1')
 
             expect(possible_access).to eq({ 'type' => 'a', 'actions' => [], 'class' => nil, 'name' => 'suse/sles/*' })
           end
@@ -223,15 +223,20 @@ RSpec.describe AccessScope, type: :model do
               .with(
                 header_expected,
                 system,
-                'SLES15-SP4-LTSS-X86'
+                '127.0.0.1',
+                true,
+                product1
             ).and_return(scc_response)
           end
 
+          # rubocop:disable RSpec/ExampleLength
           it 'returns no actions allowed' do
             expect(SccProxy).to receive(:scc_check_subscription_expiration).with(
               header_expected,
               system,
-              'SLES15-SP4-LTSS-X86'
+              '127.0.0.1',
+              true,
+              product1
             )
             yaml_string = access_policy_content
             data = YAML.safe_load yaml_string
@@ -239,7 +244,7 @@ RSpec.describe AccessScope, type: :model do
             File.write('engines/registry/spec/data/access_policy_yaml.yml', YAML.dump(data))
             allow_any_instance_of(RegistryCatalogService).to receive(:repos).and_return(['suse/ltss/ltss_repo'])
             allow(File).to receive(:read).and_return(File.read('engines/registry/spec/data/access_policy_yaml.yml'))
-            possible_access = access_scope.granted(client: client)
+            possible_access = access_scope.granted('127.0.0.1', client: client)
 
             expect(possible_access).to eq(
               {
@@ -250,6 +255,7 @@ RSpec.describe AccessScope, type: :model do
               }
             )
           end
+          # rubocop:enable RSpec/ExampleLength
         end
       end
 

--- a/engines/registry/spec/requests/api/connect/v3/systems/activations_controller_spec.rb
+++ b/engines/registry/spec/requests/api/connect/v3/systems/activations_controller_spec.rb
@@ -114,8 +114,9 @@ describe Api::Connect::V3::Systems::ActivationsController, type: :request do
             }
           }
         end
-        let(:product_hash) { system.activations.first.product.attributes.symbolize_keys.slice(:identifier, :version, :arch) }
-        let(:product_triplet) { "#{product_hash[:identifier]}_#{product_hash[:version]}_#{product_hash[:arch]}" }
+        # let(:product_hash) { system.activations.first.product.attributes.symbolize_keys.slice(:identifier, :version, :arch) }
+        # let(:product_triplet) { "#{product_hash[:identifier]}_#{product_hash[:version]}_#{product_hash[:arch]}" }
+        let(:product_class) { system.activations.first.product.product_class }
 
         before do
           allow(InstanceVerification::Providers::Example).to receive(:new).and_return(plugin_double)
@@ -243,7 +244,8 @@ describe Api::Connect::V3::Systems::ActivationsController, type: :request do
           service: {
             product: {
               id: 0o0000,
-              product_class: 'foo'
+              product_class: 'foo',
+              free: false
             }
           }
         }
@@ -262,7 +264,8 @@ describe Api::Connect::V3::Systems::ActivationsController, type: :request do
           service: {
             product: {
               id: 0o0000,
-              product_class: 'bar'
+              product_class: 'bar',
+              free: false
             }
           }
         }
@@ -271,8 +274,7 @@ describe Api::Connect::V3::Systems::ActivationsController, type: :request do
       context 'without valid repository cache' do
         context 'with X-Instance-Data headers and bad metadata and good subscription on SCC' do
           let(:plugin_double) { instance_double('InstanceVerification::Providers::Example') }
-          let(:product_hash) { system.activations.first.product.attributes.symbolize_keys.slice(:identifier, :version, :arch) }
-          let(:product_triplet) { "#{product_hash[:identifier]}_#{product_hash[:version]}_#{product_hash[:arch]}" }
+          let(:product_class) { system.activations.first.product.product_class }
 
           before do
             allow(InstanceVerification).to receive(:update_cache)
@@ -285,11 +287,12 @@ describe Api::Connect::V3::Systems::ActivationsController, type: :request do
               receive(:instance_valid?)
                 .and_raise(InstanceVerification::Exception, 'Custom plugin error')
               )
+            allow(SccProxy).to receive(:system_in_cache?).and_return(nil)
             allow(InstanceVerification).to receive(:reg_code_in_cache?).and_return(false)
             stub_request(:get, scc_systems_activations_url).to_return(status: 200, body: [body_active].to_json, headers: {})
             allow(InstanceVerification).to receive(:verify_instance).and_call_original
             expect(InstanceVerification).to receive(:update_cache).with(
-              "#{system.pubcloud_reg_code}-foo-#{product_triplet}-active",
+              "#{system.pubcloud_reg_code}-foo-#{product_class}-active",
               'byos',
               registry: false
             )
@@ -306,8 +309,7 @@ describe Api::Connect::V3::Systems::ActivationsController, type: :request do
 
         context 'with X-Instance-Data headers and bad metadata and bad subscription on SCC' do
           let(:plugin_double) { instance_double('InstanceVerification::Providers::Example') }
-          let(:product_hash) { system.activations.first.product.attributes.symbolize_keys.slice(:identifier, :version, :arch) }
-          let(:product_triplet) { "#{product_hash[:identifier]}_#{product_hash[:version]}_#{product_hash[:arch]}" }
+          let(:product_class) { system.activations.first.product.product_class }
           let(:scc_response) do
             {
               is_active: false,
@@ -330,7 +332,7 @@ describe Api::Connect::V3::Systems::ActivationsController, type: :request do
             allow(SccProxy).to receive(:scc_check_subscription_expiration).and_return(scc_response)
             allow(InstanceVerification).to receive(:verify_instance).and_call_original
             expect(InstanceVerification).to receive(:update_cache).with(
-              "#{system.pubcloud_reg_code}-foo-#{product_triplet}-inactive",
+              "#{system.pubcloud_reg_code}-foo-#{product_class}-inactive",
               'byos'
             )
             get '/connect/systems/activations', headers: headers

--- a/engines/registry/spec/requests/api/connect/v3/systems/activations_controller_spec.rb
+++ b/engines/registry/spec/requests/api/connect/v3/systems/activations_controller_spec.rb
@@ -114,8 +114,6 @@ describe Api::Connect::V3::Systems::ActivationsController, type: :request do
             }
           }
         end
-        # let(:product_hash) { system.activations.first.product.attributes.symbolize_keys.slice(:identifier, :version, :arch) }
-        # let(:product_triplet) { "#{product_hash[:identifier]}_#{product_hash[:version]}_#{product_hash[:arch]}" }
         let(:product_class) { system.activations.first.product.product_class }
 
         before do

--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -194,11 +194,15 @@ module SccProxy
 
     # rubocop:disable Metrics/CyclomaticComplexity
     # rubocop:disable Metrics/PerceivedComplexity
-    def scc_check_subscription_expiration(headers, system, product_class = nil)
+    def scc_check_subscription_expiration(headers, system, remote_ip, registry, prod)
+      cache_status = SccProxy.system_in_cache?(remote_ip, system, prod, registry)
+      return cache_status if cache_status.present?
+
       auth = headers.fetch('HTTP_AUTHORIZATION', '')
       scc_systems_activations = SccProxy.get_scc_activations(auth, system)
       return { is_active: false, message: 'No activations.' } if scc_systems_activations.empty?
 
+      product_class = prod.product_class
       status_products_classes = if system.byos?
                                   scc_systems_activations.map do |act|
                                     product = act['service']['product']
@@ -216,12 +220,38 @@ module SccProxy
 
       return { is_active: true } if !status_products_classes.empty? && status_products_classes.all?(true)
 
-      SccProxy.product_class_access(scc_systems_activations, product_class)
+      product_access_status = SccProxy.product_class_access(scc_systems_activations, product_class)
+      if product_access_status[:is_active] == false && product_access_status[:message].downcase.include?('subscription expired')
+        cache_params = {}
+        cache_params = { token: Base64.decode64(system.pubcloud_reg_code.split(',')[0]), instance_data: headers.fetch('X-Instance-Data', '') } unless system.payg?
+        cache_key = InstanceVerification.build_cache_entry(
+          remote_ip, system.login, cache_params, system.proxy_byos_mode, prod
+        )
+        InstanceVerification.set_cache_inactive(cache_key, system.proxy_byos_mode)
+      end
+      product_access_status
     rescue StandardError
       { is_active: false, message: 'Could not check the activations from SCC' }
     end
     # rubocop:enable Metrics/CyclomaticComplexity
     # rubocop:enable Metrics/PerceivedComplexity
+
+    def system_in_cache?(remote_ip, system, product, registry)
+      cache_key = InstanceVerification.build_cache_entry(
+        remote_ip, system.login, system.pubcloud_reg_code, system.proxy_byos_mode, product
+      )
+      found_cache_entry = InstanceVerification.reg_code_in_cache?(cache_key, system.proxy_byos_mode)
+      if found_cache_entry.present?
+        if found_cache_entry.include?('-inactive')
+          return { is_active: false, message: 'Subscription expired.' }
+        elsif found_cache_entry.include?('-active')
+          InstanceVerification.update_cache(cache_key, system.proxy_byos_mode, registry: registry)
+          return { is_active: true }
+        end
+      end
+      Rails.logger.info "System #{system.login} not in cache, reaching to SCC"
+      nil
+    end
 
     def scc_upgrade(auth, product, system, logger)
       uri = URI.parse(SYSTEM_PRODUCTS_URL)

--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -223,7 +223,12 @@ module SccProxy
       product_access_status = SccProxy.product_class_access(scc_systems_activations, product_class)
       if product_access_status[:is_active] == false && product_access_status[:message].downcase.include?('subscription expired')
         cache_params = {}
-        cache_params = { token: Base64.decode64(system.pubcloud_reg_code.split(',')[0]), instance_data: headers.fetch('X-Instance-Data', '') } unless system.payg?
+        unless system.payg?
+          cache_params = {
+            token: Base64.decode64(system.pubcloud_reg_code.split(',')[0]),
+            instance_data: headers.fetch('X-Instance-Data', '')
+          }
+        end
         cache_key = InstanceVerification.build_cache_entry(
           remote_ip, system.login, cache_params, system.proxy_byos_mode, prod
         )

--- a/engines/scc_proxy/spec/requests/api/connect/v3/systems/products_controller_spec.rb
+++ b/engines/scc_proxy/spec/requests/api/connect/v3/systems/products_controller_spec.rb
@@ -20,9 +20,6 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
       include_context 'version header', 3
       let(:product) { FactoryBot.create(:product, :product_sles, :with_mirrored_repositories, :with_mirrored_extensions) }
       let(:headers) { auth_header.merge(version_header) }
-      let(:product_hash) { product.attributes.symbolize_keys.slice(:identifier, :version, :arch) }
-      let(:product_triplet) { "#{product_hash[:identifier]}_#{product_hash[:version]}_#{product_hash[:arch]}" }
-
       let(:payload_byos) do
         {
           identifier: product.identifier,
@@ -129,15 +126,16 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
 
               allow(InstanceVerification).to receive(:write_cache_file).with(
                 Rails.application.config.repo_byos_cache_dir,
-                "#{Base64.strict_encode64(payload_byos[:token])}-foo-#{product_triplet}-active"
+                "#{Base64.strict_encode64(payload_byos[:token])}-foo-#{product.product_class}-active"
               )
               allow(InstanceVerification).to receive(:write_cache_file).with(
                 Rails.application.config.registry_cache_dir,
-                "#{Base64.strict_encode64(payload_byos[:token])}-foo-#{product_triplet}-active"
+                "#{Base64.strict_encode64(payload_byos[:token])}-foo-#{product.product_class}-active"
               )
             end
 
             it 'renders service JSON' do
+              system_byos.update!(system_token: nil)
               post url, params: payload_byos, headers: headers
               expect(response.body).to eq(serialized_service_json)
             end

--- a/engines/strict_authentication/app/controllers/strict_authentication/authentication_controller.rb
+++ b/engines/strict_authentication/app/controllers/strict_authentication/authentication_controller.rb
@@ -47,7 +47,9 @@ module StrictAuthentication
           repos_paths.each do |repo_path|
             if found_path == repo_path
               logger.info "verifying paid extension #{paid_extension.identifier}"
-              result = SccProxy.scc_check_subscription_expiration(request.headers, @system, paid_extension.product_class)
+              result = SccProxy.scc_check_subscription_expiration(
+                request.headers, @system, request.remote_ip, false, paid_extension
+              )
               Rails.logger.info "Result from check subscription with SCC #{result}"
               return true if result[:is_active]
 
@@ -64,7 +66,9 @@ module StrictAuthentication
           end
         end
         if @system.byos?
-          result = SccProxy.scc_check_subscription_expiration(request.headers, @system, base_product.product_class)
+          result = SccProxy.scc_check_subscription_expiration(
+            request.headers, @system, request.remote_ip, false, base_product
+          )
           Rails.logger.info "Result from check subscription with SCC #{result}"
           return true if result[:is_active]
 

--- a/engines/zypper_auth/spec/requests/strict_authentication/authentication_controller_spec.rb
+++ b/engines/zypper_auth/spec/requests/strict_authentication/authentication_controller_spec.rb
@@ -354,6 +354,11 @@ describe StrictAuthentication::AuthenticationController, type: :request do
         end
 
         context 'when subscription is active' do
+          # let(:ltss_prod) do
+          #   system_hybrid.activations.find do |act|
+          #     act.product.product_class.include?('LTSS')
+          #   end
+          # end
           let(:body_active) do
             {
               id: 1,

--- a/spec/factories/systems.rb
+++ b/spec/factories/systems.rb
@@ -60,7 +60,7 @@ FactoryBot.define do
     trait :with_activated_paid_extension do
       transient do
         product_base { create(:product, :with_mirrored_repositories, free: true) }
-        paid_product { create(:product, :with_mirrored_repositories, free: false, product_type: :extension) }
+        paid_product { create(:product, :with_mirrored_repositories, :product_sles_ltss) }
         free_product { create(:product, :with_mirrored_repositories, free: true, product_type: :extension) }
         subscription { nil }
       end


### PR DESCRIPTION
## Description

Update the SCC subscription check method to first look for the subscription
in the cache

Update the call of the method

Update build cache as scc subscription check from registry uses product class

* Related Issue / Ticket / Trello card: <link reference>

## How to test 

running zypper or registry catalog should use the cache

## Change Type

*Please select the correct option.*

- [ ] **Bug Fix** (a non-breaking change which fixes an issue)
- [X] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [ ] I have reviewed my own code and believe that it's ready for an external review.
- [ ] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

