### PR TITLE
Ignore errors when setting public permissions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,4 +107,4 @@ public_repo:
 
 public_perm: public_repo
 	@echo ensure public permission is 0777
-	@chmod -R 0777 public
+	@chmod -fR 0777 public || true


### PR DESCRIPTION
Once public/repo has been populated by a running RMT it may not be possible to update the permissions on files due to ownership changes. Also quieten the associated error messages.
