### PR TITLE
Change default behavior when mirroring delta RPM

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -259,7 +259,7 @@ The `mirroring` section lets you adjust mirroring behavior.
 
   * `mirroring.mirror_drpm`:
     Whether to mirror delta (extension = `.drpm`) RPM packages or not. Defaults
-    to `false` if absent.
+    to `true` if absent.
   * `mirroring.mirror_src`:
     Whether to mirror source (arch = `src`) RPM packages or not.
   * `mirroring.revalidate_repodata`:

--- a/config/rmt.yml
+++ b/config/rmt.yml
@@ -29,7 +29,7 @@ scc:
     job_name: <%= ENV.fetch('PROMETHEUS_JOB_NAME') { 'rmt-webserver' } %>
 
 mirroring:
-  mirror_drpm: false
+  mirror_drpm: true
   mirror_src: false
   revalidate_repodata: true
   dedup_method: hardlink

--- a/lib/rmt/config.rb
+++ b/lib/rmt/config.rb
@@ -47,7 +47,8 @@ module RMT::Config
     end
 
     def mirror_drpm_files?
-      ActiveModel::Type::Boolean.new.cast(Settings.try(:mirroring).try(:mirror_drpm)) || false
+      mirror_drpm_files = ActiveModel::Type::Boolean.new.cast(Settings.try(:mirroring).try(:mirror_drpm))
+      mirror_drpm_files.nil? ? true : mirror_drpm_files
     end
 
     WebServerConfig = Struct.new(

--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -5,6 +5,7 @@ Fri Jun  6 11:38:57 UTC 2025 - Jesús Bermúdez Velázquez <jesus.bv@suse.com>
   * rmt-server-pubcloud:
     * Only update the pubcloud regcode if there is a value (bsc#1244166)
   * Update rack (bsc#1242898)
+  * Enable delta RPM mirroring by default (revert behavior introduced on 2.22).
 
 -------------------------------------------------------------------
 Tue Jan 21 10:49:54 UTC 2025 - Jesús Bermúdez Velázquez <jesus.bv@suse.com>

--- a/package/obs/rmt.conf
+++ b/package/obs/rmt.conf
@@ -17,7 +17,7 @@ scc:
     job_name: rmt
 
 mirroring:
-  mirror_drpm: false
+  mirror_drpm: true
   mirror_src: false
   revalidate_repodata: true
   dedup_method: hardlink

--- a/spec/lib/rmt/config_spec.rb
+++ b/spec/lib/rmt/config_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe RMT::Config do
     context "when config YAML 'mirroring/mirror_drpm' is an empty string" do
       let(:mirror_drpm_value) { '' }
 
-      include_examples 'config with falsey values'
+      include_examples 'config with truthy values'
     end
 
     context "when config YAML 'mirroring/mirror_drpm' key is absent" do
@@ -100,7 +100,7 @@ RSpec.describe RMT::Config do
         CONFIG
       end
 
-      include_examples 'config with falsey values'
+      include_examples 'config with truthy values'
     end
 
     context "when config YAML 'mirroring/mirror_drpm' is false" do


### PR DESCRIPTION
## Description

This pull request changes the default behavior when the configuration attribute `mirroring/mirror_drpm` is absent (no `mirror_drpm` or `mirror_drpm` set to an empty string) on `/etc/rmt.conf`, reverting it to the previous behavior of "enable delta RPM mirroring by default".

## How to test 

Follow instructions on pull request #1308, section/scenario **How to test** > **Mirror a repository when `.drpm` mirroring is disabled**, but edit `rmt/config.local.yml` so that the `mirroring` YAML object looks like this (`mirror_drpm` should be absent):

```yaml
mirroring:
  mirror_src: false
  verify_rpm_checksums: false
  dedup_method: hardlink
```

The acceptance criteria are that when `mirroring/mirror_src` is absent, RMT **must mirror delta RPM packages**.

## Change Type

*Please select the correct option.*

- [x] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [x] I have reviewed my own code and believe that it's ready for an external review.
- [ ] I have provided comments for any hard-to-understand code.
- [x] I have documented the `MANUAL.md` file with any changes to the user experience.
- [x] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

