### PR TITLE
Changelog: add missing CVE-2026-26962 to v2.27

### DIFF
--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -3,8 +3,8 @@ Fri Apr 10 11:26:01 UTC 2026 - Adnilson Delgado <adnilson.delgado@suse.com>
 
 - Version 2.27
   * Update rack, fix CVE-2026-34763, CVE-2026-34230, CVE-2026-26961, CVE-2026-34786, CVE-2026-34831,
-    CVE-2026-34826, CVE-2026-34830, CVE-2026-34785, CVE-2026-34829, CVE-2026-26962 (bsc#1261388, bsc# 1261398,
-    bsc# 1261406, bsc# 1261417, bsc# 1261426, bsc# 1261436, bsc# 1261447, bsc# 1261458, bsc# 1261466, bsc# 1261471)
+    CVE-2026-34826, CVE-2026-34830, CVE-2026-34785, CVE-2026-34829, CVE-2026-26962 (bsc#1261388, bsc#1261398,
+    bsc#1261406, bsc#1261417, bsc#1261426, bsc#1261436, bsc#1261447, bsc#1261458, bsc#1261466, bsc#1261471)
   * fixes ReDoS vulnerability in Addressable
   * fixes Out-of-bounds Read vulnerability in rdiscount
 

--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -3,8 +3,8 @@ Fri Apr 10 11:26:01 UTC 2026 - Adnilson Delgado <adnilson.delgado@suse.com>
 
 - Version 2.27
   * Update rack, fix CVE-2026-34763, CVE-2026-34230, CVE-2026-26961, CVE-2026-34786, CVE-2026-34831,
-    CVE-2026-34826, CVE-2026-34830, CVE-2026-34785, CVE-2026-34829 (bsc#1261388, bsc# 1261398, bsc# 1261406,
-    bsc# 1261417, bsc# 1261426, bsc# 1261436, bsc# 1261447, bsc# 1261458, bsc# 1261466, bsc# 1261471)
+    CVE-2026-34826, CVE-2026-34830, CVE-2026-34785, CVE-2026-34829, CVE-2026-26962 (bsc#1261388, bsc# 1261398,
+    bsc# 1261406, bsc# 1261417, bsc# 1261426, bsc# 1261436, bsc# 1261447, bsc# 1261458, bsc# 1261466, bsc# 1261471)
   * fixes ReDoS vulnerability in Addressable
   * fixes Out-of-bounds Read vulnerability in rdiscount
 


### PR DESCRIPTION
The CVE-2026-26962 was mentioned via its Bugzilla ID (bsc#1261471) but the CVE ID itself was missing from the Version 2.27 changelog entry. This PR adds it.