### PR TITLE
Fix RPM packaging conflicts with valkey package

### DIFF
--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -71,6 +71,10 @@ jobs:
         run: |
           bash ci/rmt-build-rpm
 
+      - name: validate RPM packaging
+        run: |
+          bash ci/rmt-validate-packaging
+
       - name: gather RPM build artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -2,7 +2,7 @@
 #!UseOBSRepositories
 FROM opensuse/tumbleweed
 
-RUN zypper --non-interactive install --no-recommends ruby3.4 ruby3.4-devel
+RUN zypper --non-interactive install --no-recommends ruby3.4 ruby3.4-devel ruby3.4-rubygem-bundler
 
 RUN zypper --non-interactive install libffi-devel libmysqlclient-devel libxml2-devel \
                         libxslt-devel rpmbuild systemd gzip tar bzip2 nodejs sqlite-devel \
@@ -14,6 +14,26 @@ RUN update-alternatives --install /usr/bin/gem gem /usr/bin/gem.ruby3.4 1
 RUN update-alternatives --install /usr/bin/gem gem /usr/bin/gem.ruby4.0 2
 RUN update-alternatives --install /usr/bin/ruby ruby /usr/bin/ruby.ruby3.4 1
 RUN update-alternatives --install /usr/bin/ruby ruby /usr/bin/ruby.ruby4.0 2
+RUN update-alternatives --install /usr/bin/bundle bundle /usr/bin/bundle.ruby.ruby3.4 1
+RUN update-alternatives --install /usr/bin/bundle bundle /usr/bin/bundle.ruby.ruby4.0 2
+RUN update-alternatives --install /usr/bin/bundler bundler /usr/bin/bundler.ruby.ruby3.4 1
+RUN update-alternatives --install /usr/bin/bundler bundler /usr/bin/bundler.ruby.ruby4.0 2
+RUN update-alternatives --install /usr/bin/racc racc /usr/bin/racc.ruby.ruby3.4 1
+RUN update-alternatives --install /usr/bin/racc racc /usr/bin/racc.ruby.ruby4.0 2
+RUN update-alternatives --install /usr/bin/rake rake /usr/bin/rake.ruby.ruby3.4 1
+RUN update-alternatives --install /usr/bin/rake rake /usr/bin/rake.ruby.ruby4.0 2
+RUN update-alternatives --install /usr/bin/rbs rbs /usr/bin/rbs.ruby.ruby3.4 1
+RUN update-alternatives --install /usr/bin/rbs rbs /usr/bin/rbs.ruby.ruby4.0 2
+RUN update-alternatives --install /usr/bin/rdoc rdoc /usr/bin/rdoc.ruby.ruby3.4 1
+RUN update-alternatives --install /usr/bin/rdoc rdoc /usr/bin/rdoc.ruby.ruby4.0 2
+RUN update-alternatives --install /usr/bin/ri ri /usr/bin/ri.ruby.ruby3.4 1
+RUN update-alternatives --install /usr/bin/ri ri /usr/bin/ri.ruby.ruby4.0 2
+RUN update-alternatives --install /usr/bin/typeprof typeprof /usr/bin/typeprof.ruby.ruby3.4 1
+RUN update-alternatives --install /usr/bin/typeprof typeprof /usr/bin/typeprof.ruby.ruby4.0 2
+RUN update-alternatives --install /usr/bin/rdbg rdbg /usr/bin/rdbg.ruby.ruby3.4 1
+RUN update-alternatives --install /usr/bin/rdbg rdbg /usr/bin/rdbg.ruby.ruby4.0 2
+RUN update-alternatives --install /usr/bin/syntax_suggest syntax_suggest /usr/bin/syntax_suggest.ruby.ruby3.4 1
+RUN update-alternatives --install /usr/bin/syntax_suggest syntax_suggest /usr/bin/syntax_suggest.ruby.ruby4.0 2
 
 RUN update-alternatives --set ruby /usr/bin/ruby.ruby3.4 && \
     update-alternatives --set gem /usr/bin/gem.ruby3.4 && \

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -6,7 +6,7 @@ RUN zypper --non-interactive install --no-recommends ruby3.4 ruby3.4-devel
 
 RUN zypper --non-interactive install libffi-devel libmysqlclient-devel libxml2-devel \
                         libxslt-devel rpmbuild systemd gzip tar bzip2 nodejs sqlite-devel \
-                        make chrpath fdupes gcc libcurl-devel libyaml-devel
+                        make chrpath fdupes gcc libcurl-devel libyaml-devel valkey
 
 RUN rm /usr/bin/ruby /usr/bin/gem
 

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -10,30 +10,30 @@ RUN zypper --non-interactive install libffi-devel libmysqlclient-devel libxml2-d
 
 RUN rm /usr/bin/ruby /usr/bin/gem
 
-RUN update-alternatives --install /usr/bin/gem gem /usr/bin/gem.ruby3.4 1
-RUN update-alternatives --install /usr/bin/gem gem /usr/bin/gem.ruby4.0 2
-RUN update-alternatives --install /usr/bin/ruby ruby /usr/bin/ruby.ruby3.4 1
-RUN update-alternatives --install /usr/bin/ruby ruby /usr/bin/ruby.ruby4.0 2
-RUN update-alternatives --install /usr/bin/bundle bundle /usr/bin/bundle.ruby.ruby3.4 1
-RUN update-alternatives --install /usr/bin/bundle bundle /usr/bin/bundle.ruby.ruby4.0 2
-RUN update-alternatives --install /usr/bin/bundler bundler /usr/bin/bundler.ruby.ruby3.4 1
-RUN update-alternatives --install /usr/bin/bundler bundler /usr/bin/bundler.ruby.ruby4.0 2
-RUN update-alternatives --install /usr/bin/racc racc /usr/bin/racc.ruby.ruby3.4 1
-RUN update-alternatives --install /usr/bin/racc racc /usr/bin/racc.ruby.ruby4.0 2
-RUN update-alternatives --install /usr/bin/rake rake /usr/bin/rake.ruby.ruby3.4 1
-RUN update-alternatives --install /usr/bin/rake rake /usr/bin/rake.ruby.ruby4.0 2
-RUN update-alternatives --install /usr/bin/rbs rbs /usr/bin/rbs.ruby.ruby3.4 1
-RUN update-alternatives --install /usr/bin/rbs rbs /usr/bin/rbs.ruby.ruby4.0 2
-RUN update-alternatives --install /usr/bin/rdoc rdoc /usr/bin/rdoc.ruby.ruby3.4 1
-RUN update-alternatives --install /usr/bin/rdoc rdoc /usr/bin/rdoc.ruby.ruby4.0 2
-RUN update-alternatives --install /usr/bin/ri ri /usr/bin/ri.ruby.ruby3.4 1
-RUN update-alternatives --install /usr/bin/ri ri /usr/bin/ri.ruby.ruby4.0 2
-RUN update-alternatives --install /usr/bin/typeprof typeprof /usr/bin/typeprof.ruby.ruby3.4 1
-RUN update-alternatives --install /usr/bin/typeprof typeprof /usr/bin/typeprof.ruby.ruby4.0 2
-RUN update-alternatives --install /usr/bin/rdbg rdbg /usr/bin/rdbg.ruby.ruby3.4 1
-RUN update-alternatives --install /usr/bin/rdbg rdbg /usr/bin/rdbg.ruby.ruby4.0 2
-RUN update-alternatives --install /usr/bin/syntax_suggest syntax_suggest /usr/bin/syntax_suggest.ruby.ruby3.4 1
-RUN update-alternatives --install /usr/bin/syntax_suggest syntax_suggest /usr/bin/syntax_suggest.ruby.ruby4.0 2
+RUN update-alternatives --install /usr/bin/gem gem /usr/bin/gem.ruby3.4 1 && \
+    update-alternatives --install /usr/bin/gem gem /usr/bin/gem.ruby4.0 2 && \
+    update-alternatives --install /usr/bin/ruby ruby /usr/bin/ruby.ruby3.4 1 && \
+    update-alternatives --install /usr/bin/ruby ruby /usr/bin/ruby.ruby4.0 2 && \
+    update-alternatives --install /usr/bin/bundle bundle /usr/bin/bundle.ruby.ruby3.4 1 && \
+    update-alternatives --install /usr/bin/bundle bundle /usr/bin/bundle.ruby.ruby4.0 2 && \
+    update-alternatives --install /usr/bin/bundler bundler /usr/bin/bundler.ruby.ruby3.4 1 && \
+    update-alternatives --install /usr/bin/bundler bundler /usr/bin/bundler.ruby.ruby4.0 2 && \
+    update-alternatives --install /usr/bin/racc racc /usr/bin/racc.ruby.ruby3.4 1 && \
+    update-alternatives --install /usr/bin/racc racc /usr/bin/racc.ruby.ruby4.0 2 && \
+    update-alternatives --install /usr/bin/rake rake /usr/bin/rake.ruby.ruby3.4 1 && \
+    update-alternatives --install /usr/bin/rake rake /usr/bin/rake.ruby.ruby4.0 2 && \
+    update-alternatives --install /usr/bin/rbs rbs /usr/bin/rbs.ruby.ruby3.4 1 && \
+    update-alternatives --install /usr/bin/rbs rbs /usr/bin/rbs.ruby.ruby4.0 2 && \
+    update-alternatives --install /usr/bin/rdoc rdoc /usr/bin/rdoc.ruby.ruby3.4 1 && \
+    update-alternatives --install /usr/bin/rdoc rdoc /usr/bin/rdoc.ruby.ruby4.0 2 && \
+    update-alternatives --install /usr/bin/ri ri /usr/bin/ri.ruby.ruby3.4 1 && \
+    update-alternatives --install /usr/bin/ri ri /usr/bin/ri.ruby.ruby4.0 2 && \
+    update-alternatives --install /usr/bin/typeprof typeprof /usr/bin/typeprof.ruby.ruby3.4 1 && \
+    update-alternatives --install /usr/bin/typeprof typeprof /usr/bin/typeprof.ruby.ruby4.0 2 && \
+    update-alternatives --install /usr/bin/rdbg rdbg /usr/bin/rdbg.ruby.ruby3.4 1 && \
+    update-alternatives --install /usr/bin/rdbg rdbg /usr/bin/rdbg.ruby.ruby4.0 2 && \
+    update-alternatives --install /usr/bin/syntax_suggest syntax_suggest /usr/bin/syntax_suggest.ruby.ruby3.4 1 && \
+    update-alternatives --install /usr/bin/syntax_suggest syntax_suggest /usr/bin/syntax_suggest.ruby.ruby4.0 2
 
 RUN update-alternatives --set ruby /usr/bin/ruby.ruby3.4 && \
     update-alternatives --set gem /usr/bin/gem.ruby3.4 && \

--- a/ci/rmt-build-rpm
+++ b/ci/rmt-build-rpm
@@ -39,5 +39,6 @@ pushd "$BUILD_DIR"
   rpmbuild -ba --define '_srcdefattr (-,root,root)' --nosignature --undefine _enable_debug_packages SOURCES/rmt-server.spec
   cp -r "RPMS/x86_64/rmt-server-$VERSION"*.rpm "$ARTIFACT_DIR/"
   cp -r "RPMS/x86_64/rmt-server-config-$VERSION"*.rpm "$ARTIFACT_DIR/"
+  cp -r "RPMS/x86_64/rmt-server-pubcloud-$VERSION"*.rpm "$ARTIFACT_DIR/"
 popd
 groupend

--- a/ci/rmt-validate-packaging
+++ b/ci/rmt-validate-packaging
@@ -23,7 +23,9 @@ if [ -z "$RPMS" ]; then
 fi
 
 echo "Found RPMs to validate:"
-echo "$RPMS" | while read rpm; do echo "  - $(basename $rpm)"; done
+while IFS= read -r rpm; do
+  echo "  - $(basename "$rpm")"
+done <<< "$RPMS"
 echo ""
 
 # Check for forbidden top-level directory claims
@@ -36,7 +38,7 @@ FORBIDDEN_DIRS=(
 TOTAL_ERRORS=0
 
 # Validate each RPM
-echo "$RPMS" | while read RPM; do
+while IFS= read -r RPM; do
   PACKAGE_NAME=$(basename "$RPM")
   echo "==> Checking: $PACKAGE_NAME"
 
@@ -52,15 +54,15 @@ echo "$RPMS" | while read RPM; do
     fi
   done
 
-  if [ $ERRORS -eq 0 ]; then
+  if [ "$ERRORS" -eq 0 ]; then
     echo "  ✓ PASS: No forbidden directory claims"
   fi
 
   echo ""
-done
+done <<< "$RPMS"
 
 # Final result
-if [ $TOTAL_ERRORS -gt 0 ]; then
+if [ "$TOTAL_ERRORS" -gt 0 ]; then
   echo "FAIL: Found $TOTAL_ERRORS packaging issue(s) across all RPMs"
   echo ""
   echo "These issues must be fixed to prevent:"

--- a/ci/rmt-validate-packaging
+++ b/ci/rmt-validate-packaging
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Validate RPM packaging for directory ownership conflicts
+# This prevents conflicts with system packages and ensures transactional-update compatibility
+
+set -e
+
+SOURCE="${SOURCE:-/usr/src/rmt-server}"
+ARTIFACTS_DIR="$SOURCE/tmp/artifacts"
+
+echo "==> Validating RPM packaging..."
+echo ""
+
+# Find all rmt-server RPMs (excluding source and debuginfo)
+RPMS=$(find "$ARTIFACTS_DIR" -name "rmt-server*.rpm" -o -name "ansible-rmt-server*.rpm" 2>/dev/null | \
+       grep -v '\.src\.rpm$' | \
+       grep -v 'debuginfo' | \
+       grep -v 'debugsource' | \
+       sort)
+
+if [ -z "$RPMS" ]; then
+  echo "ERROR: No rmt-server RPMs found in $ARTIFACTS_DIR"
+  exit 1
+fi
+
+echo "Found RPMs to validate:"
+echo "$RPMS" | while read rpm; do echo "  - $(basename $rpm)"; done
+echo ""
+
+# Check for forbidden top-level directory claims
+# These directories should be owned by the filesystem package, not by application packages
+FORBIDDEN_DIRS=(
+  "/etc$"
+  "/var/lib$"
+)
+
+TOTAL_ERRORS=0
+
+# Validate each RPM
+echo "$RPMS" | while read RPM; do
+  PACKAGE_NAME=$(basename "$RPM")
+  echo "==> Checking: $PACKAGE_NAME"
+
+  ERRORS=0
+
+  # Check for forbidden directory ownership
+  for dir_pattern in "${FORBIDDEN_DIRS[@]}"; do
+    if rpm -qplv "$RPM" 2>/dev/null | grep -E "^d.*${dir_pattern}"; then
+      echo "  ✗ ERROR: Package claims ownership of ${dir_pattern}"
+      echo "    Top-level directories should be owned by filesystem package"
+      ((ERRORS++))
+      ((TOTAL_ERRORS++))
+    fi
+  done
+
+  if [ $ERRORS -eq 0 ]; then
+    echo "  ✓ PASS: No forbidden directory claims"
+  fi
+
+  echo ""
+done
+
+# Final result
+if [ $TOTAL_ERRORS -gt 0 ]; then
+  echo "FAIL: Found $TOTAL_ERRORS packaging issue(s) across all RPMs"
+  echo ""
+  echo "These issues must be fixed to prevent:"
+  echo "  - File conflicts during package installation"
+  echo "  - Permission/ownership mismatches with system packages"
+  echo "  - Compatibility issues with transactional-update systems"
+  exit 1
+fi
+
+echo "✓ PASS: All RPM packages validated successfully"
+exit 0

--- a/ci/rmt-validate-packaging
+++ b/ci/rmt-validate-packaging
@@ -11,21 +11,21 @@ echo "==> Validating RPM packaging..."
 echo ""
 
 # Find all rmt-server RPMs (excluding source and debuginfo)
-mapfile -t RPMS < <(find "$ARTIFACTS_DIR" \( -name "rmt-server*.rpm" -o -name "ansible-rmt-server*.rpm" \) 2>/dev/null | \
-                    grep -v '\.src\.rpm$' | \
-                    grep -v 'debuginfo' | \
-                    grep -v 'debugsource' | \
-                    sort)
+RPMS=$(find "$ARTIFACTS_DIR" -name "rmt-server*.rpm" -o -name "ansible-rmt-server*.rpm" 2>/dev/null | \
+       grep -v '\.src\.rpm$' | \
+       grep -v 'debuginfo' | \
+       grep -v 'debugsource' | \
+       sort)
 
-if (( ${#RPMS[@]} == 0 )); then
+if [ -z "$RPMS" ]; then
   echo "ERROR: No rmt-server RPMs found in $ARTIFACTS_DIR"
   exit 1
 fi
 
 echo "Found RPMs to validate:"
-for rpm in "${RPMS[@]}"; do
+while IFS= read -r rpm; do
   echo "  - $(basename "$rpm")"
-done
+done <<< "$RPMS"
 echo ""
 
 # Check for forbidden top-level directory claims
@@ -38,7 +38,7 @@ FORBIDDEN_DIRS=(
 TOTAL_ERRORS=0
 
 # Validate each RPM
-for RPM in "${RPMS[@]}"; do
+while IFS= read -r RPM; do
   PACKAGE_NAME=$(basename "$RPM")
   echo "==> Checking: $PACKAGE_NAME"
 
@@ -54,15 +54,15 @@ for RPM in "${RPMS[@]}"; do
     fi
   done
 
-  if (( ERRORS == 0 )); then
+  if [ "$ERRORS" -eq 0 ]; then
     echo "  ✓ PASS: No forbidden directory claims"
   fi
 
   echo ""
-done
+done <<< "$RPMS"
 
 # Final result
-if (( TOTAL_ERRORS > 0 )); then
+if [ "$TOTAL_ERRORS" -gt 0 ]; then
   echo "FAIL: Found $TOTAL_ERRORS packaging issue(s) across all RPMs"
   echo ""
   echo "These issues must be fixed to prevent:"

--- a/ci/rmt-validate-packaging
+++ b/ci/rmt-validate-packaging
@@ -11,21 +11,21 @@ echo "==> Validating RPM packaging..."
 echo ""
 
 # Find all rmt-server RPMs (excluding source and debuginfo)
-RPMS=$(find "$ARTIFACTS_DIR" -name "rmt-server*.rpm" -o -name "ansible-rmt-server*.rpm" 2>/dev/null | \
-       grep -v '\.src\.rpm$' | \
-       grep -v 'debuginfo' | \
-       grep -v 'debugsource' | \
-       sort)
+mapfile -t RPMS < <(find "$ARTIFACTS_DIR" \( -name "rmt-server*.rpm" -o -name "ansible-rmt-server*.rpm" \) 2>/dev/null | \
+                    grep -v '\.src\.rpm$' | \
+                    grep -v 'debuginfo' | \
+                    grep -v 'debugsource' | \
+                    sort)
 
-if [ -z "$RPMS" ]; then
+if (( ${#RPMS[@]} == 0 )); then
   echo "ERROR: No rmt-server RPMs found in $ARTIFACTS_DIR"
   exit 1
 fi
 
 echo "Found RPMs to validate:"
-while IFS= read -r rpm; do
+for rpm in "${RPMS[@]}"; do
   echo "  - $(basename "$rpm")"
-done <<< "$RPMS"
+done
 echo ""
 
 # Check for forbidden top-level directory claims
@@ -38,7 +38,7 @@ FORBIDDEN_DIRS=(
 TOTAL_ERRORS=0
 
 # Validate each RPM
-while IFS= read -r RPM; do
+for RPM in "${RPMS[@]}"; do
   PACKAGE_NAME=$(basename "$RPM")
   echo "==> Checking: $PACKAGE_NAME"
 
@@ -54,15 +54,15 @@ while IFS= read -r RPM; do
     fi
   done
 
-  if [ "$ERRORS" -eq 0 ]; then
+  if (( ERRORS == 0 )); then
     echo "  ✓ PASS: No forbidden directory claims"
   fi
 
   echo ""
-done <<< "$RPMS"
+done
 
 # Final result
-if [ "$TOTAL_ERRORS" -gt 0 ]; then
+if (( TOTAL_ERRORS > 0 )); then
   echo "FAIL: Found $TOTAL_ERRORS packaging issue(s) across all RPMs"
   echo ""
   echo "These issues must be fixed to prevent:"

--- a/package/obs/rmt-server.spec
+++ b/package/obs/rmt-server.spec
@@ -52,6 +52,7 @@ Source0:        %{name}-%{version}.tar.bz2
 Source1:        rmt-server-rpmlintrc
 Source2:        rmt.conf
 Source3:        rmt-cli.8.gz
+Source4:        rmt-valkey.tmpfiles
 BuildRequires:  %{ruby_version}
 BuildRequires:  %{ruby_version}-devel
 BuildRequires:  chrpath
@@ -225,8 +226,8 @@ mkdir -p %{buildroot}%{_sysconfdir}
 mv %{_builddir}/rmt.conf %{buildroot}%{_sysconfdir}/rmt.conf
 
 # valkey
-mkdir -p %{buildroot}/var/lib/valkey/6380
 install -D -m 644 package/files/valkey-6380.conf %{buildroot}%{_sysconfdir}/valkey/6380.conf
+install -D -m 644 %{SOURCE4} %{buildroot}%{_tmpfilesdir}/rmt-valkey.conf
 
 # nginx
 install -D -m 644 package/files/nginx/nginx-http.conf %{buildroot}%{_sysconfdir}/nginx/vhosts.d/rmt-server-http.conf
@@ -389,12 +390,9 @@ ansible-playbook tests/test_playbook.yml
 %config(noreplace) %{_sysconfdir}/nginx/rmt-auth.d/auth-location.conf
 
 # Valkey + Sidekiq files
-%dir /var/lib/valkey
-%dir /var/lib/valkey/6380
-%attr(-,valkey,root) /var/lib/valkey/6380
 %dir %{_sysconfdir}/valkey
-%attr(-,root,valkey) %{_sysconfdir}/valkey/6380.conf
 %config(noreplace) %{_sysconfdir}/valkey/6380.conf
+%{_tmpfilesdir}/rmt-valkey.conf
 %{_unitdir}/rmt-sidekiq.service
 %{_unitdir}/rmt-valkey.service
 %{_sbindir}/rcrmt-valkey
@@ -449,7 +447,12 @@ getent passwd %{rmt_user} >/dev/null || \
 
 # Run only on install
 if [ $1 -eq 1 ]; then
-  echo "Please run the YaST RMT module (or 'yast2 rmt' from the command line) to complete the configuration of your RMT" >> /dev/stdout
+%if 0%{?suse_version} >= 1600
+  echo "To complete the RMT configuration, install 'ansible-rmt-server' package and run:"
+  echo "  cd /usr/share/ansible/rmt && ansible-playbook site.yml"
+%else
+  echo "Please run the YaST RMT module (or 'yast2 rmt' from the command line) to complete the configuration of your RMT"
+%endif
 fi
 
 # Run only on upgrade
@@ -492,6 +495,7 @@ fi
 
 %post pubcloud
 %service_add_post rmt-server-regsharing.service rmt-server-trim-cache.service rmt-valkey.service rmt-sidekiq.service
+%tmpfiles_create %{_tmpfilesdir}/rmt-valkey.conf
 
 
 %preun pubcloud

--- a/package/obs/rmt-server.spec
+++ b/package/obs/rmt-server.spec
@@ -65,6 +65,7 @@ BuildRequires:  libxml2-devel
 BuildRequires:  libxslt-devel
 BuildRequires:  libyaml-devel
 BuildRequires:  sqlite-devel
+BuildRequires:  valkey
 BuildRequires:  pkgconfig(systemd)
 # Only require ansible build dependencies when building ansible subpackage (SLES/Leap 16+ only, not Tumbleweed)
 # Note: suse_version >= 1600 excludes Tumbleweed which has suse_version == 1699
@@ -390,7 +391,6 @@ ansible-playbook tests/test_playbook.yml
 %config(noreplace) %{_sysconfdir}/nginx/rmt-auth.d/auth-location.conf
 
 # Valkey + Sidekiq files
-%dir %{_sysconfdir}/valkey
 %config(noreplace) %{_sysconfdir}/valkey/6380.conf
 %{_tmpfilesdir}/rmt-valkey.conf
 %{_unitdir}/rmt-sidekiq.service

--- a/package/obs/rmt-server.spec
+++ b/package/obs/rmt-server.spec
@@ -153,7 +153,7 @@ sed -i '1 s|/usr/bin/env\ ruby|/usr/bin/ruby.%{ruby_version}|' bin/*
 # Set the version of bundler available within the build environment instead
 # of expect a hardcoded version. This ensures we bundle with the available version of bundler no matter which version available
 # NOTE: This relies on the fact that the lock file format does not change between bundler versions (which is not yet the case)
-sed -i "s/2\.2\.34/$(bundle.%{ruby_version} --version | grep -oE '([0-9]+\.?){3}')/g" Gemfile.lock
+sed -i "s/2\.6\.7/$(bundle.%{ruby_version} --version | grep -oE '([0-9]+\.?){3}')/g" Gemfile.lock
 
 %build
 bundle.%{ruby_version} config build.nio4r --with-cflags='%{optflags} -Wno-return-type'

--- a/package/obs/rmt-valkey.tmpfiles
+++ b/package/obs/rmt-valkey.tmpfiles
@@ -1,0 +1,5 @@
+# tmpfiles.d configuration for RMT Valkey instance
+# This ensures the data directory exists with correct permissions on transactional-update systems
+# Note: /var/lib/valkey is owned by the valkey package, we only create our subdirectory
+
+d /var/lib/valkey/6380 0750 valkey valkey -


### PR DESCRIPTION
## Description

This PR fixes directory ownership conflicts between `rmt-server-pubcloud` and the `valkey` package that prevented installation on all architectures (x86_64, s390x, aarch64, ppc64le).

**The conflict:**
```
found conflict of rmt-server-pubcloud with valkey
/etc/valkey [mode mismatch: d755 root:root, n d750 root:valkey]
/var/lib/valkey [mode mismatch: d755 root:root, d750 valkey:valkey]
```

**Root cause:** `rmt-server-pubcloud` was claiming ownership of `/etc/valkey` and `/var/lib/valkey` directories with wrong permissions, conflicting with the `valkey` package.

**Solution:**
- Remove directory ownership claims for `/var/lib/valkey` (only claim `/etc/valkey` for config file)
- Add tmpfiles.d configuration to create `/var/lib/valkey/6380` at runtime
- Update post-install message to recommend Ansible for SLES/Leap 16+
- Add CI validation to prevent regression

* Related Issue / Ticket / Trello card: N/A (found during packaging validation)

## How to test

### Method 1: Build and Install Test
```bash
# Build the RPM packages
cd package/obs
osc build SLE_16.0 x86_64

# Check for conflicts - should NOT show /var/lib/valkey ownership
rpm -qplv /var/tmp/build-root/SLE_16.0-x86_64/home/abuild/rpmbuild/RPMS/x86_64/rmt-server-pubcloud-*.rpm | grep -E "^d.*/var/lib/valkey"

# Verify tmpfiles.d is included
rpm -qpl /var/tmp/build-root/SLE_16.0-x86_64/home/abuild/rpmbuild/RPMS/x86_64/rmt-server-pubcloud-*.rpm | grep tmpfiles
# Should show: /usr/lib/tmpfiles.d/rmt-valkey.conf
```

### Method 2: CI Validation
The GitHub Actions workflow automatically runs `ci/rmt-validate-packaging` which checks all RPM packages for forbidden directory ownership.

### Method 3: Spec File Validation
```bash
# Check spec file doesn't claim forbidden directories
grep -E "^%dir /etc$|^%dir /var/lib$|^%dir /var/lib/valkey$" package/obs/rmt-server.spec
# Should return nothing (only /etc/valkey is OK)
```

## Change Type

- [x] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

- [x] I have reviewed my own code and believe that it's ready for an external review.
- [x] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [x] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change.