### PR TITLE
docker compose development environment enhancements

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -82,12 +82,15 @@ In order to run the application locally using docker-compose:
     ```
    The server will be started in the foreground and must be terminated to get
    back to the user's shell session.
+   NOTE: If you want to interact with the RMT server, leave this running.
 5. Shell access (Ctrl-D or `exit` to terminate)
     ```
     make shell
     ```
    This will start an interactive shell session within the `rmt` container that
    must be exited to return to the user's shell session.
+   NOTE: You will need to run this in a separate user shell session (window) if
+   you want to leave the RMT instance started by `make server` up and running.
 
 After doing all this, there will be `http://localhost:${EXTERNAL_PORT}` exposed
 to the network of the host, and you will be able to register clients by using

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ build-tarball: clean man
 database-up:
 	 docker compose up db -d
 
-build: Dockerfile Gemfile public_perm
+build: Dockerfile Gemfile public_repo
 	 docker compose build rmt
 
 server: build database-up
@@ -104,7 +104,4 @@ console: build database-up
 public_repo:
 	@echo ensure public/repo exists
 	@mkdir -p public/repo
-
-public_perm: public_repo
-	@echo ensure public permission is 0777
-	@chmod -fR 0777 public || true
+	@chmod -f 0777 public/repo || true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 
 ActiveRecord::Schema.define(version: 2025_03_19_155325) do
 
-  create_table "activations", charset: "utf8", force: :cascade do |t|
+  create_table "activations", charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.bigint "service_id", null: false
     t.bigint "system_id", null: false
     t.datetime "created_at", null: false
@@ -24,14 +24,14 @@ ActiveRecord::Schema.define(version: 2025_03_19_155325) do
     t.index ["system_id"], name: "index_activations_on_system_id"
   end
 
-  create_table "deregistered_systems", charset: "utf8", force: :cascade do |t|
+  create_table "deregistered_systems", charset: "utf8mb4", collation: "utf8mb4_unicode_520_ci", force: :cascade do |t|
     t.bigint "scc_system_id", null: false, comment: "SCC IDs of deregistered systems; used for forwarding to SCC"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["scc_system_id"], name: "index_deregistered_systems_on_scc_system_id", unique: true
   end
 
-  create_table "downloaded_files", charset: "utf8", force: :cascade do |t|
+  create_table "downloaded_files", charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.string "checksum_type"
     t.string "checksum"
     t.string "local_path", limit: 512
@@ -40,7 +40,7 @@ ActiveRecord::Schema.define(version: 2025_03_19_155325) do
     t.index ["local_path"], name: "index_downloaded_files_on_local_path", unique: true
   end
 
-  create_table "hw_infos", charset: "utf8", force: :cascade do |t|
+  create_table "hw_infos", charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.integer "cpus"
     t.integer "sockets"
     t.string "hypervisor"
@@ -55,7 +55,7 @@ ActiveRecord::Schema.define(version: 2025_03_19_155325) do
     t.index ["system_id"], name: "index_hw_infos_on_system_id", unique: true
   end
 
-  create_table "product_predecessors", charset: "utf8", force: :cascade do |t|
+  create_table "product_predecessors", charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.bigint "product_id", null: false
     t.bigint "predecessor_id"
     t.integer "kind", default: 0, null: false
@@ -64,7 +64,7 @@ ActiveRecord::Schema.define(version: 2025_03_19_155325) do
     t.index ["product_id"], name: "index_product_predecessors_on_product_id"
   end
 
-  create_table "products", charset: "utf8", force: :cascade do |t|
+  create_table "products", charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.string "name"
     t.text "description"
     t.string "shortname"
@@ -82,7 +82,7 @@ ActiveRecord::Schema.define(version: 2025_03_19_155325) do
     t.string "friendly_version"
   end
 
-  create_table "products_extensions", charset: "utf8", force: :cascade do |t|
+  create_table "products_extensions", charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.bigint "product_id", null: false
     t.bigint "extension_id", null: false
     t.boolean "recommended"
@@ -94,7 +94,7 @@ ActiveRecord::Schema.define(version: 2025_03_19_155325) do
     t.index ["root_product_id"], name: "fk_rails_7d0e68d364"
   end
 
-  create_table "repositories", charset: "utf8", force: :cascade do |t|
+  create_table "repositories", charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.bigint "scc_id", unsigned: true
     t.string "name", null: false
     t.string "description"
@@ -112,7 +112,7 @@ ActiveRecord::Schema.define(version: 2025_03_19_155325) do
     t.index ["scc_id"], name: "index_repositories_on_scc_id", unique: true
   end
 
-  create_table "repositories_services", charset: "utf8", force: :cascade do |t|
+  create_table "repositories_services", charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.bigint "repository_id", null: false
     t.bigint "service_id", null: false
     t.index ["repository_id"], name: "index_repositories_services_on_repository_id"
@@ -120,21 +120,21 @@ ActiveRecord::Schema.define(version: 2025_03_19_155325) do
     t.index ["service_id"], name: "index_repositories_services_on_service_id"
   end
 
-  create_table "services", charset: "utf8", force: :cascade do |t|
+  create_table "services", charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.bigint "product_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["product_id"], name: "index_services_on_product_id", unique: true
   end
 
-  create_table "subscription_product_classes", charset: "utf8", force: :cascade do |t|
+  create_table "subscription_product_classes", charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.bigint "subscription_id", null: false
     t.string "product_class", null: false
     t.index ["subscription_id", "product_class"], name: "index_product_class_unique", unique: true
     t.index ["subscription_id"], name: "index_subscription_product_classes_on_subscription_id"
   end
 
-  create_table "subscriptions", charset: "utf8", force: :cascade do |t|
+  create_table "subscriptions", charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.string "regcode", null: false
     t.string "name", null: false
     t.string "kind", null: false
@@ -149,7 +149,7 @@ ActiveRecord::Schema.define(version: 2025_03_19_155325) do
     t.index ["regcode"], name: "index_subscriptions_on_regcode"
   end
 
-  create_table "system_uptimes", charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
+  create_table "system_uptimes", charset: "utf8mb4", collation: "utf8mb4_unicode_520_ci", force: :cascade do |t|
     t.bigint "system_id", null: false
     t.date "online_at_day", null: false
     t.binary "online_at_hours", limit: 24, null: false
@@ -158,7 +158,7 @@ ActiveRecord::Schema.define(version: 2025_03_19_155325) do
     t.index ["system_id", "online_at_day"], name: "id_online_day", unique: true
   end
 
-  create_table "systems", charset: "utf8", force: :cascade do |t|
+  create_table "systems", charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.string "login"
     t.string "password"
     t.string "hostname"
@@ -169,10 +169,11 @@ ActiveRecord::Schema.define(version: 2025_03_19_155325) do
     t.datetime "scc_registered_at"
     t.bigint "scc_system_id", comment: "System ID in SCC (if the system registration was forwarded; needed for forwarding de-registrations)"
     t.boolean "proxy_byos", default: false
-    t.integer "proxy_byos_mode", default: 0
     t.string "system_token"
-    t.text "system_information", size: :long
+    t.text "system_information", size: :long, collation: "utf8mb4_bin"
     t.text "instance_data"
+    t.integer "proxy_byos_mode", default: 0
+    t.string "pubcloud_reg_code"
     t.index ["login", "password", "system_token"], name: "index_systems_on_login_and_password_and_system_token", unique: true
     t.index ["login", "password"], name: "index_systems_on_login_and_password"
     t.index ["system_token"], name: "index_systems_on_system_token"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: mariadb:10.2
+    image: registry.suse.com/suse/mariadb:10.11
     restart: unless-stopped
     volumes:
       - mariadb:/var/lib/mysql


### PR DESCRIPTION
As it appears that only the public/repo directory requires modified permissions, enhance the Makefile build rules to ensure that those permissions are being applied to the directory after ensuring that it exists, and avoid changing the permissions for other files and directories under public.

Update the docker-compose.yml's MariaDB version to match the version found in SLE 15 SP7, namely version 10.11, and switch to using the SUSE built version, available from registry.suse.com.

Updated db/schema.rb:
  * Updated charset and collation settings triggered by running the rails db:migrate against the SLE 15 SP7 MariaDB 10.11 DB.
  * Re-orders the proxy_byos_mode and system_information fields in the systems table, adding a collation setting for the latter.
  * Adds the missing pubcloud_reg_code field to the db/schema.rb to align with db/migrate/20250121104357_add_regcode_to_systems.rb.

Updated DEVELOPMENT.md to explicitly call out that the make server and make shell commands may need to be run in separate user shell sessions/windows.