### PR TITLE
fix purge

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -43,7 +43,7 @@ You can install and run this wizard like this:
 
     `rmt-cli systems remove SCC_e740f34145b84523a184ace764d0d597`
 
-  * `rmt-cli systems purge [--no-confirmation] [--before date]`:
+  * `rmt-cli systems purge [--no-confirmation] [--before date] [--quiet]`:
     Removes inactive systems.
 
     Use the `--no-confirmation` flag so the command does not ask you for
@@ -52,9 +52,12 @@ You can install and run this wizard like this:
     Use the `--before date` flag to define that systems before the given date
     should be viewed as inactive.
 
+    Use the `--quiet` flag so the command does not show all the systems that
+	match the inactive criteria before deletion.
+
     Example:
 
-    `rmt-cli systems purge --non-interactive --before 2022-02-28`
+    `rmt-cli systems purge --non-interactive --before 2022-02-28 --quiet`
 
   * `rmt-cli products list [--all] [--csv] [--name name] [--version version] [--arch arch]`:
     Lists the products that are enabled for mirroring.

--- a/lib/rmt/cli/systems.rb
+++ b/lib/rmt/cli/systems.rb
@@ -8,7 +8,8 @@ class RMT::CLI::Systems < RMT::CLI::Base
   # or handled by the batch loop
   # higher numbers like 1000, 500, 100 and even 50
   # user can see the table waiting to be populated
-  BATCH_SIZE = 20
+  VERBOSE_BATCH_SIZE = 20
+  DELETE_BATCH_SIZE = 500
 
   desc 'list', _('List registered systems.')
   option :limit, aliases: '-l', type: :numeric, default: 20, desc: _('Number of systems to display')
@@ -73,6 +74,7 @@ class RMT::CLI::Systems < RMT::CLI::Base
   desc 'purge', _('Removes inactive systems')
   option :before, aliases: '-b', type: :string, desc: _('Remove systems before the given date (format: "<year>-<month>-<day>")')
   option :confirmation, type: :boolean, default: true, desc: _('Ask for confirmation or do not ask for confirmation and require no user interaction')
+  option :quiet, aliases: '-q', type: :boolean, default: false, desc: _('do not show system details before deletion')
   long_desc <<~PURGE
     #{_('Removes old systems and their activations if they are inactive.')}
 
@@ -85,28 +87,109 @@ class RMT::CLI::Systems < RMT::CLI::Base
     $ rmt-cli systems purge --no-confirmation --before 2022-02-28
   PURGE
   def purge
-    ask, before = purge_options
-    systems = System.where('last_seen_at < ?', before).pluck(:id)
+    ask, before, quiet = purge_options
+    system_ids, fetch_ok = get_all_matches(before) unless quiet
 
-    if systems.empty?
-      warn _("No systems to be purged on this RMT instance. All systems have contacted RMT after #{before}.")
-      return
+    unless quiet
+      return handle_no_matching_systems(before, fetch_ok) if system_ids.empty?
+
+      print_rows(system_ids)
     end
-    print_rows(systems)
-    return if ask && !yesno(_('Do you want to delete these systems?'))
+    return if ask && !yesno(_("Do you want to delete all the matching systems that contacted this RMT before #{before}?"))
 
-    System.where(id: systems).in_batches(&:destroy_all)
-    puts "Purged systems that have not contacted this RMT since #{before}."
+    delete_systems(system_ids, before, fetch_ok)
   end
 
   protected
 
-  def print_rows(systems)
+  def handle_no_matching_systems(before, fetch_ok)
+    warn _('No systems to be purged on this RMT instance. All systems have contacted RMT after %{before}.') % { before: before } if fetch_ok
+  end
+
+  def delete_systems(system_ids, before, fetch_ok)
+    n_deleted, all = system_ids.blank? ? delete_inactive_systems(before) : delete_systems_by_id(system_ids)
+    return handle_no_matching_systems(before, true) if n_deleted.zero? && all
+
+    status = all ? 'all' : 'some'
+    puts _('Purged %{status} systems that have not contacted this RMT since %{before}.') % { status: status, before: before } unless n_deleted.zero?
+    puts _('Systems that have not contacted this RMT since %{before} may still be in this RMT') % { before: before } unless fetch_ok || all
+  end
+
+  def delete_inactive_systems(before)
+    n_systems_destroyed = 0
+    attempts = 0
+    begin
+      attempts += 1
+      # instead of getting all the systems to be shown
+      # before deletion, where we would know
+      # how many systems are going to be deleted
+      # query systems directly, thus we do not know how
+      # many systems before running the deletion
+      System.where('last_seen_at < ?', before).in_batches(of: DELETE_BATCH_SIZE) do |batch|
+        n_systems_destroyed += batch.destroy_all.length
+        puts _('%{n_systems_destroyed} systems destroyed') % { n_systems_destroyed: n_systems_destroyed }
+      end
+      [n_systems_destroyed, true]
+    rescue StandardError => e
+      if attempts < 3
+        puts _('Error while purging systems: %{error_class} %{e_message}. Retrying in 5 seconds (%{attempts}/3)') % {
+          error_class: e.class, e_message: e.message, attempts: attempts
+        }
+        sleep 5
+        retry
+      end
+      puts _('Could not delete all systems last seen before %{before}: %{message}') % { before: before, message: e.message }
+      [n_systems_destroyed, false]
+    end
+  end
+
+  def get_all_matches(before)
+    system_ids_matched = []
+    System.where('last_seen_at < ?', before).in_batches(of: DELETE_BATCH_SIZE, order: :desc) do |batch|
+      system_ids_matched += batch.pluck(:id)
+      puts _('%{matched} systems last seen before %{before}') % { matched: system_ids_matched.length, before: before }
+    end
+    [system_ids_matched, true]
+  rescue StandardError => e
+    puts _('Could not get all systems last seen before %{before}: %{error_class} %{message}') % { before: before, error_class: e.class, message: e.message }
+    [system_ids_matched, false]
+  end
+
+  def delete_systems_by_id(system_ids)
+    attempts = 0
+    deleted_systems = 0
+    begin
+      attempts += 1
+      system_ids.each_slice(DELETE_BATCH_SIZE) do |sliced_systems_ids|
+        System.where(id: sliced_systems_ids).destroy_all
+        deleted_systems += sliced_systems_ids.length
+        remaining_systems = system_ids.length - deleted_systems
+        puts _('%{remaining_systems} systems to be deleted') % { remaining_systems: remaining_systems } unless remaining_systems.zero?
+      end
+      [deleted_systems, true]
+    rescue StandardError => e
+      if attempts < 3
+        puts _('Error while purging systems: %{error_class} %{message}. Attempt %{attempts}/3, retrying in 5 seconds') % {
+          error_class: e.class, message: e.message, attempts: attempts
+        }
+        sleep 5
+        retry
+      else
+        remaining_systems = system_ids.length - deleted_systems
+        puts _(
+          'Error while purging the systems: %{error_class} %{message}, all %{all} systems could not be removed, %{remaining} systems still in the database'
+        ) % { error_class: e.class, message: e.message, all: system_ids.length, remaining: remaining_systems }
+      end
+      [deleted_systems, false]
+    end
+  end
+
+  def print_rows(system_ids)
     column_widths = max_column_widths
     style = {}
-    systems_first = systems.first
-    systems_last = systems.last
-    systems.each_slice(BATCH_SIZE) do |sliced_systems_ids|
+    systems_first = system_ids.first
+    systems_last = system_ids.last
+    system_ids.each_slice(VERBOSE_BATCH_SIZE) do |sliced_systems_ids|
       # avoid N + 1 queries when decorator gets the product from the activation
       sliced_systems = System.includes(:activations).where(id: sliced_systems_ids).order(id: :desc)
       decorator_systems = RMT::CLI::Decorators::SystemDecorator.new(sliced_systems)
@@ -151,7 +234,7 @@ class RMT::CLI::Systems < RMT::CLI::Base
   def purge_options
     dt = options.before.to_s.to_datetime || INACTIVE.ago
 
-    [options.confirmation, dt.strftime('%F')]
+    [options.confirmation, dt.strftime('%F'), options.quiet]
   rescue ArgumentError
     raise RMT::CLI::Error.new(_("The given date does not follow the proper format. Ensure it follows this format '<year>-<month>-<day>'."))
   end

--- a/lib/rmt/cli/systems.rb
+++ b/lib/rmt/cli/systems.rb
@@ -117,9 +117,7 @@ class RMT::CLI::Systems < RMT::CLI::Base
 
   def delete_inactive_systems(before)
     n_systems_destroyed = 0
-    attempts = 0
-    begin
-      attempts += 1
+    with_retries do
       # instead of getting all the systems to be shown
       # before deletion, where we would know
       # how many systems are going to be deleted
@@ -129,24 +127,17 @@ class RMT::CLI::Systems < RMT::CLI::Base
         n_systems_destroyed += batch.destroy_all.length
         puts _('%{n_systems_destroyed} systems destroyed') % { n_systems_destroyed: n_systems_destroyed }
       end
-      [n_systems_destroyed, true]
-    rescue StandardError => e
-      if attempts < 3
-        puts _('Error while purging systems: %{error_class} %{e_message}. Retrying in 5 seconds (%{attempts}/3)') % {
-          error_class: e.class, e_message: e.message, attempts: attempts
-        }
-        sleep 5
-        retry
-      end
-      puts _('Could not delete all systems last seen before %{before}: %{message}') % { before: before, message: e.message }
-      [n_systems_destroyed, false]
     end
+    [n_systems_destroyed, true]
+  rescue StandardError => e
+    puts _('Could not delete all systems last seen before %{before}: %{message}') % { before: before, message: e.message }
+    [n_systems_destroyed, false]
   end
 
   def get_all_matches(before)
     system_ids_matched = []
     System.where('last_seen_at < ?', before).in_batches(of: DELETE_BATCH_SIZE, order: :desc) do |batch|
-      system_ids_matched += batch.pluck(:id)
+      system_ids_matched.concat(batch.pluck(:id))
       puts _('%{matched} systems last seen before %{before}') % { matched: system_ids_matched.length, before: before }
     end
     [system_ids_matched, true]
@@ -156,31 +147,37 @@ class RMT::CLI::Systems < RMT::CLI::Base
   end
 
   def delete_systems_by_id(system_ids)
-    attempts = 0
     deleted_systems = 0
-    begin
-      attempts += 1
+    with_retries do
       system_ids.each_slice(DELETE_BATCH_SIZE) do |sliced_systems_ids|
-        System.where(id: sliced_systems_ids).destroy_all
-        deleted_systems += sliced_systems_ids.length
+        deleted_systems += System.where(id: sliced_systems_ids).destroy_all.length
         remaining_systems = system_ids.length - deleted_systems
         puts _('%{remaining_systems} systems to be deleted') % { remaining_systems: remaining_systems } unless remaining_systems.zero?
       end
-      [deleted_systems, true]
+    end
+    [deleted_systems, true]
+  rescue StandardError => e
+    remaining_systems = system_ids.length - deleted_systems
+    puts _(
+      'Error while purging the systems: %{error_class} %{message}, all %{all} systems could not be removed, %{remaining} systems still in the database'
+      ) % { error_class: e.class, message: e.message, all: system_ids.length, remaining: remaining_systems }
+    [deleted_systems, false]
+  end
+
+  def with_retries(max_attempts: 3, delay: 5)
+    attempts = 0
+    begin
+      attempts += 1
+      yield attempts
     rescue StandardError => e
-      if attempts < 3
-        puts _('Error while purging systems: %{error_class} %{message}. Attempt %{attempts}/3, retrying in 5 seconds') % {
-          error_class: e.class, message: e.message, attempts: attempts
-        }
-        sleep 5
-        retry
-      else
-        remaining_systems = system_ids.length - deleted_systems
+      if attempts < max_attempts
         puts _(
-          'Error while purging the systems: %{error_class} %{message}, all %{all} systems could not be removed, %{remaining} systems still in the database'
-        ) % { error_class: e.class, message: e.message, all: system_ids.length, remaining: remaining_systems }
+          'Error while purging systems: %{error_class} %{message}. Attempt %{attempts}/%{max}, retrying in %{delay} seconds'
+        ) % { error_class: e.class, message: e.message, attempts: attempts, max: max_attempts, delay: delay }
+        sleep delay
+        retry
       end
-      [deleted_systems, false]
+      raise
     end
   end
 

--- a/spec/lib/rmt/cli/systems_spec.rb
+++ b/spec/lib/rmt/cli/systems_spec.rb
@@ -217,6 +217,23 @@ RSpec.describe RMT::CLI::Systems do
       end
     end
 
+    context 'no systems to be purged quiet' do
+      let(:argv) { ['purge', '-q'] }
+
+      before do
+        create :system, :with_activated_product, last_seen_at: 1.month.ago
+      end
+
+      it 'shows a warning if there are no systems matching the query' do
+        bf = RMT::CLI::Systems::INACTIVE.ago.strftime('%F')
+        expect($stdin).to receive(:gets).and_return('y')
+        expect { described_class.start(argv) }.to(
+          output("Do you want to delete all the matching systems that contacted this RMT before #{bf}? (y/n) ").to_stdout.and \
+            output("No systems to be purged on this RMT instance. All systems have contacted RMT after #{bf}.\n").to_stderr
+        )
+      end
+    end
+
     context 'no systems to be purged' do
       let(:argv) { ['purge'] }
 
@@ -226,21 +243,24 @@ RSpec.describe RMT::CLI::Systems do
 
       it 'shows a warning if there are no systems matching the query' do
         bf = RMT::CLI::Systems::INACTIVE.ago.strftime('%F')
-
-        expect { described_class.start(argv) }.to output('').to_stdout.and \
+        expect { described_class.start(argv) }.to(
           output("No systems to be purged on this RMT instance. All systems have contacted RMT after #{bf}.\n").to_stderr
+        )
       end
     end
 
-    context 'there are systems to be purged' do
+    context 'there are systems to be purged quiet' do
       let!(:s1) { create :system, :with_activated_product, last_seen_at: 2.months.ago }
-      let!(:s2) { create :system, :with_activated_product, last_seen_at: 4.months.ago }
+      let!(:s2) { create :system, :with_activated_product, last_seen_at: 4.months.ago } # rubocop:disable RSpec/LetSetup
+      let(:relation_double) { instance_double(ActiveRecord::Relation) }
 
       it 'removes systems by following the default definition of inactive' do
         expect(System.count).to eq 2
 
-        expect { described_class.start(['purge', '--no-confirmation']) }
-          .to output(/#{s2.login}/).to_stdout
+        expect { described_class.start(['purge', '--no-confirmation', '-q']) }
+          .to output(
+            /1 systems destroyed.Purged all systems that have not contacted this RMT since #{Time.zone.today - 3.months}./m
+        ).to_stdout
 
         expect(System.count).to eq 1
         expect(System.first.id).to eq s1.id
@@ -249,24 +269,164 @@ RSpec.describe RMT::CLI::Systems do
       it 'removes systems by the given date' do
         expect(System.count).to eq 2
 
-        argv = ['purge', '--no-confirmation', '--before', Time.zone.now.strftime('%F')]
+        argv = ['purge', '--no-confirmation', '-q', '--before', Time.zone.now.strftime('%F')]
         expect { described_class.start(argv) }
-          .to output(/#{s1.login}/).to_stdout
+          .to output(/2 systems destroyed.Purged all systems that have not contacted this RMT since #{Time.zone.today}./m).to_stdout
 
         expect(System.count).to eq 0
       end
+
+      it 'retry to remove systems if there is an error' do
+        expect(System.count).to eq 2
+
+        allow(System).to receive(:where).and_return(relation_double)
+        allow(relation_double).to receive(:in_batches).and_raise('FOO')
+        argv = ['purge', '--no-confirmation', '-q', '--before', Time.zone.now.strftime('%F')]
+        expect { described_class.start(argv) }
+          .to output(<<~STDOUT).to_stdout
+            Error while purging systems: RuntimeError FOO. Retrying in 5 seconds (1/3)
+            Error while purging systems: RuntimeError FOO. Retrying in 5 seconds (2/3)
+            Could not delete all systems last seen before #{Time.zone.today}: FOO
+            Systems that have not contacted this RMT since #{Time.zone.today} may still be in this RMT
+          STDOUT
+
+        expect(System.count).to eq 2
+      end
+    end
+
+    context 'there are systems to be purged' do
+      let!(:product_a) { create :product, :with_mirrored_repositories, name: 'product-foo' }
+      let!(:product_b) { create :product, :with_mirrored_repositories, name: 'product-bar' }
+      let!(:s1) { create :system, :with_activated_product, hostname: 'foo-bars', last_seen_at: 2.months.ago, product: product_a }
+      let!(:s2) { create :system, :with_activated_product, hostname: 'Hostname', last_seen_at: 4.months.ago, product: product_b }
+      let!(:single_row) do
+        if s2.activations.first.product.product_string.length < 23
+          <<~TEXT
+            +---------+----------+-------------------------+-------------------------+------------------------+
+            | Login   | Hostname | Registration time       | Last seen               | Products               |
+            +---------+----------+-------------------------+-------------------------+------------------------+
+            | #{s2.login} | #{s2.hostname} | #{s2.registered_at} | #{s2.last_seen_at} | #{s2.activations.first.product.product_string} |
+            +---------+----------+-------------------------+-------------------------+------------------------+
+          TEXT
+        elsif s2.activations.first.product.product_string.length == 23
+          <<~TEXT
+            +---------+----------+-------------------------+-------------------------+-------------------------+
+            | Login   | Hostname | Registration time       | Last seen               | Products                |
+            +---------+----------+-------------------------+-------------------------+-------------------------+
+            | #{s2.login} | #{s2.hostname} | #{s2.registered_at} | #{s2.last_seen_at} | #{s2.activations.first.product.product_string} |
+            +---------+----------+-------------------------+-------------------------+-------------------------+
+          TEXT
+        end
+      end
+      let!(:multiple_rows) do
+        if s2.activations.first.product.product_string.length < 23
+          <<~TEXT
+            +---------+----------+-------------------------+-------------------------+------------------------+
+            | Login   | Hostname | Registration time       | Last seen               | Products               |
+            +---------+----------+-------------------------+-------------------------+------------------------+
+            | #{s2.login} | #{s2.hostname} | #{s2.registered_at} | #{s2.last_seen_at} | #{s2.activations.first.product.product_string} |
+            | #{s1.login} | #{s1.hostname} | #{s1.registered_at} | #{s1.last_seen_at} | #{s1.activations.first.product.product_string} |
+            +---------+----------+-------------------------+-------------------------+------------------------+
+          TEXT
+        elsif s2.activations.first.product.product_string.length == 23
+          <<~TEXT
+            +---------+----------+-------------------------+-------------------------+-------------------------+
+            | Login   | Hostname | Registration time       | Last seen               | Products                |
+            +---------+----------+-------------------------+-------------------------+-------------------------+
+            | #{s2.login} | #{s2.hostname} | #{s2.registered_at} | #{s2.last_seen_at} | #{s2.activations.first.product.product_string} |
+            | #{s1.login} | #{s1.hostname} | #{s1.registered_at} | #{s1.last_seen_at} | #{s1.activations.first.product.product_string} |
+            +---------+----------+-------------------------+-------------------------+-------------------------+
+          TEXT
+        end
+      end
+      let(:query_relation_double) { instance_double(ActiveRecord::Relation) }
+      let(:mock_batch)    { instance_double(ActiveRecord::Batches::BatchEnumerator) }
+
+      it 'removes systems by following the default definition of inactive' do
+        expect(System.count).to eq 2
+
+        stub_const('RMT::CLI::Systems::DELETE_BATCH_SIZE', 1)
+
+        expect { described_class.start(['purge', '--no-confirmation']) }
+           .to output(<<~TEXT).to_stdout
+             1 systems last seen before #{Time.zone.today - 3.months}
+             #{single_row}Purged all systems that have not contacted this RMT since #{Time.zone.today - 3.months}.
+           TEXT
+
+        expect(System.count).to eq 1
+        expect(System.first.id).to eq s1.id
+      end
+
+      it 'removes systems by the given date' do
+        expect(System.count).to eq 2
+
+        stub_const('RMT::CLI::Systems::DELETE_BATCH_SIZE', 1)
+        argv = ['purge', '--no-confirmation', '--before', Time.zone.now.strftime('%F')]
+        expect { described_class.start(argv) }
+          .to output(<<~TEXT).to_stdout
+            1 systems last seen before #{Time.zone.today}
+            2 systems last seen before #{Time.zone.today}
+            #{multiple_rows}1 systems to be deleted
+            Purged all systems that have not contacted this RMT since #{Time.zone.today}.
+          TEXT
+        expect(System.count).to eq 0
+      end
+
+      it 'handle a DB error' do
+        expect(System.count).to eq 2
+
+        allow(System).to receive(:where).and_return(query_relation_double)
+        allow(query_relation_double).to receive(:in_batches).and_raise('FOO')
+        argv = ['purge', '--no-confirmation', '--before', Time.zone.now.strftime('%F')]
+        expect { described_class.start(argv) }
+          .to output(<<~TEXT).to_stdout
+            Could not get all systems last seen before #{Time.zone.today}: RuntimeError FOO
+          TEXT
+
+        expect(System.count).to eq 2
+      end
+
+      # rubocop:disable RSpec/ExampleLength
+      it 'retry to remove systems if there is an error' do
+        expect(System.count).to eq 2
+
+        allow(System).to receive(:where) do |*args|
+          if args.first.is_a?(Hash) && args.first.key?(:id)
+            query_relation_double
+          else
+            System.method(:where).super_method.call(*args)
+          end
+        end
+        allow(query_relation_double).to receive(:destroy_all).and_raise('BAR')
+        argv = ['purge', '--no-confirmation', '--before', Time.zone.now.strftime('%F')]
+        expect { described_class.start(argv) }
+          .to output(<<~TEXT).to_stdout
+            2 systems last seen before #{Time.zone.today}
+            #{multiple_rows}Error while purging systems: RuntimeError BAR. Attempt 1/3, retrying in 5 seconds
+            Error while purging systems: RuntimeError BAR. Attempt 2/3, retrying in 5 seconds
+            Error while purging the systems: RuntimeError BAR, all 2 systems could not be removed, 2 systems still in the database
+          TEXT
+
+        expect(System.count).to eq 2
+      end
+      # rubocop:enable RSpec/ExampleLength
     end
 
     context 'purge confirmations' do
       let!(:s1) { create :system, :with_activated_product, last_seen_at: 2.months.ago }
-      let!(:s2) { create :system, :with_activated_product, last_seen_at: 4.months.ago }
+      let!(:s2) { create :system, :with_activated_product, last_seen_at: 4.months.ago } # rubocop:disable RSpec/LetSetup
+      let(:confirmation) { "Do you want to delete all the matching systems that contacted this RMT before #{Time.zone.today - 3.months}? (y/n) " }
+      let(:purge) { "Purged all systems that have not contacted this RMT since #{Time.zone.today - 3.months}." }
 
       it 'asks for confirmation' do
         expect(System.count).to eq 2
         expect($stdin).to receive(:gets).and_return('y')
 
-        expect { described_class.start(['purge']) }
-          .to output(/#{s2.login}/).to_stdout
+        expect { described_class.start(['purge', '-q']) }
+          .to output(<<~TEXT).to_stdout
+            #{confirmation}1 systems destroyed
+            Purged all systems that have not contacted this RMT since #{Time.zone.today - 3.months}.
+          TEXT
 
         expect(System.count).to eq 1
         expect(System.first.id).to eq s1.id
@@ -276,8 +436,8 @@ RSpec.describe RMT::CLI::Systems do
         expect(System.count).to eq 2
         expect($stdin).to receive(:gets).and_return('n')
 
-        expect { described_class.start(['purge']) }
-          .to output(/#{s2.login}/).to_stdout
+        expect { described_class.start(['purge', '-q']) }
+          .to output("Do you want to delete all the matching systems that contacted this RMT before #{Time.zone.today - 3.months}? (y/n) ").to_stdout
 
         expect(System.count).to eq 2
       end
@@ -287,9 +447,12 @@ RSpec.describe RMT::CLI::Systems do
         expect($stdin).to receive(:gets).and_return('e')
         expect($stdin).to receive(:gets).and_return('n')
 
-        expect { described_class.start(['purge']) }
+        expect { described_class.start(['purge', '-q']) }
           .to output(/Please answer/).to_stderr.and \
-            output(/#{s2.login}/).to_stdout
+            output(
+              "Do you want to delete all the matching systems that contacted this RMT before #{Time.zone.today - 3.months}? (y/n) " \
+                "Do you want to delete all the matching systems that contacted this RMT before #{Time.zone.today - 3.months}? (y/n) "
+            ).to_stdout
 
         expect(System.count).to eq 2
       end

--- a/spec/lib/rmt/cli/systems_spec.rb
+++ b/spec/lib/rmt/cli/systems_spec.rb
@@ -284,8 +284,8 @@ RSpec.describe RMT::CLI::Systems do
         argv = ['purge', '--no-confirmation', '-q', '--before', Time.zone.now.strftime('%F')]
         expect { described_class.start(argv) }
           .to output(<<~STDOUT).to_stdout
-            Error while purging systems: RuntimeError FOO. Retrying in 5 seconds (1/3)
-            Error while purging systems: RuntimeError FOO. Retrying in 5 seconds (2/3)
+            Error while purging systems: RuntimeError FOO. Attempt 1/3, retrying in 5 seconds
+            Error while purging systems: RuntimeError FOO. Attempt 2/3, retrying in 5 seconds
             Could not delete all systems last seen before #{Time.zone.today}: FOO
             Systems that have not contacted this RMT since #{Time.zone.today} may still be in this RMT
           STDOUT


### PR DESCRIPTION
## Description

when purging a large amount of systems, the command crashes,
these changes aim to remove the bottle-necks and to provide
more information on the process and a recovery path
    
add verbose option

* Related Issue / Ticket / Trello card: [bsc#1262706](https://bugzilla.suse.com/show_bug.cgi?id=1262706)

## How to test 

running purge in a database with ~30 million systems, the command finishes without any issue
with or without verbose option

## Change Type

*Please select the correct option.*

- [X] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [X] I have documented the `MANUAL.md` file with any changes to the user experience.
- [X] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

