### PR TITLE
Use instance id as a login on the public cloud environment

### DIFF
--- a/app/models/system.rb
+++ b/app/models/system.rb
@@ -20,11 +20,6 @@ class System < ApplicationRecord
   alias_attribute :scc_synced_at, :scc_registered_at
 
   def init
-    # if we are in the public cloud
-    # system_token should be not nil
-    self.login ||= system_token if system_token.presence
-    # if we are not in the public cloud
-    # use the regular SCC_UUID generated value
     self.login ||= System.generate_secure_login
     self.password ||= System.generate_secure_password
     self.registered_at ||= Time.zone.now

--- a/app/models/system.rb
+++ b/app/models/system.rb
@@ -20,6 +20,11 @@ class System < ApplicationRecord
   alias_attribute :scc_synced_at, :scc_registered_at
 
   def init
+    # if we are in the public cloud
+    # system_token should be not nil
+    self.login ||= system_token if system_token.presence
+    # if we are not in the public cloud
+    # use the regular SCC_UUID generated value
     self.login ||= System.generate_secure_login
     self.password ||= System.generate_secure_password
     self.registered_at ||= Time.zone.now

--- a/engines/instance_verification/lib/instance_verification/providers/example.rb
+++ b/engines/instance_verification/lib/instance_verification/providers/example.rb
@@ -57,7 +57,7 @@ class InstanceVerification::Providers::Example < InstanceVerification::ProviderB
   end
 
   def instance_identifier
-    'foo'
+    nil
   end
 
   def allowed_extension?

--- a/engines/instance_verification/spec/requests/api/connect/v3/subscriptions/systems_controller_spec.rb
+++ b/engines/instance_verification/spec/requests/api/connect/v3/subscriptions/systems_controller_spec.rb
@@ -10,7 +10,20 @@ describe Api::Connect::V3::Subscriptions::SystemsController, type: :request do
         data = JSON.parse(response.body)
         system = System.find_by(login: data['login'])
         expect(system.instance_data).to eq(instance_data)
+        expect(system.login.to_s.start_with?('SCC_'))
       end
     end
+
+    context 'using instance id' do
+      it 'saves instance data' do
+        allow_any_instance_of(InstanceVerification::Providers::Example).to receive(:instance_identifier).and_return('i-12345')
+        post '/connect/subscriptions/systems', params: { hostname: 'test', instance_data: instance_data }
+        data = JSON.parse(response.body)
+        system = System.find_by(login: data['login'])
+        expect(system.instance_data).to eq(instance_data)
+        expect(system.login.to_s.start_with?('i-'))
+      end
+    end
+
   end
 end

--- a/engines/instance_verification/spec/requests/api/connect/v3/subscriptions/systems_controller_spec.rb
+++ b/engines/instance_verification/spec/requests/api/connect/v3/subscriptions/systems_controller_spec.rb
@@ -10,7 +10,7 @@ describe Api::Connect::V3::Subscriptions::SystemsController, type: :request do
         data = JSON.parse(response.body)
         system = System.find_by(login: data['login'])
         expect(system.instance_data).to eq(instance_data)
-        expect(system.login.to_s.start_with?('SCC_'))
+        expect(system.login).to start_with('SCC_')
       end
     end
 
@@ -21,9 +21,8 @@ describe Api::Connect::V3::Subscriptions::SystemsController, type: :request do
         data = JSON.parse(response.body)
         system = System.find_by(login: data['login'])
         expect(system.instance_data).to eq(instance_data)
-        expect(system.login.to_s.start_with?('i-'))
+        expect(system.login).to start_with('i-')
       end
     end
-
   end
 end

--- a/engines/registry/spec/requests/api/connect/v3/systems/activations_controller_spec.rb
+++ b/engines/registry/spec/requests/api/connect/v3/systems/activations_controller_spec.rb
@@ -294,6 +294,7 @@ describe Api::Connect::V3::Systems::ActivationsController, type: :request do
               'byos',
               registry: false
             )
+            allow_any_instance_of(InstanceVerification::Providers::Example).to receive(:instance_identifier).and_return('foo')
             get '/connect/systems/activations', headers: headers
 
             data = JSON.parse(response.body)
@@ -329,6 +330,7 @@ describe Api::Connect::V3::Systems::ActivationsController, type: :request do
             allow(InstanceVerification).to receive(:reg_code_in_cache?).and_return(nil)
             allow(SccProxy).to receive(:scc_check_subscription_expiration).and_return(scc_response)
             allow(InstanceVerification).to receive(:verify_instance).and_call_original
+            allow_any_instance_of(InstanceVerification::Providers::Example).to receive(:instance_identifier).and_return('foo')
             expect(InstanceVerification).to receive(:update_cache).with(
               "#{system.pubcloud_reg_code}-foo-#{product_class}-inactive",
               'byos'

--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -284,13 +284,13 @@ module SccProxy
           auth_header = request.headers.fetch('HTTP_AUTHORIZATION', nil)
           system_information = hwinfo_params[:hwinfo].to_json
           instance_data = params.fetch(:instance_data, nil)
-          system_token = InstanceVerification.provider.new(nil, nil, nil, params['instance_data']).instance_identifier
+          instance_identifier = InstanceVerification.provider.new(nil, nil, nil, params['instance_data']).instance_identifier
           system_values = {
             hostname: params[:hostname],
             system_information: system_information,
             instance_data: instance_data,
-            system_token: system_token,
-            login: system_token
+            system_token: instance_identifier,
+            login: instance_identifier
           }
           if has_no_regcode?(auth_header)
             # NON BYOS case
@@ -298,7 +298,7 @@ module SccProxy
             system_values.merge({ proxy_byos_mode: :payg })
           else
             request.request_parameters['proxy_byos_mode'] = 'byos'
-            response = SccProxy.announce_system_scc(auth_header, request.request_parameters, system_token)
+            response = SccProxy.announce_system_scc(auth_header, request.request_parameters, instance_identifier)
             system_values.merge(
               {
                 scc_system_id: response['id'],

--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -285,32 +285,30 @@ module SccProxy
           system_information = hwinfo_params[:hwinfo].to_json
           instance_data = params.fetch(:instance_data, nil)
           system_token = InstanceVerification.provider.new(nil, nil, nil, params['instance_data']).instance_identifier
+          system_values = {
+            hostname: params[:hostname],
+            system_information: system_information,
+            instance_data: instance_data,
+            system_token: system_token,
+            login: system_token
+          }
           if has_no_regcode?(auth_header)
+            # NON BYOS case
             # no token sent to check with SCC
-            # standard announce case
-            @system = System.create!(
-              hostname: params[:hostname],
-              system_information: system_information,
-              proxy_byos_mode: :payg,
-              instance_data: instance_data,
-              system_token: system_token,
-              login: system_token
-            )
+            system_values.merge({ proxy_byos_mode: :payg })
           else
             request.request_parameters['proxy_byos_mode'] = 'byos'
             response = SccProxy.announce_system_scc(auth_header, request.request_parameters, system_token)
-            @system = System.create!(
-              system_token: system_token,
-              scc_system_id: response['id'],
-              login: system_token.presence,
-              password: response['password'],
-              hostname: params[:hostname],
-              proxy_byos_mode: :byos,
-              proxy_byos: true,
-              system_information: system_information,
-              instance_data: instance_data
+            system_values.merge(
+              {
+                scc_system_id: response['id'],
+                password: response['password'],
+                proxy_byos_mode: :byos,
+                proxy_byos: true
+              }
             )
           end
+          @system = System.create!(system_values)
           logger.info("System '#{@system.hostname}' announced")
           respond_with(@system, serializer: ::V3::SystemSerializer, location: nil)
         rescue *NET_HTTP_ERRORS => e

--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -293,7 +293,8 @@ module SccProxy
               system_information: system_information,
               proxy_byos_mode: :payg,
               instance_data: instance_data,
-              system_token: system_token
+              system_token: system_token,
+              login: system_token
             )
           else
             request.request_parameters['proxy_byos_mode'] = 'byos'
@@ -301,7 +302,7 @@ module SccProxy
             @system = System.create!(
               system_token: system_token,
               scc_system_id: response['id'],
-              login: response['login'],
+              login: system_token.presence,
               password: response['password'],
               hostname: params[:hostname],
               proxy_byos_mode: :byos,

--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -290,6 +290,8 @@ module SccProxy
             system_information: system_information,
             instance_data: instance_data,
             system_token: instance_identifier,
+            # using instance identifier instead of 'SCC_FOO' as login
+            # it is a unique value per instance across all CSPs
             login: instance_identifier
           }
           if has_no_regcode?(auth_header)

--- a/engines/scc_proxy/spec/requests/api/connect/v3/subscriptions/systems_controller_spec.rb
+++ b/engines/scc_proxy/spec/requests/api/connect/v3/subscriptions/systems_controller_spec.rb
@@ -9,7 +9,6 @@ describe Api::Connect::V3::Subscriptions::SystemsController, type: :request do
       let(:scc_register_response) do
         {
           id: 5684096,
-          login: 'SCC_foo',
           password: '1234',
           last_seen_at: '2021-10-24T09:48:52.658Z'
         }.to_json
@@ -33,6 +32,8 @@ describe Api::Connect::V3::Subscriptions::SystemsController, type: :request do
       end
 
       context 'valid credentials' do
+        let(:plugin_double) { instance_double('InstanceVerification::Providers::Example') }
+
         before do
           stub_request(:post, scc_register_system_url)
             .to_return(
@@ -43,8 +44,11 @@ describe Api::Connect::V3::Subscriptions::SystemsController, type: :request do
         end
 
         it 'saves the data' do
+          allow(InstanceVerification::Providers::Example).to receive(:new).at_least(:once).and_return(plugin_double)
+          allow(plugin_double).to receive(:instance_identifier).and_return('i-12345-payg')
           post '/connect/subscriptions/systems', params: params, headers: { HTTP_AUTHORIZATION: 'Token token=bar' }
-          system = System.find_by(login: 'SCC_foo')
+
+          system = System.find_by(login: 'i-12345-payg')
           expect(system.instance_data).to eq(instance_data)
         end
       end
@@ -116,6 +120,8 @@ describe Api::Connect::V3::Subscriptions::SystemsController, type: :request do
       end
 
       context 'valid credentials' do
+        let(:plugin_double) { instance_double('InstanceVerification::Providers::Example') }
+
         before do
           stub_request(:post, scc_register_system_url)
             .to_return(
@@ -126,8 +132,10 @@ describe Api::Connect::V3::Subscriptions::SystemsController, type: :request do
         end
 
         it 'saves the data' do
+          allow(InstanceVerification::Providers::Example).to receive(:new).at_least(:once).and_return(plugin_double)
+          allow(plugin_double).to receive(:instance_identifier).and_return('i-12345-payg')
           post '/connect/subscriptions/systems', params: params, headers: { HTTP_AUTHORIZATION: 'Token token=bar' }
-          system = System.find_by(login: 'SCC_foo')
+          system = System.find_by(login: 'i-12345-payg')
           expect(system.instance_data).to eq(instance_data)
         end
       end

--- a/engines/scc_proxy/spec/requests/api/connect/v3/systems/products_controller_spec.rb
+++ b/engines/scc_proxy/spec/requests/api/connect/v3/systems/products_controller_spec.rb
@@ -123,7 +123,7 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
               allow(File).to receive(:directory?)
               allow(FileUtils).to receive(:mkdir_p)
               allow(FileUtils).to receive(:touch)
-
+              allow_any_instance_of(InstanceVerification::Providers::Example).to receive(:instance_identifier).and_return('foo')
               allow(InstanceVerification).to receive(:write_cache_file).with(
                 Rails.application.config.repo_byos_cache_dir,
                 "#{Base64.strict_encode64(payload_byos[:token])}-foo-#{product.product_class}-active"

--- a/engines/scc_proxy/spec/requests/api/connect/v4/systems/products_controller_spec.rb
+++ b/engines/scc_proxy/spec/requests/api/connect/v4/systems/products_controller_spec.rb
@@ -185,7 +185,7 @@ product_type: 'module')
           it 'reports an error' do
             data = JSON.parse(response.body)
             expect(data['error']).to eq("{\"error\": \"Error'\"}")
-            expect(SccProxy).to have_received(:headers).with(headers['HTTP_AUTHORIZATION'], 'foo')
+            expect(SccProxy).to have_received(:headers).with(headers['HTTP_AUTHORIZATION'], nil)
           end
         end
 


### PR DESCRIPTION
## Description

Instance id is guarantee to be unique across the three CSPs, thus we do not need to generate a pseudo unique login value

This would help also with duplicated systems detection

* Related Issue / Ticket / Trello card: <link reference>

## How to test 

On a public cloud environment, with this changed applied the system should have the instance id as a login:

<img width="909" height="262" alt="Screenshot from 2025-07-18 15-48-53" src="https://github.com/user-attachments/assets/4ec92930-047a-4a3c-83bb-7748d070811d" />

<img width="909" height="128" alt="Screenshot from 2025-07-18 15-49-18" src="https://github.com/user-attachments/assets/70ea51c2-a058-49fb-b36f-f95547990ffd" />

## Change Type

*Please select the correct option.*

- [ ] **Bug Fix** (a non-breaking change which fixes an issue)
- [X] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

