### PR TITLE
Use bci-base:15.7 as Dockerfile base container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensuse/leap:15.6
+FROM registry.suse.com/bci/bci-base:15.7
 
 RUN zypper --non-interactive install --no-recommends \
         timezone wget gcc-c++ libffi-devel git-core zlib-devel \


### PR DESCRIPTION
## Description

The opensuse/leap:15.6 ecosystem is EOL and no longer viable as the basis for the rmt image; switching to bci-base:15.7 provides a viable base image that won't EOL for a long time.

## How to test 

Starting with a fresh docker or podman image building ecosystem with no existing rmt image, or the dependent layers required to build it, you should be able to exercute `make build` successfully with these changes, whereas without these changes you will see package conflict resolution issues.

## Change Type

*Please select the correct option.*

- [x] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [x] I have reviewed my own code and believe that it's ready for an external review.
- [ ] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

