### PR TITLE
Simplify running against a local SCC

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,8 +13,10 @@ RMT_METRICS_ENABLED=
 PROMETHEUS_JOB_NAME=
 
 # In case you want to run against a local SCC
-# SCC_HOST=http://localhost:3000/connect
-# hint: make sure to run the rmt container with port forwarding or --network host to allow access
+# SCC_HOST=http://localscc:3000/connect
+# NOTE: Ensure that localscc is configured in the /etc/hosts of the
+# environment where the RMT is running. The docker-compose.yml does
+# this automatically using an extra_hosts entry.
 
 # Credentials
 SCC_USERNAME=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
     volumes:
       - .:/srv/www/rmt
       - ./config/rmt.yml:/etc/rmt.conf
+    extra_hosts:
+      - "localscc=host-gateway"
     depends_on:
       - db
     pre_stop:


### PR DESCRIPTION
Update the .env.example SCC_HOST commented out example to use the localscc host alias rather than localhost to reference the target SCC instance, and update the docker-compose.yml's rmt definition to add an appropriate host alias in the rmt's /etc/host.