### PR TITLE
Error handling for hybrid system being announced to SCC

### DIFF
--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -352,6 +352,12 @@ module SccProxy
               @system.update(pubcloud_reg_code: encoded_reg_code)
             end
           end
+        rescue *NET_HTTP_ERRORS => e
+          logger.error(
+            "Could not activate product for system with regcode #{params[:token]}" \
+              "to SCC: #{e.message}"
+          )
+          render json: { type: 'error', error: e.message }, status: status_code(e.message), location: nil
         end
         # rubocop:enable Metrics/CyclomaticComplexity
         # rubocop:enable Metrics/PerceivedComplexity
@@ -385,12 +391,6 @@ module SccProxy
 
             SccProxy.announce_system_scc("Token token=#{params[:token]}", params, params['system_token'])
           end
-        rescue *NET_HTTP_ERRORS => e
-          logger.error(
-            "Could not register system with regcode #{params[:token]}" \
-              "to SCC: #{e.message}"
-          )
-          render json: { type: 'error', error: e.message }, status: status_code(e.message), location: nil
         end
 
         def status_code(error_message)


### PR DESCRIPTION
## Description

When a PAYG system activates a product like LTSS, the system gets announce to SCC
That request can fail and the error needs to be handled

This Fixes #1316

* Related Issue / Ticket / Trello card:  #1316

## How to test 

An error on that scenario should log the error and not produce a FATAL error

## Change Type

*Please select the correct option.*

- [X] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

