### PR TITLE
Handle instance verification exceptions

### DIFF
--- a/engines/instance_verification/lib/instance_verification/engine.rb
+++ b/engines/instance_verification/lib/instance_verification/engine.rb
@@ -189,12 +189,17 @@ module InstanceVerification
             arch: base_product.arch,
             release_type: base_product.release_type
           }
-          add_on_product_class = InstanceVerification.provider.new(
-            logger,
-            request,
-            product_hash,
-            @system.instance_data
-          ).add_on
+          begin
+            add_on_product_class = InstanceVerification.provider.new(
+              logger,
+              request,
+              product_hash,
+              @system.instance_data
+              ).add_on
+          rescue InstanceVerification::Exception => e
+            logger.error("Could not find subscription: #{e.message}")
+            raise ActionController::TranslatedError.new("Could not find subscription: #{e.message}")
+          end
           # add_on_product_class, if present, is the real product class
           # i.e. in the case of SUMA, it would be SUMA product class
           # not the SUMA base product's product class (Micro)

--- a/engines/instance_verification/spec/requests/api/connect/v3/systems/products_controller_spec.rb
+++ b/engines/instance_verification/spec/requests/api/connect/v3/systems/products_controller_spec.rb
@@ -398,6 +398,7 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
             it 'de-registers system from SCC and reports an error' do
               data = JSON.parse(response.body)
               expect(data['error']).to eq('Unexpected instance verification error has occurred')
+              expect(response).to have_http_status(422)
             end
           end
         end

--- a/engines/instance_verification/spec/requests/api/connect/v3/systems/products_controller_spec.rb
+++ b/engines/instance_verification/spec/requests/api/connect/v3/systems/products_controller_spec.rb
@@ -320,6 +320,89 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
         end
       end
 
+      context 'when activating extensions with exception' do
+        let(:instance_data) { 'dummy_instance_data' }
+        let(:system) do
+          FactoryBot.create(
+            :system, :payg, :with_system_information, :with_activated_product, product: base_product, instance_data: instance_data
+          )
+        end
+        let(:serialized_service_json) do
+          V3::ServiceSerializer.new(
+            product.service,
+            base_url: URI::HTTP.build({ scheme: response.request.scheme, host: response.request.host }).to_s
+          ).to_json
+        end
+        let(:scc_activate_url) { 'https://scc.suse.com/connect/systems/products' }
+        let(:plugin_double) { instance_double('InstanceVerification::Providers::Example') }
+        let(:payload) do
+          {
+            identifier: product.identifier,
+            version: product.version,
+            arch: product.arch,
+            instance_data: 'dummy_instance_data',
+            proxy_byos_mode: :payg,
+            hwinfo:
+            {
+              hostname: 'test',
+              cpus: '1',
+              sockets: '1',
+              hypervisor: 'Xen',
+              arch: 'x86_64',
+              uuid: 'ec235f7d-b435-e27d-86c6-c8fef3180a01',
+              cloud_provider: 'amazon'
+            }
+          }
+        end
+        let(:scc_response_body) do
+          {
+            id: 1234567,
+            login: 'SCC_3b336b126db1503a9513a14e92a6a62e',
+            password: '24f057b7941e80f9cf2d51e16e8af2d6'
+          }.to_json
+        end
+
+        before do
+          allow(InstanceVerification::Providers::Example).to receive(:new).and_return(plugin_double)
+          allow(plugin_double).to receive(:instance_identifier).and_return('foo')
+          allow(plugin_double).to receive(:parse_instance_data).and_return({ InstanceId: 'foo' })
+          allow(plugin_double).to receive(:allowed_extension?).and_return(true)
+          allow(plugin_double).to receive(:add_on).and_raise(InstanceVerification::Exception, 'FOO')
+
+          FactoryBot.create(:subscription, product_classes: product_classes)
+          stub_request(:post, scc_activate_url)
+            .to_return(
+              status: 401,
+              body: { error: 'Instance verification failed: The product is not available for this instance' }.to_json,
+              headers: {}
+            )
+          # stub the fake announcement call PAYG has to do to SCC
+          # to create the system before activate product (and skip validation)
+          stub_request(:post, 'https://scc.suse.com/connect/subscriptions/systems')
+            .to_return(status: 201, body: scc_response_body, headers: {})
+
+          post url, params: payload, headers: headers
+        end
+
+        context 'when the extension is not free' do
+          let(:base_product) { FactoryBot.create(:product, :with_mirrored_repositories) }
+
+          context 'when a suitable subscription is not found' do
+            let(:product) do
+              FactoryBot.create(
+                :product, :with_mirrored_repositories, :extension, free: false, base_products: [base_product]
+              )
+            end
+            let(:product_classes) { [base_product.product_class] }
+
+            it 'de-registers system from SCC and reports an error' do
+              data = JSON.parse(response.body)
+              expect(data['error']).to eq('Unexpected instance verification error has occurred')
+            end
+          end
+        end
+      end
+
       context 'when activating extensions without errors' do
         let(:instance_data) { 'dummy_instance_data' }
         let(:system) do

--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -314,12 +314,12 @@ module SccProxy
           respond_with(@system, serializer: ::V3::SystemSerializer, location: nil)
         rescue *NET_HTTP_ERRORS => e
           message = 'Could not register system'
-          message += " with regcode #{auth_header} to SCC" unless has_no_regcode?(auth_header) # rubocop:disable Lint/UselessAssignment
+          message += " with regcode #{auth_header} to SCC" unless has_no_regcode?(auth_header)
           logger.error("#{message}: #{e.message}")
           render json: { type: 'error', error: e.message }, status: status_code(e.message), location: nil
         rescue InstanceVerification::Exception => e
           message = 'Could not register system'
-          message += " with regcode #{auth_header} to SCC" unless has_no_regcode?(auth_header) # rubocop:disable Lint/UselessAssignment
+          message += " with regcode #{auth_header} to SCC" unless has_no_regcode?(auth_header)
           logger.error("#{message}: #{e.message}")
           render json: { type: 'error', error: e.message }, status: :unprocessable_entity, location: nil
         end

--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -320,7 +320,7 @@ module SccProxy
         rescue InstanceVerification::Exception => e
           message = 'Could not register system'
           message += " with regcode #{auth_header} to SCC" unless has_no_regcode?(auth_header) # rubocop:disable Lint/UselessAssignment
-          logger.error("message}: #{e.message}")
+          logger.error("#{message}: #{e.message}")
           render json: { type: 'error', error: e.message }, status: :unprocessable_entity, location: nil
         end
 

--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -315,7 +315,7 @@ module SccProxy
         rescue *NET_HTTP_ERRORS => e
           message = 'Could not register system'
           message += " with regcode #{auth_header} to SCC" unless has_no_regcode?(auth_header) # rubocop:disable Lint/UselessAssignment
-          logger.error("message}: #{e.message}")
+          logger.error("#{message}: #{e.message}")
           render json: { type: 'error', error: e.message }, status: status_code(e.message), location: nil
         rescue InstanceVerification::Exception => e
           message = 'Could not register system'

--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -527,6 +527,8 @@ module SccProxy
           end
         end
 
+        # rubocop:disable Metrics/CyclomaticComplexity
+        # rubocop:disable Metrics/PerceivedComplexity
         def find_system
           systems_with_token = @systems.select(&:system_token)
           if systems_with_token.empty?
@@ -578,6 +580,8 @@ module SccProxy
           end
           system
         end
+        # rubocop:enable Metrics/CyclomaticComplexity
+        # rubocop:enable Metrics/PerceivedComplexity
       end
     end
   end

--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -314,12 +314,12 @@ module SccProxy
           respond_with(@system, serializer: ::V3::SystemSerializer, location: nil)
         rescue *NET_HTTP_ERRORS => e
           message = 'Could not register system'
-          message += " with regcode #{auth_header} to SCC" unless has_no_regcode?(auth_header)
+          message += " with regcode #{auth_header} to SCC" unless has_no_regcode?(auth_header) # rubocop:disable Lint/UselessAssignment
           logger.error("message}: #{e.message}")
           render json: { type: 'error', error: e.message }, status: status_code(e.message), location: nil
         rescue InstanceVerification::Exception => e
           message = 'Could not register system'
-          message += " with regcode #{auth_header} to SCC" unless has_no_regcode?(auth_header)
+          message += " with regcode #{auth_header} to SCC" unless has_no_regcode?(auth_header) # rubocop:disable Lint/UselessAssignment
           logger.error("message}: #{e.message}")
           render json: { type: 'error', error: e.message }, status: :unprocessable_entity, location: nil
         end

--- a/engines/scc_proxy/spec/requests/api/connect/v3/subscriptions/systems_controller_spec.rb
+++ b/engines/scc_proxy/spec/requests/api/connect/v3/subscriptions/systems_controller_spec.rb
@@ -4,6 +4,7 @@ describe Api::Connect::V3::Subscriptions::SystemsController, type: :request do
   describe '#announce_system' do
     let(:instance_data) { '<instance_data/>' }
 
+    # rubocop:disable RSpec/NestedGroups
     context 'using SCC generated credentials (BYOS mode)' do
       let(:scc_register_system_url) { 'https://scc.suse.com/connect/subscriptions/systems' }
       let(:scc_register_response) do
@@ -99,6 +100,7 @@ describe Api::Connect::V3::Subscriptions::SystemsController, type: :request do
         end
       end
     end
+    # rubocop:enable RSpec/NestedGroups
 
     context 'using SCC generated credentials (PAYG/LTSS mode)' do
       let(:scc_register_system_url) { 'https://scc.suse.com/connect/subscriptions/systems' }

--- a/engines/scc_proxy/spec/requests/api/connect/v3/systems/products_controller_spec.rb
+++ b/engines/scc_proxy/spec/requests/api/connect/v3/systems/products_controller_spec.rb
@@ -519,6 +519,19 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
               post url, params: payload, headers: headers
               expect(response.body).to eq(serialized_service_json)
             end
+
+            context 'instance verification error' do
+              let(:plugin_double) { instance_double('InstanceVerification::Providers::Example') }
+
+              it 'returns error' do
+                expect(InstanceVerification::Providers::Example).to receive(:new).at_least(:once).and_return(plugin_double)
+                allow(plugin_double).to receive(:allowed_extension?).and_raise(InstanceVerification::Exception, 'Malformed instance data')
+                post url, params: payload, headers: headers
+                expect(JSON.parse(response.body)['error']).to eq('Malformed instance data')
+                expect(response.message).to eq('Unprocessable Entity')
+                expect(response.code).to eq('422')
+              end
+            end
           end
 
           context 'with a not valid registration code' do

--- a/engines/strict_authentication/spec/requests/services_controller_spec.rb
+++ b/engines/strict_authentication/spec/requests/services_controller_spec.rb
@@ -67,6 +67,29 @@ RSpec.describe ServicesController, type: :request do
           end
           its(:code) { is_expected.to eq '200' }
         end
+
+        context 'when instance identifier error for all systems' do
+          let(:plugin_double) { instance_double('InstanceVerification::Providers::Example') }
+
+          before do
+            headers['X-Instance-Data'] = Base64.strict_encode64('IMDS')
+            allow_any_instance_of(InstanceVerification::Providers::Example).to(
+              receive(:instance_valid?).and_return(true)
+            )
+            allow(File).to receive(:directory?)
+            allow(Dir).to receive(:mkdir)
+            allow(FileUtils).to receive(:touch)
+            allow(InstanceVerification).to receive(:reg_code_in_cache?).and_return(nil)
+            allow(InstanceVerification).to receive(:update_cache)
+            allow(InstanceVerification::Providers::Example).to receive(:new).at_least(:once).and_return(plugin_double)
+            allow(plugin_double).to receive(:instance_valid?).and_return(true)
+            allow(plugin_double).to receive(:instance_identifier).and_raise(InstanceVerification::Exception, 'FOO')
+
+            get "/services/#{activated_service.id}", headers: headers
+          end
+          its(:code) { is_expected.to eq '200' }
+        end
+
       end
     end
 

--- a/engines/strict_authentication/spec/requests/services_controller_spec.rb
+++ b/engines/strict_authentication/spec/requests/services_controller_spec.rb
@@ -89,7 +89,6 @@ RSpec.describe ServicesController, type: :request do
           end
           its(:code) { is_expected.to eq '200' }
         end
-
       end
     end
 


### PR DESCRIPTION
## Description

whenever we call instance verification plugin methods, an exception can raise

Handle the possible exception to not return 500 error

* Related Issue / Ticket / Trello card: <link reference>

## How to test 

Make the methods for Instance Verification plugin to raise an exception
i.e., use wrong metadata or blank metadata, the request should return 422 not 500
and an appropiate error message, for example on GCP, with a borked token.

```bash
jesus-verify-exp:/home/jesusbv # registercloudguest
Registering system to registration proxy https://smt-gce.susecloud.net

Announcing system to https://smt-gce.susecloud.net ...
Error: Registration server returned 'Token decoding error: Could not find public key for kid 8e8fc8e556f7a76d08d35829d6f90ae2e12cfd0d' (422)

jesus-verify-exp:/home/jesusbv # 
```

## Change Type

*Please select the correct option.*

- [X] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

