### PR TITLE
Fix ci/README.md with correct container image

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -29,7 +29,7 @@ To run feature tests locally, you need:
 
 ```
 # Fetch the CI container
-$ export IMAGE="registry.opensuse.org/systemsmanagement/scc/containers/15.5/rmt-ci-container:latest"
+$ export IMAGE="registry.opensuse.org/systemsmanagement/scc/containers/opensuse_tumbleweed/rmt-ci-container-ruby3.4:latest"
 
 # Build RMT rpms with the CI container the resulting rpms are in tmp/artifacts/
 $ docker run --rm -it -v $(pwd):/usr/src/rmt-server $IMAGE 'ci/rmt-build-rpm'


### PR DESCRIPTION
## Description

The instructions to run the CI process locally references the old image with ruby 2.5.9 version. This PR updates this documentation

* Related Issue / Ticket / Trello card: <link reference>

## How to test 

<!-- Describe the steps how verify your change -->

## Change Type

*Please select the correct option.*

- [ ] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [x] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [x] I have reviewed my own code and believe that it's ready for an external review.
- [x] I have provided comments for any hard-to-understand code.
- [x] I have documented the `MANUAL.md` file with any changes to the user experience.
- [x] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

