### PR TITLE
Use ruby 3.4 as a default for SLE15SP7

### DIFF
--- a/package/obs/rmt-server.spec
+++ b/package/obs/rmt-server.spec
@@ -25,7 +25,7 @@
 %define rmt_group    nginx
 
 # SLE 15 SP7 and newer (including 16.0/Factory) support Ruby 3.4
-%if 0%{?sle_version} && 0%{?sle_version} >= 150700
+%if 0%{?sle_version} && 0%{?sle_version} == 150700
 %define rb_build_versions     ruby34
 %define rb_build_ruby_abis    ruby:3.4.0
 %define ruby_version          ruby3.4

--- a/package/obs/rmt-server.spec
+++ b/package/obs/rmt-server.spec
@@ -24,10 +24,17 @@
 %define rmt_user     _rmt
 %define rmt_group    nginx
 
+# SLE 15 SP7 and newer (including 16.0/Factory) support Ruby 3.4
+%if 0%{?sle_version} && 0%{?sle_version} >= 150700
+%define rb_build_versions     ruby34
+%define rb_build_ruby_abis    ruby:3.4.0
+%define ruby_version          ruby3.4
+%else
 # Only build for the distribution default Ruby version
 %define rb_build_versions     %{rb_default_ruby}
 %define rb_build_ruby_abis    %{rb_default_ruby_abi}
 %define ruby_version          %{rb_default_ruby_suffix}
+%endif
 
 # disabling dwz for now, as it is not available in SLE15
 # related bugzilla https://bugzilla.suse.com/show_bug.cgi?id=1180984
@@ -190,7 +197,7 @@ ln -fs %{_sbindir}/service %{buildroot}%{_sbindir}/rcrmt-server-trim-cache
 mkdir -p %{buildroot}%{_sysconfdir}
 mv %{_builddir}/rmt.conf %{buildroot}%{_sysconfdir}/rmt.conf
 
-# valkey 
+# valkey
 mkdir -p %{buildroot}/var/lib/valkey/6380
 install -D -m 644 package/files/valkey-6380.conf %{buildroot}%{_sysconfdir}/valkey/6380.conf
 


### PR DESCRIPTION
## Description

The default Ruby version in SLE15 is 2.5 and this PR makes sure that when building the default version is 3.4

* Related Issue / Ticket / Trello card: <link reference>

## How to test 

<!-- Describe the steps how verify your change -->

## Change Type

*Please select the correct option.*

- [ ] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [ ] I have reviewed my own code and believe that it's ready for an external review.
- [ ] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

