### PR TITLE
Set resque in the main config

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -4,7 +4,7 @@ require 'rails'
 
 # Pick the frameworks you want:
 require 'active_model/railtie'
-require "active_job/railtie"
+require 'active_job/railtie'
 require 'active_record/railtie'
 # require "active_storage/engine"
 require 'action_controller/railtie'


### PR DESCRIPTION
## Description

Set the queue adapter in the main config because setting in the engine has no effect

* Related Issue / Ticket / Trello card: <link reference>

## How to test 

On a test infra update server
- start valkey `valkey-server` (changes for that also implemented)
- start the worker
- run a job:
```bash
> RAILS_ENV=production bin/rails runner 'FirehoseJob.perform_later(1)'
I, [2025-11-05T12:04:28.755317 #7732]  INFO -- : Enqueued FirehoseJob (Job ID: 6f1e17df-1c4e-423f-b351-f2a0cbbbb99f) to Resque(default) with arguments: 1
```
notice the `Resque(default)`

When the line of this change/PR is not present or present in the data export engine
the same command produces
`I, [2025-11-05T12:00:52.129572 #6769]  INFO -- : Enqueued FirehoseJob (Job ID: 95ec3cc6-f765-431d-8e90-08682a4c6fb8) to Async(default) with arguments: 1`

Notice the `Async` instead of `Resque`

in the rails console one can see the job as well
```bash
irb(main):012:0> Resque.info
=> {:pending=>0, :processed=>1, :queues=>1, :workers=>1, :working=>0, :failed=>56, :servers=>["<Redis::Namespace v1.11.0 with client v5.1.0 for redis://localhost:6379/0/resque>"], :environment=>"production"}
irb(main):013:0>
```

and in the log of the worker
```bash
test-rmt-ec2-1-eu-central-1a:/usr/share/rmt # RAILS_ENV=production bundle exec rake environment resque:work QUEUE='*' LOGGING=1
/usr/lib64/rmt/vendor/bundle/ruby/2.5.0/gems/ruby-next-core-1.0.3/lib/.rbnext/2.6/ruby-next/core/data.rb:5: warning: constant ::Data is deprecated
*** Starting worker test-rmt-ec2-1-eu-central-1a:7707:*
*** got: (Job{default} | ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper | [{"job_class"=>"FirehoseJob", "job_id"=>"6f1e17df-1c4e-423f-b351-f2a0cbbbb99f", "provider_job_id"=>nil, "queue_name"=>"default", "priority"=>nil, "arguments"=>[1], "executions"=>0, "exception_executions"=>{}, "locale"=>"en", "timezone"=>"UTC", "enqueued_at"=>"2025-11-05T12:04:28Z"}])
*** Running before_fork hooks with [(Job{default} | ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper | [{"job_class"=>"FirehoseJob", "job_id"=>"6f1e17df-1c4e-423f-b351-f2a0cbbbb99f", "provider_job_id"=>nil, "queue_name"=>"default", "priority"=>nil, "arguments"=>[1], "executions"=>0, "exception_executions"=>{}, "locale"=>"en", "timezone"=>"UTC", "enqueued_at"=>"2025-11-05T12:04:28Z"}])]
*** Running after_fork hooks with [(Job{default} | ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper | [{"job_class"=>"FirehoseJob", "job_id"=>"6f1e17df-1c4e-423f-b351-f2a0cbbbb99f", "provider_job_id"=>nil, "queue_name"=>"default", "priority"=>nil, "arguments"=>[1], "executions"=>0, "exception_executions"=>{}, "locale"=>"en", "timezone"=>"UTC", "enqueued_at"=>"2025-11-05T12:04:28Z"}])]
I, [2025-11-05T12:04:29.315327 #7743]  INFO -- : Performing FirehoseJob (Job ID: 6f1e17df-1c4e-423f-b351-f2a0cbbbb99f) from Resque(default) enqueued at 2025-11-05T12:04:28Z with arguments: 1
Testing the resque config
I, [2025-11-05T12:04:29.315997 #7743]  INFO -- : Performed FirehoseJob (Job ID: 6f1e17df-1c4e-423f-b351-f2a0cbbbb99f) from Resque(default) in 0.4ms
*** done: (Job{default} | ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper | [{"job_class"=>"FirehoseJob", "job_id"=>"6f1e17df-1c4e-423f-b351-f2a0cbbbb99f", "provider_job_id"=>nil, "queue_name"=>"default", "priority"=>nil, "arguments"=>[1], "executions"=>0, "exception_executions"=>{}, "locale"=>"en", "timezone"=>"UTC", "enqueued_at"=>"2025-11-05T12:04:28Z"}])
```
## Change Type

*Please select the correct option.*

- [X] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [x] I have reviewed my own code and believe that it's ready for an external review.
- [x] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

