### PR TITLE
fix race condition for PAYG

### DIFF
--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -558,7 +558,7 @@ module SccProxy
         # as BYOS in the cloud does not use SYSTEM_TOKEN headers
         def authenticate_system(skip_on_duplicated: false)
           authenticate_or_request_with_http_basic('RMT API') do |login, password|
-            @systems = System.get_by_credentials(login, password)
+            fetch_systems_from_db(login, password)
             if @systems.present?
               # Return now if we just detected duplicates and we were told to skip on
               # this situation.
@@ -578,6 +578,22 @@ module SccProxy
               error = ActionController::TranslatedError.new(N_('Invalid system credentials'))
               error.status = :unauthorized
               raise error
+            end
+          end
+        end
+
+        def fetch_systems_from_db(login, password)
+          attempts = 0
+          begin
+            attempts += 1
+            @systems = System.get_by_credentials(login, password)
+            raise ActionController::TranslatedError.new(N_('No systems found')) if Settings.dig(:regsharing, :peers) && @systems.blank?
+          rescue StandardError
+            if attempts < 5
+              # handle a possible race condition
+              # if there are peers/siblings
+              sleep 6
+              retry
             end
           end
         end

--- a/engines/strict_authentication/spec/requests/strict_authentication/authentication_controller_spec.rb
+++ b/engines/strict_authentication/spec/requests/strict_authentication/authentication_controller_spec.rb
@@ -14,7 +14,10 @@ module StrictAuthentication
       end
 
       context 'with invalid credentials' do
-        before { get '/api/auth/check', headers: basic_auth_header('invalid', 'invalid') }
+        before do
+          allow(Settings).to receive(:dig).and_return(['foo'])
+          get '/api/auth/check', headers: basic_auth_header('invalid', 'invalid')
+        end
         its(:code) { is_expected.to eq '401' }
       end
 


### PR DESCRIPTION
## Description

there is an scenario when a PAYG system gets registered with sibling A, then the systems tries to access sibling B immediately after that registration and the registration sharing has not propagated the needed values, producing 'Invalid system credentials' error on the system

* Related Issue / Ticket / Trello card: [bsc#1268149](https://bugzilla.suse.com/show_bug.cgi?id=1268149)

## How to test 

Run the same tests that produced the error consistently and the error should not happen 

## Change Type

*Please select the correct option.*

- [X] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [X] I have documented the `MANUAL.md` file with any changes to the user experience.
- [X] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

