### PR TITLE
Update instance data

### DIFF
--- a/app/models/system.rb
+++ b/app/models/system.rb
@@ -73,7 +73,7 @@ class System < ApplicationRecord
   end
 
   def update_instance_data(instance_data)
-    update(instance_data: instance_data)
+    update!(instance_data: instance_data)
   end
 
   before_update do |system|

--- a/app/models/system.rb
+++ b/app/models/system.rb
@@ -72,6 +72,10 @@ class System < ApplicationRecord
     end
   end
 
+  def update_instance_data(instance_data)
+    update(instance_data: instance_data)
+  end
+
   before_update do |system|
     # reset SCC sync timestamp so that the system can be re-synced on change
     system.scc_synced_at = nil

--- a/engines/instance_verification/lib/instance_verification/engine.rb
+++ b/engines/instance_verification/lib/instance_verification/engine.rb
@@ -132,6 +132,8 @@ module InstanceVerification
       if result[:is_active]
         # update the cache for the base product
         InstanceVerification.set_cache_active(cache_key, 'byos')
+        system.instance_data = decoded_instance_data
+        system.save!
         return true
       end
       # if can not get the activations, set the cache inactive

--- a/engines/instance_verification/lib/instance_verification/engine.rb
+++ b/engines/instance_verification/lib/instance_verification/engine.rb
@@ -118,6 +118,11 @@ module InstanceVerification
     is_valid = verification_provider.instance_valid?
     # update repository and registry cache
     InstanceVerification.set_cache_active(cache_key, system.proxy_byos_mode)
+    # update the instance data when valid and not in the cache
+    # before RMT 2.22, there was no need as the instance data was fresh from the client
+    # after 2.22 we are using instance data from the DB and we need to refresh that data
+    system.instance_data = decoded_instance_data
+    system.save!
     is_valid
   rescue InstanceVerification::Exception => e
     if system.byos?
@@ -130,7 +135,6 @@ module InstanceVerification
         return true
       end
       # if can not get the activations, set the cache inactive
-      # "AAA YmFy-foo-product-129_15.3_x86_64""
       InstanceVerification.set_cache_inactive(cache_key, system.proxy_byos_mode)
     end
     ZypperAuth.zypper_auth_message(request, system, verification_provider, e.message)

--- a/engines/instance_verification/lib/instance_verification/engine.rb
+++ b/engines/instance_verification/lib/instance_verification/engine.rb
@@ -121,8 +121,7 @@ module InstanceVerification
     # update the instance data when valid and not in the cache
     # before RMT 2.22, there was no need as the instance data was fresh from the client
     # after 2.22 we are using instance data from the DB and we need to refresh that data
-    system.instance_data = decoded_instance_data
-    system.save!
+    system.update_instance_data(decoded_instance_data)
     is_valid
   rescue InstanceVerification::Exception => e
     if system.byos?
@@ -132,8 +131,7 @@ module InstanceVerification
       if result[:is_active]
         # update the cache for the base product
         InstanceVerification.set_cache_active(cache_key, 'byos')
-        system.instance_data = decoded_instance_data
-        system.save!
+        system.update_instance_data(decoded_instance_data)
         return true
       end
       # if can not get the activations, set the cache inactive

--- a/engines/instance_verification/spec/requests/api/connect/v3/systems/products_controller_spec.rb
+++ b/engines/instance_verification/spec/requests/api/connect/v3/systems/products_controller_spec.rb
@@ -402,7 +402,7 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
             "#{Base64.strict_encode64(payload_token[:token])}-foo-#{product.product_class}"
           end
           let(:active_cache_entry) { cache_entry + '-active' }
-          let(:headers) { auth_header.merge('X-Instance-Data' => 'dummy_instance_data') }
+          let(:headers) { auth_header.merge('X-Instance-Data' => Base64.strict_encode64('dummy_instance_data')) }
 
           before do
             allow(InstanceVerification::Providers::Example).to receive(:new).and_return(plugin_double)
@@ -429,7 +429,7 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
 
             # expect(InstanceVerification).to receive(:update_cache).with(cache_entry, 'hybrid')
             expect(InstanceVerification).to receive(:update_cache).with(active_cache_entry, 'hybrid', registry: false)
-            headers['X-Instance-Data'] = instance_data
+            headers['X-Instance-Data'] = Base64.strict_encode64(instance_data)
             post url, params: payload_token, headers: headers
           end
 

--- a/engines/registry/spec/requests/api/connect/v3/systems/activations_controller_spec.rb
+++ b/engines/registry/spec/requests/api/connect/v3/systems/activations_controller_spec.rb
@@ -27,7 +27,7 @@ describe Api::Connect::V3::Systems::ActivationsController, type: :request do
           let(:plugin_double) { instance_double('InstanceVerification::Providers::Example') }
 
           before do
-            headers['X-Instance-Data'] = 'IMDS'
+            headers['X-Instance-Data'] = Base64.strict_encode64('IMDS')
             Thread.current[:logger] = RMT::Logger.new('/dev/null')
           end
 
@@ -68,7 +68,7 @@ describe Api::Connect::V3::Systems::ActivationsController, type: :request do
           allow(File).to receive(:join).and_call_original
           allow(InstanceVerification).to receive(:update_cache)
           allow(InstanceVerification).to receive(:verify_instance).and_call_original
-          headers['X-Instance-Data'] = 'IMDS'
+          headers['X-Instance-Data'] = Base64.strict_encode64('IMDS')
         end
 
         it 'refreshes registry cache key only' do
@@ -128,7 +128,7 @@ describe Api::Connect::V3::Systems::ActivationsController, type: :request do
           allow(InstanceVerification).to receive(:update_cache)
           allow(InstanceVerification).to receive(:verify_instance).and_call_original
           stub_request(:get, scc_systems_activations_url).to_return(status: 200, body: [body_active].to_json, headers: {})
-          headers['X-Instance-Data'] = 'IMDS'
+          headers['X-Instance-Data'] = Base64.strict_encode64('IMDS')
         end
 
         context 'no registry' do
@@ -276,7 +276,7 @@ describe Api::Connect::V3::Systems::ActivationsController, type: :request do
 
           before do
             allow(InstanceVerification).to receive(:update_cache)
-            headers['X-Instance-Data'] = 'IMDS'
+            headers['X-Instance-Data'] = Base64.strict_encode64('IMDS')
             Thread.current[:logger] = RMT::Logger.new('/dev/null')
           end
 
@@ -317,7 +317,7 @@ describe Api::Connect::V3::Systems::ActivationsController, type: :request do
 
           before do
             allow(InstanceVerification).to receive(:update_cache)
-            headers['X-Instance-Data'] = 'IMDS'
+            headers['X-Instance-Data'] = Base64.strict_encode64('IMDS')
             Thread.current[:logger] = RMT::Logger.new('/dev/null')
           end
 

--- a/engines/scc_proxy/spec/requests/api/connect/v3/systems/products_controller_spec.rb
+++ b/engines/scc_proxy/spec/requests/api/connect/v3/systems/products_controller_spec.rb
@@ -102,7 +102,7 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
               ]
             }
           end
-          let(:headers) { auth_header.merge('X-Instance-Data' => 'dummy_instance_data') }
+          let(:headers) { auth_header.merge('X-Instance-Data' => Base64.strict_encode64('dummy_instance_data')) }
 
           before do
             allow(plugin_double).to(

--- a/engines/strict_authentication/spec/requests/services_controller_spec.rb
+++ b/engines/strict_authentication/spec/requests/services_controller_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe ServicesController, type: :request do
 
         context 'when service is not registered' do
           before do
-            headers['X-Instance-Data'] = 'IMDS'
+            headers['X-Instance-Data'] = Base64.strict_encode64('IMDS')
             get "/services/#{service.id}", headers: headers
           end
 
@@ -54,7 +54,7 @@ RSpec.describe ServicesController, type: :request do
 
         context 'when service is registered' do
           before do
-            headers['X-Instance-Data'] = 'IMDS'
+            headers['X-Instance-Data'] = Base64.strict_encode64('IMDS')
             allow_any_instance_of(InstanceVerification::Providers::Example).to(
               receive(:instance_valid?).and_return(true)
             )
@@ -74,7 +74,7 @@ RSpec.describe ServicesController, type: :request do
       include_context 'auth header', :system, :login, :password
 
       before do
-        headers['X-Instance-Data'] = 'IMDS'
+        headers['X-Instance-Data'] = Base64.strict_encode64('IMDS')
         allow_any_instance_of(InstanceVerification::Providers::Example).to(
           receive(:instance_valid?).and_return(true)
         )

--- a/engines/strict_authentication/spec/requests/strict_authentication/authentication_controller_spec.rb
+++ b/engines/strict_authentication/spec/requests/strict_authentication/authentication_controller_spec.rb
@@ -24,7 +24,7 @@ module StrictAuthentication
         context 'valid instance' do
           before do
             allow(InstanceVerification).to receive(:verify_instance).and_return(true)
-            get '/api/auth/check', headers: auth_header.merge({ 'X-Original-URI': requested_uri, 'X-Instance-Data': 'IMDS' })
+            get '/api/auth/check', headers: auth_header.merge({ 'X-Original-URI': requested_uri, 'X-Instance-Data': Base64.strict_encode64('IMDS') })
             allow(File).to receive(:directory?)
             allow(Dir).to receive(:mkdir)
             allow(FileUtils).to receive(:touch)

--- a/engines/zypper_auth/spec/requests/api/connect/v3/systems/activations_controller_spec.rb
+++ b/engines/zypper_auth/spec/requests/api/connect/v3/systems/activations_controller_spec.rb
@@ -37,7 +37,7 @@ describe Api::Connect::V3::Systems::ActivationsController, type: :request do
     end
 
     context 'with X-Instance-Data headers' do
-      let(:headers) { auth_header.merge(version_header).merge({ 'X-Instance-Data' => 'instance_data' }) }
+      let(:headers) { auth_header.merge(version_header).merge({ 'X-Instance-Data' => Base64.strict_encode64('instance_data') }) }
 
       it 'has service URLs with HTTP scheme' do
         data = JSON.parse(response.body)

--- a/engines/zypper_auth/spec/requests/strict_authentication/authentication_controller_spec.rb
+++ b/engines/zypper_auth/spec/requests/strict_authentication/authentication_controller_spec.rb
@@ -71,7 +71,7 @@ describe StrictAuthentication::AuthenticationController, type: :request do
       end
 
       context 'with instance_data headers and instance data is invalid' do
-        let(:headers) { auth_header.merge({ 'X-Original-URI': requested_uri, 'X-Instance-Data': 'test' }) }
+        let(:headers) { auth_header.merge({ 'X-Original-URI': requested_uri, 'X-Instance-Data': Base64.strict_encode64('test') }) }
 
         before do
           allow(InstanceVerification).to receive(:reg_code_in_cache?).and_return(nil)
@@ -96,8 +96,8 @@ describe StrictAuthentication::AuthenticationController, type: :request do
         end
         let(:requested_uri_byos) { '/repo' + local_path + '/repodata/repomd.xml' }
         let(:paid_requested_uri_byos) { '/repo' + paid_local_path + '/repodata/repomd.xml' }
-        let(:headers) { auth_header.merge({ 'X-Original-URI': requested_uri_byos, 'X-Instance-Data': 'test' }) }
-        let(:paid_headers) { auth_header.merge({ 'X-Original-URI': paid_requested_uri_byos, 'X-Instance-Data': 'test' }) }
+        let(:headers) { auth_header.merge({ 'X-Original-URI': requested_uri_byos, 'X-Instance-Data': Base64.strict_encode64('test') }) }
+        let(:paid_headers) { auth_header.merge({ 'X-Original-URI': paid_requested_uri_byos, 'X-Instance-Data': Base64.strict_encode64('test') }) }
         let(:body_active) do
           {
             id: 1,
@@ -322,7 +322,7 @@ describe StrictAuthentication::AuthenticationController, type: :request do
       end
 
       context 'with instance_data headers and instance data is valid' do
-        let(:headers) { auth_header.merge({ 'X-Original-URI': requested_uri, 'X-Instance-Data': 'test' }) }
+        let(:headers) { auth_header.merge({ 'X-Original-URI': requested_uri, 'X-Instance-Data': Base64.strict_encode64('test') }) }
         let(:data_export_double) { instance_double('DataExport::Handlers::Example') }
 
         before do
@@ -346,7 +346,7 @@ describe StrictAuthentication::AuthenticationController, type: :request do
         let(:scc_systems_activations_url) { 'https://scc.suse.com/connect/systems/activations' }
         let(:system_hybrid) { FactoryBot.create(:system, :hybrid, :with_activated_paid_extension, pubcloud_reg_code: 'INTERNAL-USE-FOO') }
         let(:requested_uri) { '/repo' + system_hybrid.repositories.first[:local_path] + '/repodata/repomd.xml' }
-        let(:headers) { auth_header.merge({ 'X-Original-URI': requested_uri, 'X-Instance-Data': 'test' }) }
+        let(:headers) { auth_header.merge({ 'X-Original-URI': requested_uri, 'X-Instance-Data': Base64.strict_encode64('test') }) }
         let(:ltss_prod) do
           activation = system_hybrid.activations.find { |act| act.product.product_class.include?('LTSS') }
           activation.product

--- a/spec/factories/systems.rb
+++ b/spec/factories/systems.rb
@@ -15,6 +15,7 @@ FactoryBot.define do
     end
 
     trait :hybrid do
+      pubcloud_reg_code { 'regitration_code' }
       proxy_byos_mode { :hybrid }
     end
 

--- a/spec/models/system_spec.rb
+++ b/spec/models/system_spec.rb
@@ -68,6 +68,11 @@ RSpec.describe System, type: :model do
       system.reload
       expect(system.scc_synced_at).to be(nil)
     end
+
+    it 'update the instance data' do
+      system.update_instance_data('foo')
+      expect(system.instance_data).to eq('foo')
+    end
   end
 
   it 'assigns nil system_token on create' do


### PR DESCRIPTION
## Description

Refresh or update the instance data in the DB, before RMT 2.22 there was no need to do this
as the instance data was fresh from the client, after 2.22 we are using instance data from the DB 
and we need to refresh that data


* Related Issue / Ticket / Trello card: <link reference>

## How to test 

Run a zypper up on a already registered instance with instance data on the DB and that instance data should get updated on the DB

## Change Type

*Please select the correct option.*

- [ ] **Bug Fix** (a non-breaking change which fixes an issue)
- [X] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

