### PR TITLE
Sidekiq new version does not use redis-namespaces

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -119,4 +119,3 @@ gem 'repomd_parser'
 
 # Use Sidekiq for ActiveJob
 gem 'sidekiq'
-gem 'redis-namespace'

--- a/Gemfile
+++ b/Gemfile
@@ -118,4 +118,4 @@ gem 'ronn-ng'
 gem 'repomd_parser'
 
 # Use Sidekiq for ActiveJob
-gem 'sidekiq'
+gem 'sidekiq', '>= 7.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -471,7 +471,7 @@ DEPENDENCIES
   ruby_parser
   scc-codestyle (~> 0.7.0)
   shoulda-matchers
-  sidekiq
+  sidekiq (>= 7.0)
   simplecov
   spring
   spring-commands-rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -242,12 +242,8 @@ GEM
       tsort
     readline (0.0.4)
       reline
-    redis (5.4.1)
-      redis-client (>= 0.22.0)
     redis-client (0.28.0)
       connection_pool
-    redis-namespace (1.11.0)
-      redis (>= 4)
     regexp_parser (2.11.3)
     reline (0.6.3)
       io-console (~> 0.5)
@@ -464,7 +460,6 @@ DEPENDENCIES
   puma
   rackup
   railties (~> 8.1.0)
-  redis-namespace
   repomd_parser
   responders
   ronn-ng

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -8,7 +8,7 @@ redis_config = {
   url: Settings.try(:redis).try(:url) || 'redis://127.0.0.1:6380/0',
   connect_timeout: 10,
   reconnect_attempts: 3,
-  namespace: 'rmt_sidekiq'
+  db: 1
 }
 
 # :nocov:


### PR DESCRIPTION
## Description

Support for redis-namespace has been removed
One option is to use Redis's numbered databases instead

See [sidekiq-release-doc](https://github.com/sidekiq/sidekiq/blob/main/docs/7.0-Upgrade.md#redis-namespace) for more info

* Related Issue / Ticket / Trello card: <link reference>

## How to test 

<!-- Describe the steps how verify your change -->

## Change Type

*Please select the correct option.*

- [X] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

