### PR TITLE
Fix nil token

### DIFF
--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -372,8 +372,7 @@ module SccProxy
               mode
             )
           end
-          token = params.fetch(:token, '') || ''
-          update_pubcloud_reg_code(Base64.strict_encode64(token))
+          update_pubcloud_reg_code(Base64.strict_encode64(params[:token])) unless params[:token].blank?
         rescue *NET_HTTP_ERRORS => e
           logger.error(
             "Could not activate product for system with regcode #{params[:token]}" \

--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -372,7 +372,8 @@ module SccProxy
               mode
             )
           end
-          update_pubcloud_reg_code(Base64.strict_encode64(params.fetch(:token, '')))
+          token = params.fetch(:token, '') || ''
+          update_pubcloud_reg_code(Base64.strict_encode64(token))
         rescue *NET_HTTP_ERRORS => e
           logger.error(
             "Could not activate product for system with regcode #{params[:token]}" \

--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -372,7 +372,7 @@ module SccProxy
               mode
             )
           end
-          update_pubcloud_reg_code(Base64.strict_encode64(params[:token])) unless params[:token].blank?
+          update_pubcloud_reg_code(Base64.strict_encode64(params[:token])) if params[:token].present?
         rescue *NET_HTTP_ERRORS => e
           logger.error(
             "Could not activate product for system with regcode #{params[:token]}" \

--- a/engines/zypper_auth/spec/requests/api/connect/v3/systems/products_controller_spec.rb
+++ b/engines/zypper_auth/spec/requests/api/connect/v3/systems/products_controller_spec.rb
@@ -32,6 +32,9 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
 
       it 'service url has http scheme' do
         expect(service_url).to match(%r{^plugin:/susecloud})
+        # when no token in params we do not update the pubcloud registration code
+        # bsc#1244166
+        expect(controller).not_to receive(:update_pubcloud_reg_code)
       end
     end
 


### PR DESCRIPTION
## Description

Some requests do send the token key in the params without any value or with nil value

This fixes that case

* Related Issue / Ticket / Trello card: [bsc#1244166](https://bugzilla.suse.com/show_bug.cgi?id=1244166
)
## How to test 

Tests have been updated to reflect that, activate a product on BYOS mode and send the token with nil value
it should not raise any error and the public cloud registration code should not get updated (or the method called)

## Change Type

*Please select the correct option.*

- [X] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

