### PR TITLE
Fix record unique

### DIFF
--- a/engines/registration_sharing/app/controllers/registration_sharing/rmt_to_rmt_controller.rb
+++ b/engines/registration_sharing/app/controllers/registration_sharing/rmt_to_rmt_controller.rb
@@ -21,7 +21,7 @@ module RegistrationSharing
           )
         end
         system.lock!
-        system.update(system_params)
+        system.assign_attributes(system_params)
 
         # TODO: remove this block when proxy_byos column gets dropped
         if !params.key?(:proxy_byos_mode) && system.attribute_names.include?('proxy_byos_mode')
@@ -41,7 +41,6 @@ module RegistrationSharing
           )
         end
 
-        system.instance_data = params[:instance_data]
         system.save!
       end
     end

--- a/engines/registration_sharing/app/controllers/registration_sharing/rmt_to_rmt_controller.rb
+++ b/engines/registration_sharing/app/controllers/registration_sharing/rmt_to_rmt_controller.rb
@@ -7,19 +7,7 @@ module RegistrationSharing
 
     def create
       System.transaction do
-        begin
-          system = System.find_or_create_by(
-            login: params[:login],
-            password: params[:password],
-            system_token: params[:system_token]
-            )
-        rescue ActiveRecord::RecordNotUnique
-          system = System.find_by!(
-            login: params[:login],
-            password: params[:password],
-            system_token: params[:system_token]
-          )
-        end
+        system = fetch_system
         system.lock!
         system.assign_attributes(system_params)
 
@@ -44,6 +32,20 @@ module RegistrationSharing
     end
 
     protected
+
+    def fetch_system
+      System.find_or_create_by(
+        login: params[:login],
+        password: params[:password],
+        system_token: params[:system_token]
+        )
+    rescue ActiveRecord::RecordNotUnique
+      System.find_by!(
+        login: params.expect(:login),
+        password: params.expect(:password),
+        system_token: params.expect(:system_token)
+      )
+    end
 
     def system_params
       params.permit(

--- a/engines/registration_sharing/app/controllers/registration_sharing/rmt_to_rmt_controller.rb
+++ b/engines/registration_sharing/app/controllers/registration_sharing/rmt_to_rmt_controller.rb
@@ -7,11 +7,20 @@ module RegistrationSharing
 
     def create
       System.transaction do
-        system = System.find_or_create_by(
-          login: params[:login],
-          password: params[:password],
-          system_token: params[:system_token]
-        )
+        begin
+          system = System.find_or_create_by(
+            login: params[:login],
+            password: params[:password],
+            system_token: params[:system_token]
+            )
+        rescue ActiveRecord::RecordNotUnique
+          system = System.find_by!(
+            login: params[:login],
+            password: params[:password],
+            system_token: params[:system_token]
+          )
+        end
+        system.lock!
         system.update(system_params)
 
         # TODO: remove this block when proxy_byos column gets dropped

--- a/engines/registration_sharing/spec/requests/registration_sharing/rmt_to_rmt_controller_spec.rb
+++ b/engines/registration_sharing/spec/requests/registration_sharing/rmt_to_rmt_controller_spec.rb
@@ -175,7 +175,8 @@ module RegistrationSharing
       before do
         System.create!(
           login: login_payg,
-          password: password
+          password: password,
+          system_token: login_payg
         )
         allow(System).to receive(:find_or_create_by).and_raise(ActiveRecord::RecordNotUnique)
         allow(System).to receive(:find_by!).and_call_original
@@ -184,6 +185,7 @@ module RegistrationSharing
           params: {
             login: login_payg,
             password: password,
+            system_token: login_payg,
             created_at: created_at,
             registered_at: registered_at,
             last_seen_at: last_seen_at,

--- a/engines/registration_sharing/spec/requests/registration_sharing/rmt_to_rmt_controller_spec.rb
+++ b/engines/registration_sharing/spec/requests/registration_sharing/rmt_to_rmt_controller_spec.rb
@@ -171,6 +171,53 @@ module RegistrationSharing
       end
     end
 
+    describe 'duplicate race condition' do
+      before do
+        System.create!(
+          login: login_payg,
+          password: password
+        )
+        allow(System).to receive(:find_or_create_by).and_raise(ActiveRecord::RecordNotUnique)
+        allow(System).to receive(:find_by!).and_call_original
+        post(
+          '/api/regsharing',
+          params: {
+            login: login_payg,
+            password: password,
+            created_at: created_at,
+            registered_at: registered_at,
+            last_seen_at: last_seen_at,
+            proxy_byos_mode: :hybrid,
+            pubcloud_reg_code: pubcloud_reg_code,
+            activations: [
+              {
+                product_id: product.id,
+                created_at: created_at
+              }
+            ],
+            instance_data: instance_data
+          },
+          headers: { 'Authorization' => "Bearer #{request_token}" }
+          )
+      end
+
+      context 'with correct credentials' do
+        it 'performs HTTP request successfully' do
+          expect(response).to have_http_status(204)
+        end
+
+        context 'system' do
+          subject(:system) { System.find_by(login: login_payg) }
+
+          it { is_expected.not_to eq(nil) }
+          its(:proxy_byos_mode) { is_expected.to eq('hybrid') }
+          it 'saves instance data' do
+            expect(system.instance_data).to eq(instance_data)
+          end
+        end
+      end
+    end
+
     describe '#destroy' do
       let!(:system) { FactoryBot.create(:system) }
 


### PR DESCRIPTION
## Description

fix the race condition to update a system at querying level and update level

generate SQL statement in one place

remove redundant SQL call and make it trigger at save! call 

remove unnecessary assignment of instance data, as it is already included in system_params 

* Related Issue / Ticket / Trello card: [bsc#1268303](https://bugzilla.suse.com/show_bug.cgi?id=1268303)

## How to test 


## Change Type

*Please select the correct option.*

- [X] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [X] I have documented the `MANUAL.md` file with any changes to the user experience.
- [X] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

