### PR TITLE
remove use of ActiveSupport::Configurable

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GEM
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
-    active_model_serializers (0.10.15)
+    active_model_serializers (0.10.16)
       actionpack (>= 4.1)
       activemodel (>= 4.1)
       case_transform (>= 0.2)


### PR DESCRIPTION
## Description

this change was done in master branch in #1402 PR
but not ported to rmt_3 branch, making a warning

DEPRECATION WARNING: ActiveSupport::Configurable is deprecated without replacement, and will be removed in Rails 8.2.

show up, this warning shall be removed

this change fixes that

* Related Issue / Ticket / Trello card: <link reference>

## How to test 

start RMT, the warning in the description must not show up

## Change Type

*Please select the correct option.*

- [ ] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [X] I have documented the `MANUAL.md` file with any changes to the user experience.
- [X] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

