### PR TITLE
Export data when system activates or upgrades a product

### DIFF
--- a/engines/data_export/lib/data_export/engine.rb
+++ b/engines/data_export/lib/data_export/engine.rb
@@ -27,16 +27,12 @@ module DataExport
       end
 
       Api::Connect::V3::Systems::SystemsController.class_eval do
-        after_action :export_rmt_data, only: %i[update], if: -> { response.successful? && !@system.byos? }
+        after_action :export_rmt_data, only: %i[update], if: -> { response.successful? && !@system.byos? && !@system.products.empty? }
 
         def export_rmt_data
-          if @system.products.empty?
+          @system.products.pluck(:name).each do |prod_name|
+            params[:dw_product_name] = prod_name
             send_data
-          else
-            @system.products.pluck(:name).each do |prod_name|
-              params[:dw_product_name] = prod_name
-              send_data
-            end
           end
         rescue StandardError => e
           logger.error('Unexpected data export error has occurred:')

--- a/engines/data_export/lib/data_export/engine.rb
+++ b/engines/data_export/lib/data_export/engine.rb
@@ -48,6 +48,28 @@ module DataExport
           logger.error(e.backtrace)
         end
       end
+
+      Api::Connect::V3::Systems::ProductsController.class_eval do
+        after_action :export_rmt_data, only: %i[activate upgrade], if: -> { response.successful? && !@system.byos? }
+
+        def export_rmt_data
+          params[:product_triplet] = @product.product_string
+          data_export_handler = DataExport.handler.new(
+            @system,
+            request,
+            params,
+            logger
+          )
+          data_export_handler.export_rmt_data
+          logger.info "System #{@system.login} info updated by data export handler after activating or updating the product #{@product.product_string}"
+        rescue StandardError => e
+          logger.error('Unexpected data export error has occurred:')
+          logger.error(e.message)
+          logger.error("System login: #{@system.login}, IP: #{request.remote_ip}")
+          logger.error('Backtrace:')
+          logger.error(e.backtrace)
+        end
+      end
     end
   end
 end

--- a/engines/data_export/lib/data_export/engine.rb
+++ b/engines/data_export/lib/data_export/engine.rb
@@ -27,7 +27,7 @@ module DataExport
       end
 
       Api::Connect::V3::Systems::SystemsController.class_eval do
-        after_action :export_rmt_data, only: %i[update], if: -> { response.successful? && !@system.byos? && !@system.products.empty? }
+        after_action :export_rmt_data, only: %i[update], if: -> { response.successful? && !@system.byos? && @system.products.present? }
 
         def export_rmt_data
           @system.products.pluck(:name).each do |prod_name|

--- a/engines/data_export/spec/requests/api/connect/v3/systems/products_controller_spec.rb
+++ b/engines/data_export/spec/requests/api/connect/v3/systems/products_controller_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+describe Api::Connect::V3::Systems::ProductsController, type: :request do
+  include_context 'auth header', :system, :login, :password
+  include_context 'version header', 3
+
+  let(:system) { FactoryBot.create(:system, :payg) }
+  let(:url) { connect_systems_products_url }
+  let(:headers) { auth_header.merge(version_header) }
+  let(:product) { FactoryBot.create(:product, :product_sles, :with_mirrored_repositories, :with_mirrored_extensions) }
+  let(:payload) do
+    {
+      identifier: product.identifier,
+      version: product.version,
+      arch: product.arch,
+      token: 'super_reg_code'
+    }
+  end
+
+  describe '#activate' do
+    subject(:activate_action) { post url, params: payload, headers: headers }
+
+    let(:verify_plugin_double) { instance_double('InstanceVerification::Providers::Example') }
+    let(:plugin_double) { instance_double('DataExport::Handlers::Example') }
+
+    after { FileUtils.rm_rf(File.dirname(Rails.application.config.registry_cache_dir)) }
+
+    context 'when activate success' do
+      before { allow(DataExport::Handlers::Example).to receive(:new).and_return(plugin_double) }
+
+      context 'when data export success' do
+        let(:system) { FactoryBot.create(:system, :payg) }
+
+        it do
+          expect(plugin_double).to receive(:export_rmt_data)
+          activate_action
+        end
+      end
+
+      context 'when data export fails' do
+        before do
+          allow(plugin_double).to receive(:export_rmt_data).and_raise('foo')
+          allow(Rails.logger).to receive(:error)
+        end
+
+        it do
+          expect(plugin_double).to receive(:export_rmt_data)
+          expect(Rails.logger).to receive(:error)
+          activate_action
+        end
+      end
+    end
+  end
+end

--- a/engines/data_export/spec/requests/api/connect/v3/systems/systems_controller_spec.rb
+++ b/engines/data_export/spec/requests/api/connect/v3/systems/systems_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Api::Connect::V3::Systems::SystemsController do
   include_context 'user-agent header'
   include_context 'zypp user-agent header'
 
-  let(:system) { FactoryBot.create(:system, hostname: 'initial') }
+  let(:system) { FactoryBot.create(:system, :with_activated_base_product, hostname: 'initial') }
   let(:url) { '/connect/systems' }
   let(:headers) { auth_header.merge(version_header) }
   let(:hwinfo) do
@@ -39,6 +39,8 @@ RSpec.describe Api::Connect::V3::Systems::SystemsController do
       end
 
       context 'when data export fails' do
+        let(:system) { FactoryBot.create(:system, hostname: 'initial') }
+
         before do
           allow(plugin_double).to receive(:export_rmt_data).and_raise('foo')
           allow(Rails.logger).to receive(:error)

--- a/engines/data_export/spec/requests/api/connect/v3/systems/systems_controller_spec.rb
+++ b/engines/data_export/spec/requests/api/connect/v3/systems/systems_controller_spec.rb
@@ -39,8 +39,6 @@ RSpec.describe Api::Connect::V3::Systems::SystemsController do
       end
 
       context 'when data export fails' do
-        let(:system) { FactoryBot.create(:system, hostname: 'initial') }
-
         before do
           allow(plugin_double).to receive(:export_rmt_data).and_raise('foo')
           allow(Rails.logger).to receive(:error)


### PR DESCRIPTION
## Description

Send the information to data warehouse whenever a system activates or upgrades a product

* Related Issue / Ticket / Trello card: https://trello.com/c/n8vD9v1b

## How to test 

With the DataExport engine on, the activation of a product should trigger the data export method

## Change Type

*Please select the correct option.*

- [ ] **Bug Fix** (a non-breaking change which fixes an issue)
- [X] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

