### PR TITLE
Fix rmt-sidekiq service starting error

### DIFF
--- a/bin/sidekiq
+++ b/bin/sidekiq
@@ -9,6 +9,8 @@
 #
 
 require "pathname"
+require_relative "../config/environment"
+
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile",
   Pathname.new(__FILE__).realpath)
 
@@ -19,5 +21,4 @@ require "sidekiq/cli"
 # Parse Sidekiq CLI arguments first (including -e)
 Sidekiq::CLI.instance.parse
 
-require_relative "../config/environment"
 Sidekiq::CLI.instance.run


### PR DESCRIPTION
## Description

Sidekiq service had an error on start. This PR fix it. 


## How to test 

Make sure that `rmt-sidekiq` service starts with no issues.

## Change Type

*Please select the correct option.*

- [x] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [x] I have reviewed my own code and believe that it's ready for an external review.
- [x] I have provided comments for any hard-to-understand code.
- [x] I have documented the `MANUAL.md` file with any changes to the user experience.
- [x] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

