### PR TITLE
Allow product activation for products without repository (RMT3)

### DIFF
--- a/app/controllers/api/connect/v3/systems/products_controller.rb
+++ b/app/controllers/api/connect/v3/systems/products_controller.rb
@@ -94,7 +94,7 @@ class Api::Connect::V3::Systems::ProductsController < Api::Connect::BaseControll
   end
 
   def check_product_service_and_repositories
-    unless @product.service && @product.repositories.present?
+    unless @product.service
       fail ActionController::TranslatedError.new(N_('No repositories found for product: %s'), @product.friendly_name)
     end
 

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -123,6 +123,23 @@ FactoryBot.define do
       friendly_version { 'Live Patching' }
     end
 
+    trait :product_rancher do
+      identifier { 'rancher' }
+      name { 'Rancher Subscription' }
+      description { 'A Rancher Manager subscription...' }
+      shortname { 'Rancher' }
+      former_identifier { 'rancher' }
+      product_type { :base }
+      product_class { 'RANCHER-X86' }
+      release_type { nil }
+      release_stage { 'released' }
+      version { '2.13.6' }
+      arch { 'unknown' }
+      free { false }
+      cpe { 'cpe:/o:suse:rancher:2.13.6' }
+      friendly_version { '2.13.6' }
+    end
+
     trait :extension do
       product_type { 'extension' }
     end

--- a/spec/requests/api/connect/v3/systems/products_controller_spec.rb
+++ b/spec/requests/api/connect/v3/systems/products_controller_spec.rb
@@ -42,6 +42,21 @@ RSpec.describe Api::Connect::V3::Systems::ProductsController do
       its(:body) { is_expected.to eq(error_json) }
     end
 
+    context 'when product is Rancher based (No repositories)' do
+      subject(:json_data) { JSON.parse(response.body, symbolize_names: true) }
+
+      let(:product) { create(:product, :product_rancher, :with_service) }
+
+      before do
+        post url, headers: headers, params: payload
+      end
+
+      it 'creates a system and associates it with the rancher product' do
+        expect(response).to have_http_status(:created)
+        expect(json_data[:product][:id]).to eq(product.id)
+      end
+    end
+
     context 'when product has unmet root dependencies' do
       subject { response }
 


### PR DESCRIPTION
## Description

To allow Rancher Manager to be registered with RMT servers, products without repositories need to be allowed in the API.

This allows Rancher Manager to register against RMT which is needed, to support PAYG Rancher registrations.

RMT2 version of this PR: https://github.com/SUSE/rmt/pull/1479


## How to test these changes:

### Requirements:
- depends on: https://github.com/SUSE/happy-customer/pull/9164
- Run the above branch in as your local SCC environment or wait until it is in production
- Point your local RMT to your local SCC (Hint: `.env` and `SCC_HOST=http://localscc:3000/connect` is your friend if you running the containerized development setup`
- Then sync RMT with an organization which has an active Rancher subscription (`rmt-cli sync`)
- Then use the `public-api-demo` tool from https://github.com/SUSE/connect-ng/ (`make build; ./out/public-api-demo`)
- `public-api-demo` mimicks a standard registration using the public library, was it is used by Rancher (scc-operator)
- Run:
```
# On your host where RMT is locally running and port 4224 is assigned to it (default)
$ cd <connect-ng>
$ make build
$ SCC_HOST=http://localhost:4224 ./out/public-api-demo rancher 2.5.7 unknown cmd/public-api-demo/examples/system_information_rancher.json
# expect: This succeeds to register and fails for the none existing labeling support
# expect: RMT now has a new system
> rmt-cli systems list
# expect: RMT can sync those systems to SCC
> rmt-cli systems scc-sync
# expect: The system shows up in your local SCC/production under the proxy you used
```
## Change Type

*Please select the correct option.*

- [ ] **Bug Fix** (a non-breaking change which fixes an issue)
- [x] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [x] I have reviewed my own code and believe that it's ready for an external review.
- [x] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

