### PR TITLE
Fix error when loading yaml

### DIFF
--- a/engines/registry/app/models/access_scope.rb
+++ b/engines/registry/app/models/access_scope.rb
@@ -83,7 +83,7 @@ class AccessScope
 
   def allowed_paths(system, remote_ip)
     repo_list = RegistryCatalogService.new.repos(system, reload: false)
-    access_policies_yml = YAML.safe_load(
+    access_policies_yml = YAML.unsafe_load(
       File.read(Rails.application.config.access_policies)
     )
     active_product_classes = system.activations.includes(:product).pluck(:product_class)

--- a/engines/registry/spec/app/models/access_scope_spec.rb
+++ b/engines/registry/spec/app/models/access_scope_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe AccessScope, type: :model do
 
         it 'returns default auth actions (no free repos included)' do
           yaml_string = access_policy_content
-          data = YAML.safe_load yaml_string
+          data = YAML.unsafe_load yaml_string
           data[product1.product_class] = 'suse/sles/**'
           File.write('engines/registry/spec/data/access_policy_yaml.yml', YAML.dump(data))
           allow_any_instance_of(RegistryCatalogService).to receive(:repos).and_return(['suse/sles/super_repo'])
@@ -250,7 +250,7 @@ RSpec.describe AccessScope, type: :model do
               product1
             )
             yaml_string = access_policy_content
-            data = YAML.safe_load yaml_string
+            data = YAML.unsafe_load yaml_string
             data[product1.product_class] = 'suse/ltss/**'
             File.write('engines/registry/spec/data/access_policy_yaml.yml', YAML.dump(data))
             allow_any_instance_of(RegistryCatalogService).to receive(:repos).and_return(['suse/ltss/ltss_repo'])


### PR DESCRIPTION
## Description

Psych gem changed the default behaviour around expanding aliases in
Ruby 3 and it raises an error when loading a yaml file

see [rails/rails#42257](https://github.com/rails/rails/pull/42257) for more info

* Related Issue / Ticket / Trello card: <link reference>

## How to test 

<!-- Describe the steps how verify your change -->

## Change Type

*Please select the correct option.*

- [X] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

