### PR TITLE
remove proxy_byos column

### DIFF
--- a/db/migrate/20260618160300_remove_proxy_byos_from_systems.rb
+++ b/db/migrate/20260618160300_remove_proxy_byos_from_systems.rb
@@ -1,0 +1,5 @@
+class RemoveProxyByosFromSystems < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured { remove_column :systems, :proxy_byos, :boolean, default: false }
+  end
+end

--- a/engines/data_export/spec/requests/api/connect/v3/systems/systems_controller_spec.rb
+++ b/engines/data_export/spec/requests/api/connect/v3/systems/systems_controller_spec.rb
@@ -80,7 +80,6 @@ RSpec.describe Api::Connect::V3::Systems::SystemsController do
           'updated_at',
           'scc_registered_at',
           'scc_system_id',
-          'proxy_byos',
           'system_token',
           'system_information',
           'instance_data',

--- a/engines/registration_sharing/app/controllers/registration_sharing/rmt_to_rmt_controller.rb
+++ b/engines/registration_sharing/app/controllers/registration_sharing/rmt_to_rmt_controller.rb
@@ -14,13 +14,6 @@ module RegistrationSharing
         )
         system.update(system_params)
 
-        # TODO: remove this block when proxy_byos column gets dropped
-        if !params.key?(:proxy_byos_mode) && system.attribute_names.include?('proxy_byos_mode')
-          # the info comes from a sibling that does not have proxy_byos_mode
-          # to a sibling does have proxy_byos_mode
-          system.proxy_byos_mode = system.proxy_byos ? :byos : :payg
-        end
-        # end todo
         system.activations = []
         params[:activations].each do |activation|
           product = Product.find_by(id: activation[:product_id])
@@ -46,10 +39,10 @@ module RegistrationSharing
 
     def system_params
       params.permit(
-        :login, :password, :hostname, :proxy_byos, :proxy_byos_mode,
+        :login, :password, :hostname, :proxy_byos_mode,
         :system_token, :registered_at, :created_at, :last_seen_at,
         :instance_data, :pubcloud_reg_code
-)
+      )
     end
 
     def authenticate

--- a/engines/registration_sharing/lib/registration_sharing/client.rb
+++ b/engines/registration_sharing/lib/registration_sharing/client.rb
@@ -21,7 +21,7 @@ class RegistrationSharing::Client
   def peer_register_system(system)
     params = {}
 
-    %w[login password hostname proxy_byos proxy_byos_mode system_token registered_at created_at last_seen_at instance_data
+    %w[login password hostname proxy_byos_mode system_token registered_at created_at last_seen_at instance_data
        pubcloud_reg_code].each do |attribute|
       params[attribute] = system.send(attribute)
     end

--- a/engines/registration_sharing/spec/lib/registration_sharing/client_spec.rb
+++ b/engines/registration_sharing/spec/lib/registration_sharing/client_spec.rb
@@ -32,7 +32,6 @@ describe RegistrationSharing::Client do
         'login' => system.login,
         'password' => system.password,
         'hostname' => system.hostname,
-        'proxy_byos' => system.byos?,
         'proxy_byos_mode' => system.proxy_byos_mode,
         'system_token' => system.system_token,
         'registered_at' => system.registered_at,

--- a/engines/registration_sharing/spec/requests/registration_sharing/rmt_to_rmt_controller_spec.rb
+++ b/engines/registration_sharing/spec/requests/registration_sharing/rmt_to_rmt_controller_spec.rb
@@ -35,7 +35,7 @@ module RegistrationSharing
             created_at: created_at,
             registered_at: registered_at,
             last_seen_at: last_seen_at,
-            proxy_byos: true,
+            proxy_byos_mode: :byos,
             pubcloud_reg_code: pubcloud_reg_code,
             activations: [
               {
@@ -99,7 +99,7 @@ module RegistrationSharing
             created_at: created_at,
             registered_at: registered_at,
             last_seen_at: last_seen_at,
-            proxy_byos: false,
+            proxy_byos_mode: :payg,
             pubcloud_reg_code: pubcloud_reg_code,
             activations: [
               {
@@ -164,7 +164,6 @@ module RegistrationSharing
 
           it { is_expected.not_to eq(nil) }
           its(:proxy_byos_mode) { is_expected.to eq('hybrid') }
-          its(:proxy_byos) { is_expected.to eq(false) }
           it 'saves instance data' do
             expect(system.instance_data).to eq(instance_data)
           end

--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -317,7 +317,6 @@ module SccProxy
                 scc_system_id: scc_response['id'],
                 password: scc_response['password'],
                 proxy_byos_mode: :byos,
-                proxy_byos: true
               }
             )
             profile_response_header_handling(scc_response_headers)

--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -316,7 +316,7 @@ module SccProxy
               {
                 scc_system_id: scc_response['id'],
                 password: scc_response['password'],
-                proxy_byos_mode: :byos,
+                proxy_byos_mode: :byos
               }
             )
             profile_response_header_handling(scc_response_headers)

--- a/engines/scc_proxy/spec/requests/api/connect/v3/subscriptions/systems_controller_spec.rb
+++ b/engines/scc_proxy/spec/requests/api/connect/v3/subscriptions/systems_controller_spec.rb
@@ -54,7 +54,6 @@ describe Api::Connect::V3::Subscriptions::SystemsController, type: :request do
 
           system = System.find_by(login: 'i-12345-payg')
           expect(system.proxy_byos_mode).to eq('byos')
-          expect(system.proxy_byos).to eq(true)
           expect(system.instance_data).to eq(instance_data)
         end
 


### PR DESCRIPTION
## Description

all the update servers in production have the new column proxy_byos_mode, after a period of adjustment having both columns should be safe to switch to the new column and remove the old one

* Related Issue / Ticket / Trello card: <link reference>

## How to test 

after applying the migration, the `proxy_byos` column should not be present
and regular RMT operations should work without any issue

## Change Type

*Please select the correct option.*

- [ ] **Bug Fix** (a non-breaking change which fixes an issue)
- [X] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [X] I have documented the `MANUAL.md` file with any changes to the user experience.
- [X] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

