### PR TITLE
Fix CVE-2026-42256 and release version 3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,15 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 source 'https://rubygems.org'
 ruby '~> 3.4'
 
-gem 'rails', '~> 8.1.0'
+# Individual Rails components (instead of meta-gem)
+# This excludes actionmailer/actionmailbox to avoid CVE-2026-42256 (bsc#1265369)
+gem 'railties', '~> 8.1.0'
+gem 'activesupport', '~> 8.1.0'
+gem 'activemodel', '~> 8.1.0'
+gem 'activerecord', '~> 8.1.0'
+gem 'activejob', '~> 8.1.0'
+gem 'actionpack', '~> 8.1.0'
+gem 'actionview', '~> 8.1.0'
 
 gem 'bootsnap', require: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ ruby '~> 3.4'
 
 # Individual Rails components (instead of meta-gem)
 # This excludes actionmailer/actionmailbox to avoid CVE-2026-42256 (bsc#1265369)
+# as well as other unused Rails dependencies (actioncable, actiontext, activestorage)
 gem 'railties', '~> 8.1.0'
 gem 'activesupport', '~> 8.1.0'
 gem 'activemodel', '~> 8.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,28 +1,6 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    action_text-trix (2.1.16)
-      railties
-    actioncable (8.1.2)
-      actionpack (= 8.1.2)
-      activesupport (= 8.1.2)
-      nio4r (~> 2.0)
-      websocket-driver (>= 0.6.1)
-      zeitwerk (~> 2.6)
-    actionmailbox (8.1.2)
-      actionpack (= 8.1.2)
-      activejob (= 8.1.2)
-      activerecord (= 8.1.2)
-      activestorage (= 8.1.2)
-      activesupport (= 8.1.2)
-      mail (>= 2.8.0)
-    actionmailer (8.1.2)
-      actionpack (= 8.1.2)
-      actionview (= 8.1.2)
-      activejob (= 8.1.2)
-      activesupport (= 8.1.2)
-      mail (>= 2.8.0)
-      rails-dom-testing (~> 2.2)
     actionpack (8.1.2)
       actionview (= 8.1.2)
       activesupport (= 8.1.2)
@@ -33,14 +11,6 @@ GEM
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
       useragent (~> 0.16)
-    actiontext (8.1.2)
-      action_text-trix (~> 2.1.15)
-      actionpack (= 8.1.2)
-      activerecord (= 8.1.2)
-      activestorage (= 8.1.2)
-      activesupport (= 8.1.2)
-      globalid (>= 0.6.0)
-      nokogiri (>= 1.8.5)
     actionview (8.1.2)
       activesupport (= 8.1.2)
       builder (~> 3.1)
@@ -61,12 +31,6 @@ GEM
       activemodel (= 8.1.2)
       activesupport (= 8.1.2)
       timeout (>= 0.4.0)
-    activestorage (8.1.2)
-      actionpack (= 8.1.2)
-      activejob (= 8.1.2)
-      activerecord (= 8.1.2)
-      activesupport (= 8.1.2)
-      marcel (~> 1.0)
     activesupport (8.1.2)
       base64
       bigdecimal
@@ -199,16 +163,8 @@ GEM
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     lumberjack (1.4.2)
-    mail (2.9.0)
-      logger
-      mini_mime (>= 0.1.1)
-      net-imap
-      net-pop
-      net-smtp
-    marcel (1.1.0)
     memory_profiler (1.1.0)
     method_source (1.1.0)
-    mini_mime (1.1.5)
     minitest (6.0.2)
       drb (~> 2.0)
       prism (~> 1.5)
@@ -220,15 +176,6 @@ GEM
     mysql2 (0.5.7)
       bigdecimal
     nenv (0.3.0)
-    net-imap (0.5.12)
-      date
-      net-protocol
-    net-pop (0.1.2)
-      net-protocol
-    net-protocol (0.2.2)
-      timeout
-    net-smtp (0.5.1)
-      net-protocol
     nio4r (2.7.5)
     nokogiri (1.19.1-x86_64-linux-gnu)
       racc (~> 1.4)
@@ -268,20 +215,6 @@ GEM
       rack (>= 1.3)
     rackup (2.3.1)
       rack (>= 3)
-    rails (8.1.2)
-      actioncable (= 8.1.2)
-      actionmailbox (= 8.1.2)
-      actionmailer (= 8.1.2)
-      actionpack (= 8.1.2)
-      actiontext (= 8.1.2)
-      actionview (= 8.1.2)
-      activejob (= 8.1.2)
-      activemodel (= 8.1.2)
-      activerecord (= 8.1.2)
-      activestorage (= 8.1.2)
-      activesupport (= 8.1.2)
-      bundler (>= 1.15.0)
-      railties (= 8.1.2)
     rails-dom-testing (2.3.0)
       activesupport (>= 5.0.0)
       minitest
@@ -470,10 +403,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.9.2)
-    websocket-driver (0.8.0)
-      base64
-      websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.5)
     yabeda (0.14.0)
       anyway_config (>= 1.0, < 3)
       concurrent-ruby
@@ -499,7 +428,13 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  actionpack (~> 8.1.0)
+  actionview (~> 8.1.0)
   active_model_serializers
+  activejob (~> 8.1.0)
+  activemodel (~> 8.1.0)
+  activerecord (~> 8.1.0)
+  activesupport (~> 8.1.0)
   awesome_print
   base32
   bootsnap
@@ -528,7 +463,7 @@ DEPENDENCIES
   public_suffix
   puma
   rackup
-  rails (~> 8.1.0)
+  railties (~> 8.1.0)
   redis-namespace
   repomd_parser
   responders

--- a/config/application.rb
+++ b/config/application.rb
@@ -2,19 +2,13 @@ require_relative 'boot'
 
 require 'rails'
 
-# Pick the frameworks you want:
+# Load only the Rails components needed by RMT
+# See Gemfile for exclusions (actionmailer, actionmailbox, etc.)
 require 'active_model/railtie'
 require 'active_job/railtie'
 require 'active_record/railtie'
-# require "active_storage/engine"
 require 'action_controller/railtie'
-# require "action_mailer/railtie"
-# require "action_mailbox/engine"
-# require "action_text/engine"
 require 'action_view/railtie'
-# require "action_cable/engine"
-# require "sprockets/railtie"
-# require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/lib/rmt.rb
+++ b/lib/rmt.rb
@@ -1,5 +1,5 @@
 module RMT
-  VERSION ||= '3.0.alpha'.freeze
+  VERSION ||= '3.0'.freeze
 
   DEFAULT_USER = '_rmt'.freeze
   DEFAULT_GROUP = 'nginx'.freeze

--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon May 18 16:07:59 UTC 2026 - Natnael Getahun <natnael.getahun@suse.com>
+
+- Version 3.0
+  * Security fix: Remove unused ActionMailer/ActionMailbox components to eliminate CVE-2026-42256 (bsc#1265369)
+  * Split Rails meta-gem into individual components for better security control
+
+-------------------------------------------------------------------
 Wed Apr 29 10:13:52 UTC 2026 - Adnilson Delgado <adnilson.delgado@suse.com>
 
 - Version 3.0.alpha

--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -2,7 +2,8 @@
 Mon May 18 16:07:59 UTC 2026 - Natnael Getahun <natnael.getahun@suse.com>
 
 - Version 3.0
-  * Security fix: Remove unused ActionMailer/ActionMailbox components to eliminate CVE-2026-42256 (bsc#1265369)
+  * Security fix: Remove unused ActionMailer/ActionMailbox components to
+    eliminate CVE-2026-42256 (bsc#1265369)
   * Split Rails meta-gem into individual components for better security control
 
 -------------------------------------------------------------------

--- a/package/obs/rmt-server.spec
+++ b/package/obs/rmt-server.spec
@@ -41,7 +41,7 @@
 %undefine _find_debuginfo_dwz_opts
 
 Name:           rmt-server
-Version:        3.0.alpha
+Version:        3.0
 Release:        0
 Summary:        Repository mirroring tool and registration proxy for SCC
 License:        GPL-2.0-or-later


### PR DESCRIPTION
## Description

This PR addresses CVE-2026-42256 (bsc#1265369) by removing unused ActionMailer and ActionMailbox components from the Rails dependency tree. These components introduced a vulnerable net-imap dependency that RMT doesn't need. The fix splits the Rails meta-gem into individual component gems, excluding the unused parts.

Additionally, this PR bumps the version from 3.0.alpha to 3.0 for the official release.

* Related Issue / Ticket / Trello card: bsc#1265369 (CVE-2026-42256)

## How to test 

1. Verify that `bundle list` does not include net-imap, actionmailer, or actionmailbox
2. Verify version is reported as 3.0

## Change Type

*Please select the correct option.*

- [x] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [x] I have reviewed my own code and believe that it's ready for an external review.
- [x] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [x] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change.