### PR TITLE
Fix only one handler for data exporter

### DIFF
--- a/engines/data_export/lib/data_export.rb
+++ b/engines/data_export/lib/data_export.rb
@@ -18,6 +18,8 @@ require 'data_export/handler_base'
 
 handlers = Dir.glob(File.join(__dir__, 'data_export/handlers/*.rb'))
 
+logger.info 'No data exporter handler found' unless handlers.size
+
 raise 'Too many data export handlers found' if handlers.size > 1
 
 # rubocop:disable Lint:UnreachableLoop

--- a/engines/data_export/lib/data_export/engine.rb
+++ b/engines/data_export/lib/data_export/engine.rb
@@ -27,7 +27,10 @@ module DataExport
       end
 
       Api::Connect::V3::Systems::SystemsController.class_eval do
-        after_action :export_rmt_data, only: %i[update], if: -> { DataExport.handler.presence && response.successful? && !@system.byos? && @system.products.present? }
+        after_action :export_rmt_data, only: %i[update], if: lambda {
+          DataExport.handler.presence && response.successful? && !@system.byos? &&
+          @system.products.present?
+        }
 
         def export_rmt_data
           @system.products.pluck(:name).each do |prod_name|

--- a/engines/data_export/lib/data_export/engine.rb
+++ b/engines/data_export/lib/data_export/engine.rb
@@ -4,7 +4,7 @@ module DataExport
     config.after_initialize do
       # replaces RMT registration for SCC registration
       Api::Connect::V3::Subscriptions::SystemsController.class_eval do
-        after_action :export_rmt_data, only: %i[announce_system], if: -> { response.successful? && !@system.byos? }
+        after_action :export_rmt_data, only: %i[announce_system], if: -> { DataExport.handler.presence && response.successful? && !@system.byos? }
 
         def export_rmt_data
           # no need to check if system is nil
@@ -27,7 +27,7 @@ module DataExport
       end
 
       Api::Connect::V3::Systems::SystemsController.class_eval do
-        after_action :export_rmt_data, only: %i[update], if: -> { response.successful? && !@system.byos? && @system.products.present? }
+        after_action :export_rmt_data, only: %i[update], if: -> { DataExport.handler.presence && response.successful? && !@system.byos? && @system.products.present? }
 
         def export_rmt_data
           @system.products.pluck(:name).each do |prod_name|
@@ -57,7 +57,7 @@ module DataExport
       end
 
       Api::Connect::V3::Systems::ProductsController.class_eval do
-        after_action :export_rmt_data, only: %i[activate upgrade], if: -> { response.successful? && !@system.byos? }
+        after_action :export_rmt_data, only: %i[activate upgrade], if: -> { DataExport.handler.presence && response.successful? && !@system.byos? }
 
         def export_rmt_data
           params[:dw_product_name] = @product.name

--- a/package/obs/rmt-server.spec
+++ b/package/obs/rmt-server.spec
@@ -392,6 +392,9 @@ fi
 
 %post pubcloud
 %service_add_post rmt-server-regsharing.service rmt-server-trim-cache.service
+if [ $"(ls %{data_dir}/engines/data_export/lib/data_export/handlers/ | grep '*.rb' | wc -l > 1)" ]; then
+    mv %{data_dir}/engines/data_export/lib/data_export/handlers/example.rb %{data_dir}/engines/data_export/lib/data_export/handlers/example
+fi
 
 %preun pubcloud
 %service_del_preun rmt-server-regsharing.service rmt-server-trim-cache.service

--- a/package/obs/rmt-server.spec
+++ b/package/obs/rmt-server.spec
@@ -392,9 +392,6 @@ fi
 
 %post pubcloud
 %service_add_post rmt-server-regsharing.service rmt-server-trim-cache.service
-if [ $"(ls %{data_dir}/engines/data_export/lib/data_export/handlers/ | grep '*.rb' | wc -l > 1)" ]; then
-    mv %{data_dir}/engines/data_export/lib/data_export/handlers/example.rb %{data_dir}/engines/data_export/lib/data_export/handlers/example
-fi
 
 %preun pubcloud
 %service_del_preun rmt-server-regsharing.service rmt-server-trim-cache.service


### PR DESCRIPTION
## Description

if there are more than one handler for the data exporter, RMT will fail

Under the scenario of someone implementing their own handler, i.e. foo.rb and placing it there, they may rename or move example.rb and that would be OK

but if RMT gets updated it will place example.rb in the same location, making two handlers for the data exporter when it should be only one

This fixes that scenario and fixes bsc#1248869

* Related Issue / Ticket / Trello card: [bsc#1248869](https://bugzilla.suse.com/show_bug.cgi?id=1248869
)
## How to test 

On a server with RMT and data export engine with a handler, i.e. handler.rb, example.rb should be move to example in the same directory

## Change Type

*Please select the correct option.*

- [X] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

