### PR TITLE
Handle no reg code

### DIFF
--- a/engines/instance_verification/lib/instance_verification/engine.rb
+++ b/engines/instance_verification/lib/instance_verification/engine.rb
@@ -99,7 +99,7 @@ module InstanceVerification
     cache_params = {}
     # we are checking the base product so we pick the first registration code
     # PAYG instances have no registration code
-    cache_params = { token: Base64.decode64(system.pubcloud_reg_code.split(',')[0]), instance_data: decoded_instance_data } unless system.payg?
+    cache_params = { token: Base64.decode64(system.pubcloud_reg_code.split(',')[0]), instance_data: decoded_instance_data } unless system.payg? || system.pubcloud_reg_code.blank?
     cache_key = InstanceVerification.build_cache_entry(
       request.remote_ip, system.login, cache_params, system.proxy_byos_mode, base_product
     )

--- a/engines/zypper_auth/spec/requests/services_controller_spec.rb
+++ b/engines/zypper_auth/spec/requests/services_controller_spec.rb
@@ -12,7 +12,7 @@ describe ServicesController do
       repo_items.map { |r| r.attr(:url) }
     end
 
-    let(:system) { FactoryBot.create(:system, :with_activated_product) }
+    let(:system) { FactoryBot.create(:system, :byos, :with_activated_product) }
     let(:service) { system.products.first.service }
 
     context 'without X-Instance-Data header' do
@@ -58,6 +58,11 @@ describe ServicesController do
 
       context 'when instance verification returns false' do
         before do
+          stub_request(:get, 'https://scc.suse.com/connect/systems/activations')
+            .to_return(status: 200, body: '', headers: {})
+          expect(InstanceVerification).to receive(:build_cache_entry).with(
+            '127.0.0.1', system.login, {}, system.proxy_byos_mode, system.products.find_by(product_type: 'base')
+          )
           get "/services/#{service.id}", headers: headers
         end
 


### PR DESCRIPTION
## Description

When building the cache, the system could not have
a public cloud registraton code

* Related Issue / Ticket / Trello card: <link reference>

## How to test 

Use a BYOS system without a registration code in the DB to run zypper up

## Change Type

*Please select the correct option.*

- [X] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [ ] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

