### PR TITLE
Catch parsing exceptions

### DIFF
--- a/engines/instance_verification/app/controllers/instance_verification/billing_check_controller.rb
+++ b/engines/instance_verification/app/controllers/instance_verification/billing_check_controller.rb
@@ -14,6 +14,9 @@ module InstanceVerification
       is_payg = verification_provider.payg_billing_code?(iid, params[:identifier])
 
       render status: :ok, json: { flavor: is_payg ? 'PAYG' : 'BYOS' }
+    rescue InstanceVerification::Exception => e
+      logger.error "Instance metadata '#{params[:metadata]}' could not be parsed: #{e.message}"
+      render status: :unprocessable_entity, json: { flavor: 'BYOS' }
     end
   end
 end

--- a/engines/instance_verification/app/controllers/instance_verification/billing_check_controller.rb
+++ b/engines/instance_verification/app/controllers/instance_verification/billing_check_controller.rb
@@ -16,6 +16,7 @@ module InstanceVerification
       render status: :ok, json: { flavor: is_payg ? 'PAYG' : 'BYOS' }
     rescue InstanceVerification::Exception => e
       logger.error "Instance metadata '#{params[:metadata]}' could not be parsed: #{e.message}"
+      # when the verification failed for any reason, the agreed flavor is BYOS
       render status: :unprocessable_entity, json: { flavor: 'BYOS' }
     end
   end

--- a/engines/instance_verification/lib/instance_verification/engine.rb
+++ b/engines/instance_verification/lib/instance_verification/engine.rb
@@ -251,15 +251,12 @@ module InstanceVerification
         end
 
         def verify_base_product_activation(product)
-          verification_provider = InstanceVerification.provider.new(
+          InstanceVerification.provider.new(
             logger,
             request,
             params.permit(:identifier, :version, :arch, :release_type).to_h,
             @system.instance_data
-          )
-
-          raise 'Unspecified error' unless verification_provider.instance_valid?
-
+          ).instance_valid?
           # we use the token sent from the client if present
           # instead of the value stored in the DB
           params[:instance_data] = @system.instance_data

--- a/engines/instance_verification/lib/instance_verification/providers/example.rb
+++ b/engines/instance_verification/lib/instance_verification/providers/example.rb
@@ -28,6 +28,9 @@ class InstanceVerification::Providers::Example < InstanceVerification::ProviderB
 
   def parse_instance_data
     # :nocov:
+    if @product_hash && @product_hash[:identifier] == 'Raise error'
+      raise InstanceVerification::Exception, 'Missing signature'
+    end
     if @instance_data.include? '<instance_data/>'
       return { 'instance_data' => 'parsed_instance_data', 'example_id' => '1234' } # :nocov:
     end

--- a/engines/instance_verification/spec/requests/api/connect/v3/systems/products_controller_spec.rb
+++ b/engines/instance_verification/spec/requests/api/connect/v3/systems/products_controller_spec.rb
@@ -189,7 +189,7 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
               .with(be_a(ActiveSupport::Logger), be_a(ActionDispatch::Request), expected_payload, instance_data).and_return(plugin_double).at_least(:once)
             expect(InstanceVerification::Providers::Example).to receive(:new)
               .with(nil, nil, nil, instance_data).and_call_original.at_least(:once)
-            expect(plugin_double).to receive(:instance_valid?).and_return(false)
+            expect(plugin_double).to receive(:instance_valid?).and_raise('ERROR')
             allow(plugin_double).to receive(:allowed_extension?).and_return(true)
             post url, params: payload, headers: headers
           end
@@ -516,14 +516,14 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
           ).to_json
         end
 
-        context 'when verification provider returns false' do
+        context 'when verification provider raises an exception' do
           before do
             expect(InstanceVerification::Providers::Example).to receive(:new)
               .with(be_a(ActiveSupport::Logger), be_a(ActionDispatch::Request), expected_payload, instance_data).and_return(plugin_double).at_least(:once)
             expect(InstanceVerification::Providers::Example).to receive(:new)
               .with(nil, nil, nil, instance_data).and_call_original.at_least(:once)
             allow(plugin_double).to receive(:allowed_extension?).and_return(true)
-            expect(plugin_double).to receive(:instance_valid?).and_return(false)
+            expect(plugin_double).to receive(:instance_valid?).and_raise('WELL SOMETHING WENT WRONG')
             post url, params: payload, headers: headers
           end
 

--- a/engines/instance_verification/spec/requests/instance_verification/billing_check_controller_spec.rb
+++ b/engines/instance_verification/spec/requests/instance_verification/billing_check_controller_spec.rb
@@ -62,7 +62,7 @@ module InstanceVerification
           get '/api/instance/check', params: { metadata: billing_info.to_s, identifier: 'SLES' }
           expect(JSON.parse(response.body)['flavor']).to eq('BYOS')
           expect(response.message).to eq('Unprocessable Entity')
-          expect(response.code).to eq("422")
+          expect(response.code).to eq('422')
         end
       end
     end

--- a/engines/scc_suma_api/app/controllers/scc_suma_api/scc_suma_api_controller.rb
+++ b/engines/scc_suma_api/app/controllers/scc_suma_api/scc_suma_api_controller.rb
@@ -55,7 +55,9 @@ module SccSumaApi
       raise 'Unspecified error' unless systems_found.present? || verification_provider.instance_valid?
     rescue InstanceVerification::Exception => e
       logger.error "Could not check if instance metadata '#{instance_data}' is valid: #{e.message}"
-      raise e.message
+      error = ActionController::TranslatedError.new(N_(e.message))
+      error.status = :unprocessable_entity
+      raise error
     end
 
     def product_tree_json

--- a/engines/scc_suma_api/app/controllers/scc_suma_api/scc_suma_api_controller.rb
+++ b/engines/scc_suma_api/app/controllers/scc_suma_api/scc_suma_api_controller.rb
@@ -53,6 +53,9 @@ module SccSumaApi
       systems_found = System.find_by(system_token: iid['instanceId'], proxy_byos_mode: :byos)
 
       raise 'Unspecified error' unless systems_found.present? || verification_provider.instance_valid?
+    rescue InstanceVerification::Exception => e
+      logger.error "Could not check if instance metadata '#{instance_data}' is valid: #{e.message}"
+      raise e.message
     end
 
     def product_tree_json

--- a/engines/scc_suma_api/spec/requests/scc_suma_api/scc_suma_api_controller_spec.rb
+++ b/engines/scc_suma_api/spec/requests/scc_suma_api/scc_suma_api_controller_spec.rb
@@ -100,21 +100,25 @@ module SccSumaApi
         end
 
         context 'metadata is not valid' do
+          let(:error_payload) do
+            {
+              'X-INSTANCE-IDENTIFIER' => 'Raise error',
+              'X-INSTANCE-VERSION' => product.version,
+              'X-INSTANCE-ARCH' => product.arch
+            }
+          end
+
           before do
-            allow(plugin_double).to(
-              receive(:parse_instance_data)
-                .and_raise(InstanceVerification::Exception, 'Missing signature')
-              )
             allow(SUSE::Connect::Api).to receive(:new).and_return api_double
             allow(api_double).to receive(:list_products_unscoped).and_return products
             allow(RMT::Logger).to receive(:new).and_return(logger)
-            # File.delete(unscoped_file) if File.exist?(unscoped_file)
-            get '/api/scc/unscoped-products', headers: payload
+            File.delete(unscoped_file) if File.exist?(unscoped_file)
+            get '/api/scc/unscoped-products', headers: error_payload
           end
 
           it 'raise an exception' do
-            expect(response.code).to eq '400'
-            expect(response.body).to eq 'foo'
+            expect(response.code).to eq '422'
+            expect(JSON.parse(response.body)['error']).to eq 'Missing signature'
           end
         end
       end

--- a/engines/scc_suma_api/spec/requests/scc_suma_api/scc_suma_api_controller_spec.rb
+++ b/engines/scc_suma_api/spec/requests/scc_suma_api/scc_suma_api_controller_spec.rb
@@ -98,6 +98,25 @@ module SccSumaApi
           its(:code) { is_expected.to eq '200' }
           its(:body) { is_expected.to eq products.to_json.to_s }
         end
+
+        context 'metadata is not valid' do
+          before do
+            allow(plugin_double).to(
+              receive(:parse_instance_data)
+                .and_raise(InstanceVerification::Exception, 'Missing signature')
+              )
+            allow(SUSE::Connect::Api).to receive(:new).and_return api_double
+            allow(api_double).to receive(:list_products_unscoped).and_return products
+            allow(RMT::Logger).to receive(:new).and_return(logger)
+            # File.delete(unscoped_file) if File.exist?(unscoped_file)
+            get '/api/scc/unscoped-products', headers: payload
+          end
+
+          it 'raise an exception' do
+            expect(response.code).to eq '400'
+            expect(response.body).to eq 'foo'
+          end
+        end
       end
 
       context 'get repos redirect' do


### PR DESCRIPTION
## Description

RMT should not produce 500 errors, any time we parse or validate
the instance metadata we should handle the possible exceptions


* Related Issue / Ticket / Trello card: <link reference>

## How to test 

Try to register an instance, activate a product with wrong metadata should not produce 500 error

Running instance billing flavor check from the client with wrong metadata that 

- could not be parsed: should not produce 500 error
- could be parsed but not verified: should not produce 500 error

## Change Type

*Please select the correct option.*

- [X] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [ ] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

