### PR TITLE
Remove RGS repos without auth tokens

### DIFF
--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -21,7 +21,8 @@ class Repository < ApplicationRecord
   class << self
 
     def remove_suse_repos_without_tokens!
-      where(auth_token: nil).where("external_url LIKE '%.suse.com%'").where(installer_updates: 0).where.not(scc_id: nil).delete_all
+      where(auth_token: nil).where("external_url LIKE '%.suse.com%' OR external_url LIKE '%.ranchergovernment.com%'")
+        .where(installer_updates: 0).where.not(scc_id: nil).delete_all
     end
 
     # Mangles remote repo URL to make a nicer local path, see specs for examples

--- a/spec/lib/rmt/scc_spec.rb
+++ b/spec/lib/rmt/scc_spec.rb
@@ -256,6 +256,14 @@ describe RMT::SCC do
         external_url: 'https://updates.suse.com/repos/dummy/'
       )
     end
+    let!(:rgs_repo_without_token) do
+      FactoryBot.create(
+        :repository,
+        :with_products,
+        auth_token: nil,
+        external_url: 'https://installer-updates.ranchergovernment.com/repos/not/updates'
+      )
+    end
     let!(:other_repo_without_token) do
       FactoryBot.create(
         :repository,
@@ -304,6 +312,10 @@ describe RMT::SCC do
 
     it 'SUSE repos without auth_tokens are removed' do
       expect { suse_repo_without_token.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it 'RGS repos without auth_tokens are removed' do
+      expect { rgs_repo_without_token.reload }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
     it 'other repos without auth_tokens persist' do


### PR DESCRIPTION
## Description

We want to assert RMT works with RGS' CDN domain name. Here in RMT we are removing the RGS (rancher) repos without auth tokens.

* Related Issue / Ticket / Trello card: https://trello.com/c/dm1h7IUR/3882-rgs-s-assert-rmt-works-with-rgs-cdn-domain-name

## How to test 

N/A

## Change Type

*Please select the correct option.*

- [ ] **Bug Fix** (a non-breaking change which fixes an issue)
- [x] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [x] I have reviewed my own code and believe that it's ready for an external review.
- [ ] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

