### PR TITLE
Add cache parameters to create the cache for BYOS or HYBRID

### DIFF
--- a/engines/instance_verification/lib/instance_verification/engine.rb
+++ b/engines/instance_verification/lib/instance_verification/engine.rb
@@ -122,7 +122,7 @@ module InstanceVerification
   rescue InstanceVerification::Exception => e
     if system.byos?
       result = SccProxy.scc_check_subscription_expiration(
-        request.headers, system, request.remote_ip, false, base_product
+        request.headers, system, request.remote_ip, false, cache_params, base_product
       )
       if result[:is_active]
         # update the cache for the base product

--- a/engines/registry/app/models/access_scope.rb
+++ b/engines/registry/app/models/access_scope.rb
@@ -95,9 +95,17 @@ class AccessScope
         auth_header = {
           'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Basic.encode_credentials(system.login, system.password)
         }
+        cache_params = {}
+        if system.pubcloud_reg_code.presence
+          decoded_instance_data = Base64.decode64(system.instance_data)
+          cache_params = {
+            token: Base64.decode64(system.pubcloud_reg_code.split(',')[0]),
+            instance_data: decoded_instance_data
+          }
+        end
         allowed_non_free_products.each do |non_free_prod|
           activation_state = SccProxy.scc_check_subscription_expiration(
-            auth_header, system, remote_ip, true, non_free_prod
+            auth_header, system, remote_ip, true, cache_params, non_free_prod
           )
           unless activation_state[:is_active]
             Rails.logger.info(

--- a/engines/registry/spec/app/models/access_scope_spec.rb
+++ b/engines/registry/spec/app/models/access_scope_spec.rb
@@ -194,10 +194,13 @@ RSpec.describe AccessScope, type: :model do
 
         let(:system) do
           system = FactoryBot.create(:system, :hybrid)
+          system.pubcloud_reg_code = 'pubcloud_reg_code'
+          system.instance_data = 'dummy_instance_data'
           system.activations << [
             FactoryBot.create(:activation, system: system, service: product1.service),
             FactoryBot.create(:activation, system: system, service: product2.service)
           ]
+          system.save!
           system
         end
         let(:product1) do
@@ -225,6 +228,10 @@ RSpec.describe AccessScope, type: :model do
                 system,
                 '127.0.0.1',
                 true,
+                {
+                  token: Base64.decode64(system.pubcloud_reg_code.split(',')[0]),
+                  instance_data: Base64.decode64(system.instance_data)
+                },
                 product1
             ).and_return(scc_response)
           end
@@ -236,6 +243,10 @@ RSpec.describe AccessScope, type: :model do
               system,
               '127.0.0.1',
               true,
+              {
+                token: Base64.decode64(system.pubcloud_reg_code.split(',')[0]),
+                instance_data: Base64.decode64(system.instance_data)
+              },
               product1
             )
             yaml_string = access_policy_content

--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -194,8 +194,8 @@ module SccProxy
 
     # rubocop:disable Metrics/CyclomaticComplexity
     # rubocop:disable Metrics/PerceivedComplexity
-    def scc_check_subscription_expiration(headers, system, remote_ip, registry, prod)
-      cache_status = SccProxy.system_in_cache?(remote_ip, system, prod, registry)
+    def scc_check_subscription_expiration(headers, system, remote_ip, registry, cache_params, prod) # rubocop:disable Metrics/ParameterLists
+      cache_status = SccProxy.system_in_cache?(remote_ip, system, prod, registry, cache_params)
       return cache_status if cache_status.present?
 
       auth = headers.fetch('HTTP_AUTHORIZATION', '')
@@ -241,9 +241,9 @@ module SccProxy
     # rubocop:enable Metrics/CyclomaticComplexity
     # rubocop:enable Metrics/PerceivedComplexity
 
-    def system_in_cache?(remote_ip, system, product, registry)
+    def system_in_cache?(remote_ip, system, product, registry, cache_params)
       cache_key = InstanceVerification.build_cache_entry(
-        remote_ip, system.login, system.pubcloud_reg_code, system.proxy_byos_mode, product
+        remote_ip, system.login, cache_params, system.proxy_byos_mode, product
       )
       found_cache_entry = InstanceVerification.reg_code_in_cache?(cache_key, system.proxy_byos_mode)
       if found_cache_entry.present?

--- a/engines/strict_authentication/app/controllers/strict_authentication/authentication_controller.rb
+++ b/engines/strict_authentication/app/controllers/strict_authentication/authentication_controller.rb
@@ -16,6 +16,8 @@ module StrictAuthentication
 
     # rubocop:disable Metrics/CyclomaticComplexity
     # rubocop:disable Metrics/PerceivedComplexity
+    # rubocop:disable Metrics/AbcSize
+    # rubocop:disable Metrics/MethodLength
     def path_allowed?(headers)
       path = headers['X-Original-URI']
       return false if path.blank?
@@ -35,11 +37,12 @@ module StrictAuthentication
       if @system.hybrid? || @system.byos?
         # check if the path is paid for hybrid or byos instances
         base_product = @system.products.find_by(product_type: 'base')
+        decoded_instance_data = Base64.decode64(request.headers['X-Instance-Data'].to_s)
         verification_provider = InstanceVerification.provider.new(
           logger,
           request,
           base_product.attributes.symbolize_keys.slice(:identifier, :version, :arch, :release_type),
-          Base64.decode64(request.headers['X-Instance-Data'].to_s) # instance data
+          decoded_instance_data
         )
         paid_extensions = @system.products.select { |prod| prod if !prod.free && prod.product_type == 'extension' }
         paid_extensions.each do |paid_extension|
@@ -47,8 +50,15 @@ module StrictAuthentication
           repos_paths.each do |repo_path|
             if found_path == repo_path
               logger.info "verifying paid extension #{paid_extension.identifier}"
+              cache_params = {}
+              if @system.pubcloud_reg_code.presence
+                cache_params = {
+                  token: Base64.decode64(@system.pubcloud_reg_code.split(',')[0]),
+                  instance_data: decoded_instance_data
+                }
+              end
               result = SccProxy.scc_check_subscription_expiration(
-                request.headers, @system, request.remote_ip, false, paid_extension
+                request.headers, @system, request.remote_ip, false, cache_params, paid_extension
               )
               Rails.logger.info "Result from check subscription with SCC #{result}"
               return true if result[:is_active]
@@ -66,8 +76,11 @@ module StrictAuthentication
           end
         end
         if @system.byos?
+          instance_data = Base64.decode64(headers['X-Instance-Data'].to_s)
+          cache_params = {}
+          cache_params = { token: Base64.decode64(@system.pubcloud_reg_code.split(',')[0]), instance_data: instance_data } if @system.pubcloud_reg_code.presence
           result = SccProxy.scc_check_subscription_expiration(
-            request.headers, @system, request.remote_ip, false, base_product
+            request.headers, @system, request.remote_ip, false, cache_params, base_product
           )
           Rails.logger.info "Result from check subscription with SCC #{result}"
           return true if result[:is_active]
@@ -83,6 +96,8 @@ module StrictAuthentication
         end
       end
     end
+    # rubocop:enable Metrics/AbcSize
+    # rubocop:enable Metrics/MethodLength
     # rubocop:enable Metrics/CyclomaticComplexity
     # rubocop:enable Metrics/PerceivedComplexity
 

--- a/engines/zypper_auth/spec/requests/strict_authentication/authentication_controller_spec.rb
+++ b/engines/zypper_auth/spec/requests/strict_authentication/authentication_controller_spec.rb
@@ -22,7 +22,7 @@ describe StrictAuthentication::AuthenticationController, type: :request do
         it 'return false and message for expired subscription' do
           allow(InstanceVerification).to receive(:build_cache_entry).and_return('foo')
           allow(InstanceVerification).to receive(:reg_code_in_cache?).and_return('foo-inactive')
-          result = SccProxy.system_in_cache?('foo', system, 'prod', 'registry')
+          result = SccProxy.system_in_cache?('foo', system, 'prod', 'registry', {})
           expect(result[:is_active]).to eq(false)
           expect(result[:message]).to eq('Subscription expired.')
         end
@@ -33,7 +33,7 @@ describe StrictAuthentication::AuthenticationController, type: :request do
           allow(InstanceVerification).to receive(:build_cache_entry).and_return('foo')
           allow(InstanceVerification).to receive(:reg_code_in_cache?).and_return('foo-active')
           allow(InstanceVerification).to receive(:update_cache)
-          result = SccProxy.system_in_cache?('foo', system, 'prod', 'registry')
+          result = SccProxy.system_in_cache?('foo', system, 'prod', 'registry', {})
           expect(result[:is_active]).to eq(true)
         end
       end
@@ -42,7 +42,7 @@ describe StrictAuthentication::AuthenticationController, type: :request do
         it 'return false and message for expired subscription' do
           allow(InstanceVerification).to receive(:build_cache_entry).and_return('foo')
           allow(InstanceVerification).to receive(:reg_code_in_cache?).and_return(nil)
-          result = SccProxy.system_in_cache?('foo', system, 'prod', 'registry')
+          result = SccProxy.system_in_cache?('foo', system, 'prod', 'registry', {})
           expect(result).to be(nil)
         end
       end
@@ -194,7 +194,13 @@ describe StrictAuthentication::AuthenticationController, type: :request do
             }
           }
         end
-        let(:system_byos) { FactoryBot.create(:system, :byos, :with_activated_paid_extension) }
+        let(:system_byos) do
+          system = FactoryBot.create(:system, :byos, :with_activated_paid_extension)
+          system.pubcloud_reg_code = 'pubcloud_reg_code'
+          system.save!
+          system
+        end
+
         let(:scc_systems_activations_url) { 'https://scc.suse.com/connect/systems/activations' }
 
         include_context 'auth header', :system_byos, :login, :password
@@ -396,6 +402,7 @@ describe StrictAuthentication::AuthenticationController, type: :request do
               system_hybrid,
               '127.0.0.1',
               'false',
+              {},
               ltss_prod
             )
             expect(result[:is_active]).to be(true)
@@ -436,6 +443,7 @@ describe StrictAuthentication::AuthenticationController, type: :request do
               system_hybrid,
               '127.0.0.1',
               'false',
+              {},
               ltss_prod
             )
             expect(result[:is_active]).to eq(false)
@@ -480,6 +488,7 @@ describe StrictAuthentication::AuthenticationController, type: :request do
               system_hybrid,
               '127.0.0.1',
               'false',
+              {},
               ltss_prod
             )
             expect(result[:is_active]).to eq(false)
@@ -524,6 +533,7 @@ describe StrictAuthentication::AuthenticationController, type: :request do
               system_hybrid,
               '127.0.0.1',
               'false',
+              {},
               ltss_prod
             )
             expect(result[:is_active]).to eq(false)


### PR DESCRIPTION
## Description

For some paths of BYOS, scc_check_subscription needs the cache parameters
This change adds said parameters

Update the method calls and tests


## How to test 

Register a BYOS i.e. ami-0ebae39929f571942 (for eu-central-1) suse-sles-15-sp6-byos-v20250409-hvm-ssd-x86_64 should succeed

## Change Type

*Please select the correct option.*

- [X] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

