### PR TITLE
remove hidden N+1 queries in regsharing

### DIFF
--- a/engines/registration_sharing/app/controllers/registration_sharing/rmt_to_rmt_controller.rb
+++ b/engines/registration_sharing/app/controllers/registration_sharing/rmt_to_rmt_controller.rb
@@ -22,8 +22,14 @@ module RegistrationSharing
         end
         # end todo
         system.activations = []
+        product_ids = params[:activations].map { |a| a[:product_id].to_i }.uniq
+        # batch load all products and services
+        # prevent a second hidden (N+1) query when the loop calls product.service on every iteration
+        # it eager-loads the services alongside the products
+        products_by_id = Product.includes(:service).where(id: product_ids).index_by(&:id)
+
         params[:activations].each do |activation|
-          product = Product.find_by(id: activation[:product_id])
+          product = products_by_id[activation[:product_id].to_i]
           raise "Product #{product_id} not found" unless product
 
           system.activations << Activation.new(


### PR DESCRIPTION
## Description

eager-load the products and services outside the loop

* Related Issue / Ticket / Trello card: <link reference>

## How to test 

when running a registration sharing and debugging the DB queries, there should be a lot fewer queries when getting the activations

## Change Type

*Please select the correct option.*

- [X] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [X] I have documented the `MANUAL.md` file with any changes to the user experience.
- [X] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

