### PR TITLE
Fix missing public/repo path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,7 @@ package/obs/.osc
 package/obs/rmt-cli.8.gz
 package/obs/_link
 package/systemsmanagement:SCC:RMT
-repo
+/public/repo/
 registry
 
 vendor/

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -68,22 +68,27 @@ In order to run the application locally using docker-compose:
    Center](https://scc.suse.com/organization). At this point you might also want
    to tweak the `EXTERNAL_PORT` environment variable from this file if you want
    to expose the main service with a port different than from the default one.
-3. Change the permissions on the `public` folder so anyone can access it (i.e.
-   `chmod -R 0777 public`). This is needed so the docker container can write
-   into this specific directory which is protected by default by the `rmt-cli`
-   tool.
-4. Build the image (can be also used to update gems)
+3. Build the image (can be also used to update gems)
     ```
     make build
     ```
-5. Run the server
+   Note that this will change the permissions on the `public` folder so anyone
+   can access it (i.e. `chmod -R 0777 public`). This is needed so the docker
+   container can write into this specific directory which is protected by default
+   by the `rmt-cli` tool.
+4. Run the server (Ctrl-C to terminate)
     ```
     make server
     ```
-6. Shell access
+   The server will be started in the foreground and must be terminated to get
+   back to the user's shell session.
+5. Shell access (Ctrl-D or `exit` to terminate)
     ```
     make shell
     ```
+   This will start an interactive shell session within the `rmt` container that
+   must be exited to return to the user's shell session.
+
 After doing all this, there will be `http://localhost:${EXTERNAL_PORT}` exposed
 to the network of the host, and you will be able to register clients by using
 this url. At this point, though, notice that there are two ways to run clients

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 NAME          = rmt-server
 VERSION       = $(shell ruby -e 'require "./lib/rmt.rb"; print RMT::VERSION')
 
-.PHONY: clean man dist build-tarball database-up server shell console
+.PHONY: clean man dist build-tarball database-up server shell console public_repo public_perm
 
 all:
 	@:
@@ -89,7 +89,7 @@ build-tarball: clean man
 database-up:
 	 docker compose up db -d
 
-build: Dockerfile Gemfile
+build: Dockerfile Gemfile public_perm
 	 docker compose build rmt
 
 server: build database-up
@@ -100,3 +100,11 @@ shell: build database-up
 
 console: build database-up
 	 docker compose run --rm -ti rmt bundle exec rails c
+
+public_repo:
+	@echo ensure public/repo exists
+	@mkdir -p public/repo
+
+public_perm: public_repo
+	@echo ensure public permission is 0777
+	@chmod -R 0777 public


### PR DESCRIPTION
## Description

With the removal of the public/repo/.gitignore file the public/repo directory is no longer included in the git repo, causing make build to fail due a missing public/repo directory.

To avoid problems cause by this issue, and additionally simplify the use of the docker compose development environment, this patch adds new make rules to ensure that both the public/repo path is created and then public hierarchy is updated with appropriate permissions. These new rules will be triggered as preconditions for the build rule.

Update the DEVELOPMENT.md file to reflect these changes, and also explicitly indicate that running the server rule leaves the server running in the foreground of the user's shell session, and the same is true for the shell rule.

Also update the toplevel .gitignore to explicitly ignore just the public/repo directory, rather than any occurrence of a directory or file with the name repo.


* Related Issue: #1352 

## How to test 

Run `make build` in a freshly checked out repo; without the change it will fail, with the change it will succeed, and will also automatically set the public repo to have 0777 permissions.

## Change Type

*Please select the correct option.*

- [ ] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

This a development environment setup change, which doesn't fall into any of the above categories.

## Checklist

*Please check off each item if the requirement is met.*

- [x] I have reviewed my own code and believe that it's ready for an external review.
- [ ] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

NOTE: This is a repeat of #1353 based upon a branch in the main repo, rather than a fork, so that the tests can run successfully.