### PR TITLE
Find system only necessary

### DIFF
--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -273,6 +273,7 @@ module SccProxy
     end
   end
 
+  # rubocop:disable Metrics/ClassLength
   class Engine < ::Rails::Engine
     isolate_namespace SccProxy
     config.generators.api_only = true
@@ -514,9 +515,9 @@ module SccProxy
               instance_data = Base64.decode64(request.headers['X-Instance-Data'].to_s) if request.headers['X-Instance-Data'].present?
               @system = find_system(login, instance_data)
               if @system.blank?
-                error = ActionController::TranslatedError.new(N_(
-                    "Can not find system with present credentials #{login} #{instance_data}"
-                ))
+                error = ActionController::TranslatedError.new(
+                  N_("Can not find system with present credentials #{login} #{instance_data}")
+                )
                 error.status = :unauthorized
                 raise error
               end
@@ -590,13 +591,10 @@ module SccProxy
             # check for possible duplicated system_tokens
             multiple_system_tokens = systems_with_token.group_by { |sys| sys[:system_token] }.keys
 
-            message = if multiple_system_tokens.length > 1
-                        "System with login #{login} authenticated, multiple system tokens (system tokens #{duplicated_system_tokens.join(',')})"
-                      else
-                        # no different systems
-                        # first system is chosen
-                        message = "System with login #{login} authenticated, system token #{system.system_token}"
-                      end
+            message = "System with login #{login} authenticated, system token #{system.system_token}"
+            if multiple_system_tokens.length > 1
+              message = "System with login #{login} authenticated, multiple system tokens (system tokens #{multiple_system_tokens.join(',')})"
+            end
           end
           logger.info _(message)
           system
@@ -632,3 +630,4 @@ module SccProxy
   end
 end
 # rubocop:enable Metrics/ModuleLength
+# rubocop:enable Metrics/ClassLength

--- a/engines/scc_proxy/spec/requests/api/connect/v3/systems/products_controller_spec.rb
+++ b/engines/scc_proxy/spec/requests/api/connect/v3/systems/products_controller_spec.rb
@@ -482,7 +482,7 @@ describe Api::Connect::V3::Systems::ProductsController, type: :request do
         end
 
 
-        context 'when system is connected to SCC' do
+        context 'when system is connected to SCC and multiple tokens' do
           let(:system_payg) do
             FactoryBot.create(:system, :payg, :with_system_information, :with_activated_base_product, instance_data: instance_data,
               system_token: new_system_token)

--- a/engines/zypper_auth/spec/requests/strict_authentication/authentication_controller_spec.rb
+++ b/engines/zypper_auth/spec/requests/strict_authentication/authentication_controller_spec.rb
@@ -360,11 +360,6 @@ describe StrictAuthentication::AuthenticationController, type: :request do
         end
 
         context 'when subscription is active' do
-          # let(:ltss_prod) do
-          #   system_hybrid.activations.find do |act|
-          #     act.product.product_class.include?('LTSS')
-          #   end
-          # end
           let(:body_active) do
             {
               id: 1,
@@ -579,6 +574,8 @@ describe StrictAuthentication::AuthenticationController, type: :request do
 
             before do
               allow(InstanceVerification).to receive(:verify_instance).and_return(true)
+              allow(InstanceVerification::Providers::Example).to receive(:new).and_return(plugin_double)
+              allow(plugin_double).to receive(:instance_identifier).and_return('i-1234')
               allow(DataExport::Handlers::Example).to receive(:new).and_return(data_export_double)
               expect(data_export_double).to receive(:export_rmt_data)
               get '/api/auth/check', headers: headers


### PR DESCRIPTION
## Description

Handle find_systems in two ways

- when there is instance identifier
- when there is not instance identifier

in the case that there is an instance identifier
in the request headers, it means we can check an exact match

if there is not an instance identifier in the headers,
we need to check for duplicates

* Related Issue / Ticket / Trello card: <link reference>

## How to test 

for an existing system in the DB with login as instance identifier:
  auth an instance with the same login, pass and token it should not update the token
  
 for an existing system in the DB with login not as instance identifier and token present:
   auth an instance with the same login pass and token it should not update the token
   
for an existing system in the DB with login not  as instance identifier and token not present (nil):
  auth an instance with the same login, pass and a new token, it should update the token  

## Change Type

*Please select the correct option.*

- [ ] **Bug Fix** (a non-breaking change which fixes an issue)
- [X] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

