### PR TITLE
Use decoded instance data to create the cache

### DIFF
--- a/engines/instance_verification/lib/instance_verification/engine.rb
+++ b/engines/instance_verification/lib/instance_verification/engine.rb
@@ -89,17 +89,17 @@ module InstanceVerification
     base_product = system.products.find_by(product_type: 'base')
     return false unless base_product
 
-    instance_data = request.headers['X-Instance-Data'].to_s
+    decoded_instance_data = Base64.decode64(request.headers['X-Instance-Data'].to_s)
     verification_provider = InstanceVerification.provider.new(
       logger,
       request,
       base_product.attributes.symbolize_keys.slice(:identifier, :version, :arch, :release_type),
-      Base64.decode64(instance_data)
+      decoded_instance_data
     )
     cache_params = {}
     # we are checking the base product so we pick the first registration code
     # PAYG instances have no registration code
-    cache_params = { token: Base64.decode64(system.pubcloud_reg_code.split(',')[0]), instance_data: instance_data } unless system.payg?
+    cache_params = { token: Base64.decode64(system.pubcloud_reg_code.split(',')[0]), instance_data: decoded_instance_data } unless system.payg?
     cache_key = InstanceVerification.build_cache_entry(
       request.remote_ip, system.login, cache_params, system.proxy_byos_mode, base_product
     )

--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -226,7 +226,7 @@ module SccProxy
         unless system.payg?
           cache_params = {
             token: Base64.decode64(system.pubcloud_reg_code.split(',')[0]),
-            instance_data: headers.fetch('X-Instance-Data', '')
+            instance_data: Base64.decode64(headers.fetch('X-Instance-Data', ''))
           }
         end
         cache_key = InstanceVerification.build_cache_entry(


### PR DESCRIPTION
## Description

Missing decoding of instance data for BYOS path

## How to test 

register a BYOS i.e. `ami-0ebae39929f571942` (for eu-central-1) `suse-sles-15-sp6-byos-v20250409-hvm-ssd-x86_64` should succeed



## Change Type

*Please select the correct option.*

- [X] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

