### PR TITLE
Bump bundler to 2.2.34 to build on SP6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ registry
 vendor/
 coverage/
 .idea/
+.mise.toml
 integration/prophet/options-local.yml
 
 # Ignore encrypted secrets key file.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM opensuse/leap:15.3
+FROM opensuse/leap:15.6
 
 RUN zypper --non-interactive install --no-recommends \
         timezone wget gcc-c++ libffi-devel git-core zlib-devel \
         libxml2-devel libxslt-devel cron libmariadb-devel mariadb-client sqlite3-devel \
-        vim ruby2.5 ruby2.5-devel ruby2.5-rubygem-bundler SUSEConnect && \
+        vim ruby2.5 ruby2.5-devel ruby2.5-rubygem-bundler SUSEConnect bzip2 gzip && \
     zypper --non-interactive install -t pattern devel_basis && \
     update-alternatives --install /usr/bin/bundle bundle /usr/bin/bundle.ruby2.5 5 && \
     update-alternatives --install /usr/bin/bundler bundler /usr/bin/bundler.ruby2.5 5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -440,4 +440,4 @@ DEPENDENCIES
   yabeda-rails
 
 BUNDLED WITH
-   1.17.3
+   2.2.34

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 NAME          = rmt-server
 VERSION       = $(shell ruby -e 'require "./lib/rmt.rb"; print RMT::VERSION')
 
+.PHONY = all clean man dist build-tarball
+
 all:
 	@:
 
@@ -13,7 +15,10 @@ man:
 	ronn --roff --pipe --manual RMT MANUAL.md > rmt-cli.8 && gzip -f rmt-cli.8
 	mv rmt-cli.8.gz package/obs
 
-dist: clean man
+dist:
+	docker-compose run -it -v $(PWD):/srv/www/rmt --rm rmt make build-tarball
+
+build-tarball: clean man
 	@mkdir -p $(NAME)-$(VERSION)/
 
 	@cp -r app $(NAME)-$(VERSION)/

--- a/ci/rmt-build-rpm
+++ b/ci/rmt-build-rpm
@@ -22,7 +22,7 @@ mkdir -p "$ARTIFACT_DIR"
 
 group "create rmt-server tarball"
 pushd "$SOURCE"
-  make dist
+  make build-tarball
   cp "$SOURCE/package/obs/rmt-server-$VERSION.tar.bz2" "$ARTIFACT_DIR"
 popd
 groupend

--- a/ci/rmt-run-feature-tests
+++ b/ci/rmt-run-feature-tests
@@ -11,6 +11,12 @@ group "synchronize SCC product/repositories"
   rmt-cli sync
 groupend
 
+group "install feature test dependencies"
+pushd "$SOURCE"
+  bundle install --with test
+popd
+groupend
+
 group "run feature tests"
 pushd "$SOURCE"
   NO_COVERAGE=true bundle exec rspec features/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   db:
     image: mariadb:10.2

--- a/package/obs/rmt-server.spec
+++ b/package/obs/rmt-server.spec
@@ -116,6 +116,12 @@ cp -p %{SOURCE2} .
 %setup -q
 sed -i '1 s|/usr/bin/env\ ruby|/usr/bin/ruby.%{ruby_version}|' bin/*
 
+# Everything below 15.6 does not have bundler version 2.2.34 available
+# Fallback to the old version 1.16.1 for those
+%if 0%{?sle_version} < 150600
+sed -i 's/2\.2\.34/1\.16\.1/g' Gemfile.lock
+%endif
+
 %build
 bundle.%{ruby_version} config build.nio4r --with-cflags='%{optflags} -Wno-return-type'
 bundle.%{ruby_version} config set deployment 'true'

--- a/package/obs/rmt-server.spec
+++ b/package/obs/rmt-server.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package rmt-server
 #
-# Copyright (c) 2024 SUSE LLC
+# Copyright (c) 2025 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -115,6 +115,10 @@ cp -p %{SOURCE2} .
 
 %setup -q
 sed -i '1 s|/usr/bin/env\ ruby|/usr/bin/ruby.%{ruby_version}|' bin/*
+# Set the version of bundler available within the build environment instead
+# of expect a hardcoded version. This ensures we bundle with the available version of bundler no matter which version available
+# NOTE: This relies on the fact that the lock file format does not change between bundler versions (which is not yet the case)
+sed -i "s/2\.2\.34/$(bundle.%{ruby_version} --version | grep -oE '([0-9]+\.?){3}')/g" Gemfile.lock
 
 %build
 bundle.%{ruby_version} config build.nio4r --with-cflags='%{optflags} -Wno-return-type'

--- a/package/obs/rmt-server.spec
+++ b/package/obs/rmt-server.spec
@@ -116,12 +116,6 @@ cp -p %{SOURCE2} .
 %setup -q
 sed -i '1 s|/usr/bin/env\ ruby|/usr/bin/ruby.%{ruby_version}|' bin/*
 
-# Everything below 15.6 does not have bundler version 2.2.34 available
-# Fallback to the old version 1.16.1 for those
-%if 0%{?sle_version} < 150600
-sed -i 's/2\.2\.34/1\.16\.1/g' Gemfile.lock
-%endif
-
 %build
 bundle.%{ruby_version} config build.nio4r --with-cflags='%{optflags} -Wno-return-type'
 bundle.%{ruby_version} config set deployment 'true'


### PR DESCRIPTION
## Description

Bundler had a major upgrade on SP6 due to CVEs which renders the 1.x branch unusable. This needs to be taken into account in the CI and additionally also in the spec file.

Here try to fix to get CI working again and make building RMT a little bit more easy.

The PR does:

- Fix the CI running the new version
- Move `make dist` into a container rather running on the development maschine
- Replace bundler version on rpm build time with the available from the build environment

NOTE: The updated bundler (2.2.34) version is now available on almost all service packs


card: https://trello.com/c/FpA0HZsY/3900-fix-rmt-package-building-on-obs

**How to test this merge request:**

- RMT CI is working again
- make dist:
```
 $ make dist
# expect: To run a container and build the tarball. The result is available in `package/obs`
```

- build against SLESSP7 (which not yet has the 2.2.34 update)
```
 $ make dist
 $ cp -r package/obs/* <obs project checkout>
 $ cd <obs project checkout>
 $ osc build SLE_15_SP7
```
HINT: To checkout a new copy of the the devel project from obs: `osc co systemsmanagement:SCC:RMT rmt-server`

**As always, if you think something is missing or having trouble to understand, please reach out!** :rocket:

thank you :rocket:
