### PR TITLE
Refactor registry generalize

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -108,6 +108,8 @@ gem 'ronn-ng'
 
 gem 'repomd_parser'
 
+gem 'benchmark'
+
 # Use Sidekiq for ActiveJob
 gem 'sidekiq'
 gem 'redis-namespace'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,7 @@ GEM
     awesome_print (1.9.2)
     base32 (0.3.4)
     base64 (0.3.0)
+    benchmark (0.4.0)
     bigdecimal (4.0.1)
     bootsnap (1.19.0)
       msgpack (~> 1.2)
@@ -502,6 +503,7 @@ DEPENDENCIES
   active_model_serializers
   awesome_print
   base32
+  benchmark
   bootsnap
   byebug
   config

--- a/config/rmt.yml
+++ b/config/rmt.yml
@@ -57,7 +57,7 @@ connect_api:
 redis:
   url: <%= ENV.fetch('REDIS_URL', nil) %>
 
-# Optional registry setup. If used the values cannot be empty
+# Optional registry engine setup. If used the values cannot be empty
 # registry:
 #   service:
 #   realm:

--- a/config/rmt.yml
+++ b/config/rmt.yml
@@ -56,6 +56,8 @@ connect_api:
 
 redis:
   url: <%= ENV.fetch('REDIS_URL', nil) %>
-registry:
-  service:
-  realm:
+
+# Optional registry setup. If used the values cannot be empty
+# registry:
+#   service:
+#   realm:

--- a/config/rmt.yml
+++ b/config/rmt.yml
@@ -56,3 +56,6 @@ connect_api:
 
 redis:
   url: <%= ENV.fetch('REDIS_URL', nil) %>
+registry:
+  service:
+  realm:

--- a/engines/registry/app/controllers/registry/registry_controller.rb
+++ b/engines/registry/app/controllers/registry/registry_controller.rb
@@ -2,7 +2,6 @@ module Registry
   class RegistryAuthError < ArgumentError; end
 
   class RegistryController < Registry::ApplicationController
-    REGISTRY_SERVICE = 'SUSE Linux OCI Registry'.freeze
     REGISTRY_API_VERSION = 'registry/2.0'.freeze
 
     before_action :set_requested_scopes, except: [ :catalog ]
@@ -69,7 +68,8 @@ module Registry
       # skip authentication if this is not a login request
       return unless request.authorization
 
-      authenticate_or_request_with_http_basic('SUSE Registry Authentication') do |login, password|
+      realm = Settings.try[:registry].try(:realm) rescue ''
+      authenticate_or_request_with_http_basic(realm) do |login, password|
         begin
           @client = Registry::AuthenticatedClient.new(login, password, request.remote_ip)
         rescue StandardError
@@ -102,9 +102,10 @@ module Registry
 
     # is called by authenticate_or_request_with_http_token when client provides no token
     def request_http_token_authentication(realm = authorize_url, message = 'authentication required')
+      service = Settings.try[:registry].try(:service) rescue ''
       www_authenticate = [
         %(Bearer realm="#{realm.delete('"')}"),
-        %(service="#{REGISTRY_SERVICE.delete('"')}"),
+        %(service="#{service.delete('"')}"),
         %(scope="registry:catalog:*")
       ]
 

--- a/engines/registry/app/controllers/registry/registry_controller.rb
+++ b/engines/registry/app/controllers/registry/registry_controller.rb
@@ -68,7 +68,9 @@ module Registry
       # skip authentication if this is not a login request
       return unless request.authorization
 
-      realm = Settings.try[:registry].try(:realm) rescue ''
+      realm = Settings.try(:registry).try(:realm)
+      raise RegistryAuthError, 'registry not configured properly in /etc/rmt.conf' if realm.blank?
+
       authenticate_or_request_with_http_basic(realm) do |login, password|
         begin
           @client = Registry::AuthenticatedClient.new(login, password, request.remote_ip)
@@ -102,7 +104,9 @@ module Registry
 
     # is called by authenticate_or_request_with_http_token when client provides no token
     def request_http_token_authentication(realm = authorize_url, message = 'authentication required')
-      service = Settings.try[:registry].try(:service) rescue ''
+      service = Settings.try(:registry).try(:service)
+      raise RegistryAuthError, 'registry not configured properly in /etc/rmt.conf' if service.blank?
+
       www_authenticate = [
         %(Bearer realm="#{realm.delete('"')}"),
         %(service="#{service.delete('"')}"),

--- a/engines/registry/app/models/access_token.rb
+++ b/engines/registry/app/models/access_token.rb
@@ -5,7 +5,7 @@ require 'base32'
 class AccessToken
   def initialize(account, service, granted_scopes)
     @account = account
-    @service = service # "SUSE Linux OCI Registry"
+    @service = service
     @granted_scopes = granted_scopes
   end
 

--- a/engines/registry/app/services/registry_catalog_service.rb
+++ b/engines/registry/app/services/registry_catalog_service.rb
@@ -39,6 +39,8 @@ class RegistryCatalogService
     framework = InstanceVerification.provider.name.rpartition('::')[2].downcase
     uri = URI.parse(URI.join("https://registry-#{framework}.susecloud.net", AUTH_URL).to_s)
     service = Settings.try(:registry).try(:service) rescue ''
+    raise StandardError, 'registry not configured properly in /etc/rmt.conf' if service.blank?
+
     catalog_token_params = {
       service: service,
       account: system.login,

--- a/engines/registry/app/services/registry_catalog_service.rb
+++ b/engines/registry/app/services/registry_catalog_service.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require 'json'
 require 'net/http'
 require 'benchmark'
@@ -5,7 +6,6 @@ require 'benchmark'
 CATALOG_API_URL = 'http://127.0.0.1:5000/v2/_catalog'.freeze
 AUTH_URL = 'api/registry/authorize'.freeze
 CATALOG_SCOPE = 'registry:catalog:*'.freeze
-SERVICE = 'SUSE Linux OCI Registry'.freeze
 
 class RegistryCatalogService
   attr_accessor :catalog_api_url
@@ -39,8 +39,9 @@ class RegistryCatalogService
   def catalog_token(system)
     framework = InstanceVerification.provider.name.rpartition('::')[2].downcase
     uri = URI.parse(URI.join("https://registry-#{framework}.susecloud.net", AUTH_URL).to_s)
+    service = Settings.try(:registry).try(:service) rescue ''
     catalog_token_params = {
-      service: SERVICE,
+      service: service,
       account: system.login,
       scope: CATALOG_SCOPE
     }

--- a/engines/registry/app/services/registry_catalog_service.rb
+++ b/engines/registry/app/services/registry_catalog_service.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 require 'json'
 require 'net/http'
 require 'benchmark'

--- a/engines/registry/app/services/registry_catalog_service.rb
+++ b/engines/registry/app/services/registry_catalog_service.rb
@@ -38,7 +38,7 @@ class RegistryCatalogService
   def catalog_token(system)
     framework = InstanceVerification.provider.name.rpartition('::')[2].downcase
     uri = URI.parse(URI.join("https://registry-#{framework}.susecloud.net", AUTH_URL).to_s)
-    service = Settings.try(:registry).try(:service) rescue ''
+    service = Settings.try(:registry).try(:service)
     raise StandardError, 'registry not configured properly in /etc/rmt.conf' if service.blank?
 
     catalog_token_params = {

--- a/engines/registry/spec/app/controllers/registry_controller_spec.rb
+++ b/engines/registry/spec/app/controllers/registry_controller_spec.rb
@@ -59,7 +59,9 @@ module Registry
           allow(Settings).to receive(:try).with(:registry).and_return({})
           # allow(settings_registry).to receive(:try).with(:realm).and_return(registry_realm)
           allow_any_instance_of(AuthenticatedClient).to receive(:cache_file_exist?).and_return(true)
-          expect { get('/api/registry/authorize', headers: auth_headers) }.to raise_error(RegistryAuthError, 'registry not configured properly in /etc/rmt.conf')
+          expect { get('/api/registry/authorize', headers: auth_headers) }.to raise_error(
+            RegistryAuthError, 'registry not configured properly in /etc/rmt.conf'
+          )
         end
       end
     end

--- a/engines/registry/spec/app/controllers/registry_controller_spec.rb
+++ b/engines/registry/spec/app/controllers/registry_controller_spec.rb
@@ -94,6 +94,10 @@ module Registry
         end
 
         context 'with a valid token' do
+          let(:settings_registry) do
+            { service: 'foo', realm: 'bar' }
+          end
+
           it 'has catalog access' do
             allow(File).to receive(:read).and_return(access_policy_content)
             allow_any_instance_of(AuthenticatedClient).to receive(:cache_file_exist?).and_return(true)
@@ -104,7 +108,8 @@ module Registry
               )
 
             auth_headers_token['Authorization'] = format("Bearer #{json_response[:token]}")
-            allow(Settings).to receive_message_chain(:registry, :service).and_return(registry_service)
+            allow(Settings).to receive(:try).with(:registry).and_return(settings_registry)
+            allow(settings_registry).to receive(:try).with(:service).and_return(registry_service)
             get('/api/registry/catalog', headers: auth_headers_token)
 
             expect(response).to have_http_status(:ok)

--- a/engines/registry/spec/app/controllers/registry_controller_spec.rb
+++ b/engines/registry/spec/app/controllers/registry_controller_spec.rb
@@ -3,11 +3,19 @@ require 'rails_helper'
 # rubocop:disable Metrics/ModuleLength
 module Registry
   describe RegistryController, type: :request do
+    let(:settings_registry) do
+      { service: 'foo', realm: 'bar' }
+    end
+    let(:registry_service) { 'SUSE Linux OCI Registry' }
+    let(:registry_realm) { 'SUSE Registry Authentication' }
+
     describe '#authenticate' do
       context 'login request with invalid credentials' do
         let(:auth_headers) { { 'Authorization' => ActionController::HttpAuthentication::Basic.encode_credentials('login', 'password') } }
 
         it 'succeeds with login + password from secrets' do
+          allow(Settings).to receive(:try).with(:registry).and_return(settings_registry)
+          allow(settings_registry).to receive(:try).with(:realm).and_return(registry_realm)
           get('/api/registry/authorize', headers: auth_headers)
 
           expect(response).to have_http_status(:unauthorized)
@@ -19,6 +27,8 @@ module Registry
         let(:auth_headers) { { 'Authorization' => ActionController::HttpAuthentication::Basic.encode_credentials(system.login, system.password) } }
 
         it 'succeeds with login + password from secrets' do
+          allow(Settings).to receive(:try).with(:registry).and_return(settings_registry)
+          allow(settings_registry).to receive(:try).with(:realm).and_return(registry_realm)
           allow_any_instance_of(AuthenticatedClient).to receive(:cache_file_exist?).and_return(true)
           get('/api/registry/authorize', headers: auth_headers)
 
@@ -31,6 +41,8 @@ module Registry
         let(:auth_headers) { { 'Authorization' => ActionController::HttpAuthentication::Basic.encode_credentials(system.login, system.password) } }
 
         it 'raises exception and returns unauth' do
+          allow(Settings).to receive(:try).with(:registry).and_return(settings_registry)
+          allow(settings_registry).to receive(:try).with(:realm).and_return(registry_realm)
           allow_any_instance_of(AuthenticatedClient).to receive(:cache_file_exist?).and_return(true)
           allow(Base32).to receive(:encode).and_raise('FOO')
           get('/api/registry/authorize', headers: auth_headers)
@@ -45,12 +57,17 @@ module Registry
       let(:auth_headers) { { 'Authorization' => ActionController::HttpAuthentication::Basic.encode_credentials(system.login, system.password) } }
 
       it 'returns 401' do
+        allow(Settings).to receive(:try).with(:registry).and_return(settings_registry)
+        allow(settings_registry).to receive(:try).with(:service).and_return(registry_service)
         get('/api/registry/catalog')
         expect(response).to have_http_status(:unauthorized)
         expect(response.header['WWW-Authenticate']).not_to include('error="insufficient_scope"')
       end
 
       it 'with a token that has no access to catalog' do
+        allow(Settings).to receive(:try).with(:registry).and_return(settings_registry)
+        allow(settings_registry).to receive(:try).with(:realm).and_return(registry_realm)
+        allow(settings_registry).to receive(:try).with(:service).and_return(registry_service)
         get('/api/registry/authorize', params: { scope: '' }, headers: auth_headers)
 
         request.headers.merge({ 'HTTP_AUTHORIZATION' => "Bearer #{json_response[:token]}" })
@@ -69,7 +86,6 @@ module Registry
       end
       let(:authorize_url) { 'api/registry/authorize' }
       let(:root_url) { 'smt-ec2.susecloud.net' }
-      let(:registry_service) { 'SUSE Linux OCI Registry' }
       let(:access_policy_content) { File.read('engines/registry/spec/data/access_policy_yaml.yml') }
       let(:registry_conf) { { root_url: root_url } }
 
@@ -94,11 +110,9 @@ module Registry
         end
 
         context 'with a valid token' do
-          let(:settings_registry) do
-            { service: 'foo', realm: 'bar' }
-          end
-
           it 'has catalog access' do
+            allow(Settings).to receive(:try).with(:registry).and_return(settings_registry)
+            allow(settings_registry).to receive(:try).with(:realm).and_return(registry_realm)
             allow(File).to receive(:read).and_return(access_policy_content)
             allow_any_instance_of(AuthenticatedClient).to receive(:cache_file_exist?).and_return(true)
             get(
@@ -118,6 +132,8 @@ module Registry
 
         context 'when token is invalid' do
           it 'denies the access' do
+            allow(Settings).to receive(:try).with(:registry).and_return(settings_registry)
+            allow(settings_registry).to receive(:try).with(:realm).and_return(registry_realm)
             get(
               '/api/registry/authorize',
               params: { service: registry_service, scope: 'registry:catalog:*' },
@@ -134,6 +150,8 @@ module Registry
 
         context 'when an error happens' do
           it 'denies the access' do
+            allow(Settings).to receive(:try).with(:registry).and_return(settings_registry)
+            allow(settings_registry).to receive(:try).with(:realm).and_return(registry_realm)
             allow_any_instance_of(AccessScope).to receive(:allowed_paths).and_raise(RegistryAuthError, 'Foo')
             allow(File).to receive(:read).and_return(access_policy_content)
             allow_any_instance_of(AuthenticatedClient).to receive(:cache_file_exist?).and_return(true)
@@ -191,6 +209,8 @@ module Registry
 
         context 'with a valid token' do
           it 'can not find system' do
+            allow(Settings).to receive(:try).with(:registry).and_return(settings_registry)
+            allow(settings_registry).to receive(:try).with(:realm).and_return(registry_realm)
             allow(File).to receive(:read).and_return(access_policy_content)
             allow_any_instance_of(AuthenticatedClient).to receive(:cache_file_exist?).and_return(true)
             get(

--- a/engines/registry/spec/app/controllers/registry_controller_spec.rb
+++ b/engines/registry/spec/app/controllers/registry_controller_spec.rb
@@ -50,6 +50,18 @@ module Registry
           expect(response).to have_http_status(:unauthorized)
         end
       end
+
+      context 'login request with misconfigured registry' do
+        let(:system) { create(:system) }
+        let(:auth_headers) { { 'Authorization' => ActionController::HttpAuthentication::Basic.encode_credentials(system.login, system.password) } }
+
+        it 'raise an error with a clear message' do
+          allow(Settings).to receive(:try).with(:registry).and_return({})
+          # allow(settings_registry).to receive(:try).with(:realm).and_return(registry_realm)
+          allow_any_instance_of(AuthenticatedClient).to receive(:cache_file_exist?).and_return(true)
+          expect { get('/api/registry/authorize', headers: auth_headers) }.to raise_error(RegistryAuthError, 'registry not configured properly in /etc/rmt.conf')
+        end
+      end
     end
 
     describe '#catalog without access token' do
@@ -74,6 +86,16 @@ module Registry
         get('/api/registry/catalog', headers: auth_headers)
 
         expect(response.header['WWW-Authenticate']).to include('error="insufficient_scope"')
+      end
+    end
+
+    describe '#catalog with misconfigured registry' do
+      let(:system) { create(:system) }
+      let(:auth_headers) { { 'Authorization' => ActionController::HttpAuthentication::Basic.encode_credentials(system.login, system.password) } }
+
+      it 'raise an error with a clear message' do
+        allow(Settings).to receive(:try).with(:registry).and_return({})
+        expect { get('/api/registry/catalog') }.to raise_error(RegistryAuthError, 'registry not configured properly in /etc/rmt.conf')
       end
     end
 

--- a/engines/registry/spec/app/controllers/registry_controller_spec.rb
+++ b/engines/registry/spec/app/controllers/registry_controller_spec.rb
@@ -69,6 +69,7 @@ module Registry
       end
       let(:authorize_url) { 'api/registry/authorize' }
       let(:root_url) { 'smt-ec2.susecloud.net' }
+      let(:registry_service) { 'SUSE Linux OCI Registry' }
       let(:access_policy_content) { File.read('engines/registry/spec/data/access_policy_yaml.yml') }
       let(:registry_conf) { { root_url: root_url } }
 
@@ -98,11 +99,12 @@ module Registry
             allow_any_instance_of(AuthenticatedClient).to receive(:cache_file_exist?).and_return(true)
             get(
               '/api/registry/authorize',
-              params: { service: 'SUSE Linux OCI Registry', scope: 'registry:catalog:*' },
+              params: { service: registry_service, scope: 'registry:catalog:*' },
               headers: auth_headers
               )
 
             auth_headers_token['Authorization'] = format("Bearer #{json_response[:token]}")
+            allow(Settings).to receive_message_chain(:registry, :service).and_return(registry_service)
             get('/api/registry/catalog', headers: auth_headers_token)
 
             expect(response).to have_http_status(:ok)
@@ -113,7 +115,7 @@ module Registry
           it 'denies the access' do
             get(
               '/api/registry/authorize',
-              params: { service: 'SUSE Linux OCI Registry', scope: 'registry:catalog:*' },
+              params: { service: registry_service, scope: 'registry:catalog:*' },
               headers: auth_headers
               )
 

--- a/engines/registry/spec/app/services/registry_catalog_service_spec.rb
+++ b/engines/registry/spec/app/services/registry_catalog_service_spec.rb
@@ -14,15 +14,18 @@ describe RegistryCatalogService do
   let(:registry_conf) { { root_url: root_url } }
 
   before do
+    allow(Settings).to receive_message_chain(:registry, :service).and_return(
+      'SUSE Linux OCI Registry'
+    )
     stub_request(:get, "#{auth_url}?#{params}").with(
       headers: {
         'Accept' => '*/*',
         'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
         'User-Agent' => 'Ruby'
       }
-).to_return(
-  status: 200, body: JSON.dump({ token: 'foo_token' }), headers: {}
-      )
+    ).to_return(
+      status: 200, body: JSON.dump({ token: 'foo_token' }), headers: {}
+    )
 
     stub_request(:get, "#{registry.catalog_api_url}?n=1000")
       .to_return(body: JSON.dump(response), status: 200, headers: { 'Content-type' => 'application/json' })

--- a/engines/registry/spec/app/services/registry_catalog_service_spec.rb
+++ b/engines/registry/spec/app/services/registry_catalog_service_spec.rb
@@ -12,9 +12,13 @@ describe RegistryCatalogService do
     %w[repo repo.v2 level1/repo.v2 level1/level2 level1/level2/repo level1/level2/level.3 level1/level2/level.3/repo]
   end
   let(:registry_conf) { { root_url: root_url } }
+  let(:settings_registry) do
+    { service: 'foo', realm: 'bar' }
+  end
 
   before do
-    allow(Settings).to receive_message_chain(:registry, :service).and_return(
+    allow(Settings).to receive(:try).with(:registry).and_return(settings_registry)
+    allow(settings_registry).to receive(:try).with(:service).and_return(
       'SUSE Linux OCI Registry'
     )
     stub_request(:get, "#{auth_url}?#{params}").with(

--- a/engines/registry/spec/app/services/registry_catalog_service_spec.rb
+++ b/engines/registry/spec/app/services/registry_catalog_service_spec.rb
@@ -16,27 +16,40 @@ describe RegistryCatalogService do
     { service: 'foo', realm: 'bar' }
   end
 
-  before do
-    allow(Settings).to receive(:try).with(:registry).and_return(settings_registry)
-    allow(settings_registry).to receive(:try).with(:service).and_return(
-      'SUSE Linux OCI Registry'
-    )
-    stub_request(:get, "#{auth_url}?#{params}").with(
-      headers: {
-        'Accept' => '*/*',
-        'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-        'User-Agent' => 'Ruby'
-      }
-    ).to_return(
-      status: 200, body: JSON.dump({ token: 'foo_token' }), headers: {}
-    )
+  context 'registry configured properly' do
+    before do
+      allow(Settings).to receive(:try).with(:registry).and_return(settings_registry)
+      allow(settings_registry).to receive(:try).with(:service).and_return(
+        'SUSE Linux OCI Registry'
+      )
+      stub_request(:get, "#{auth_url}?#{params}").with(
+        headers: {
+          'Accept' => '*/*',
+          'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'User-Agent' => 'Ruby'
+        }
+      ).to_return(
+        status: 200, body: JSON.dump({ token: 'foo_token' }), headers: {}
+      )
 
-    stub_request(:get, "#{registry.catalog_api_url}?n=1000")
-      .to_return(body: JSON.dump(response), status: 200, headers: { 'Content-type' => 'application/json' })
+      stub_request(:get, "#{registry.catalog_api_url}?n=1000")
+        .to_return(body: JSON.dump(response), status: 200, headers: { 'Content-type' => 'application/json' })
+    end
+
+    it 'lists all repos' do
+      allow(System).to receive(:where).and_return([system])
+      expect(registry.repos(system).length).to eq repositories_returned.size
+    end
   end
 
-  it 'lists all repos' do
-    allow(System).to receive(:where).and_return([system])
-    expect(registry.repos(system).length).to eq repositories_returned.size
+  context 'registry misconfigured' do
+    before do
+      allow(Settings).to receive(:try).with(:registry).and_return({})
+    end
+
+    it 'raise an error with a clear message' do
+      allow(System).to receive(:where).and_return([system])
+      expect { registry.repos(system) }.to raise_error(StandardError, 'registry not configured properly in /etc/rmt.conf')
+    end
   end
 end


### PR DESCRIPTION
## Description

The implementation of the registry was done in a SUSE specific way

we should remove any SUSE specific concepts in the registry setup that is part of the update infrastructure and make it generic, that 3rd party cloud providers that run their own update infrastructure can provide the same service to their PAYG customers as we do

* Related Issue / Ticket / Trello card: [PCT-1126](https://jira.suse.com/browse/PCT-1126)

## How to test 

registry access should work the same as before 

## Change Type

*Please select the correct option.*

- [ ] **Bug Fix** (a non-breaking change which fixes an issue)
- [X] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

