### PR TITLE
change data column type in profile table

### DIFF
--- a/db/migrate/20260618151105_change_data_type.rb
+++ b/db/migrate/20260618151105_change_data_type.rb
@@ -1,0 +1,12 @@
+class ChangeDataType < ActiveRecord::Migration[6.1]
+  def up
+    # change the column to MEDIUMTEXT (limit of 16 MB)
+    safety_assured do
+      change_column :profiles, :data, :text, limit: 16.megabytes
+    end
+  end
+
+  def down
+    change_column :profiles, :data, :text
+  end
+end


### PR DESCRIPTION
## Description
currently the data column type is TEXT

TEXT 65535 max length in bytes

and this changes the type to MEDIUMTEXT

MEDIUMTEXT 16777215 max length in bytes

which it could be less depending on the encoding

* Related Issue / Ticket / Trello card: [bsc#1268305](https://bugzilla.suse.com/show_bug.cgi?id=1268305)

## How to test 

Apply the change/migration, then inspect the table, that column should have the expected type (MEDIUMTEXT)

## Change Type

*Please select the correct option.*

- [X] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [X] I have documented the `MANUAL.md` file with any changes to the user experience.
- [X] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

