### PR TITLE
fix the race condition when there is no system matching

### DIFF
--- a/app/controllers/api/connect/v3/systems/products_controller.rb
+++ b/app/controllers/api/connect/v3/systems/products_controller.rb
@@ -208,6 +208,6 @@ class Api::Connect::V3::Systems::ProductsController < Api::Connect::BaseControll
 
   def handle_invalid_foreign_key
     error = { errors: _('The system is not valid or no longer exists') }
-    render json: error, status: :unprocessable_content
+    render json: error, status: :unprocessable_entity
   end
 end

--- a/app/controllers/api/connect/v3/systems/products_controller.rb
+++ b/app/controllers/api/connect/v3/systems/products_controller.rb
@@ -5,6 +5,7 @@ class Api::Connect::V3::Systems::ProductsController < Api::Connect::BaseControll
   before_action :check_product_service_and_repositories, only: %i[show activate]
   before_action :load_subscription, only: %i[activate upgrade]
   before_action :check_base_product_dependencies, only: %i[activate upgrade show]
+  rescue_from ActiveRecord::InvalidForeignKey, with: :handle_invalid_foreign_key
   after_action :refresh_system_token, only: %i[activate upgrade], if: -> { request.headers.key?(SYSTEM_TOKEN_HEADER) }
 
   def activate
@@ -205,4 +206,8 @@ class Api::Connect::V3::Systems::ProductsController < Api::Connect::BaseControll
     Product.find_by(product_search_params(product_hash))
   end
 
+  def handle_invalid_foreign_key
+    error = { errors: _('The system is not valid or no longer exists') }
+    render json: error, status: :unprocessable_content
+  end
 end

--- a/spec/requests/api/connect/v3/systems/products_controller_spec.rb
+++ b/spec/requests/api/connect/v3/systems/products_controller_spec.rb
@@ -483,6 +483,43 @@ RSpec.describe Api::Connect::V3::Systems::ProductsController do
     end
   end
 
+  describe 'with a race condition' do
+    subject { response }
+
+    let(:request) { put url, headers: headers, params: payload }
+    let(:new_product) { FactoryBot.create(:product, :with_mirrored_repositories) }
+    let(:payload) do
+      {
+        identifier: new_product.identifier,
+        version: new_product.version,
+        arch: new_product.arch
+      }
+    end
+    let(:serialized_json) do
+      V3::ServiceSerializer.new(
+        new_product.service,
+        base_url: URI::HTTP.build({ scheme: response.request.scheme, host: response.request.host }).to_s
+      ).to_json
+    end
+
+    before do
+      allow_any_instance_of(ActiveRecord::Associations::CollectionProxy)
+        .to receive(:where).and_wrap_original do |original_method, *args|
+        # silently update the system record in the background
+        system.update(id: 9999)
+        # continue with the original ActiveRecord call which will now fail
+        # because the foreign key (system_id) no longer points to a valid system.
+        original_method.call(*args)
+      end
+    end
+
+    it 'return an error' do
+      request
+      expect(response.code).to eq('422')
+      expect(response.body).to include('system is not valid')
+    end
+  end
+
   describe 'online/offline migrations' do
     shared_examples 'migration return values' do
       before { post url, headers: headers, params: payload }


### PR DESCRIPTION
## Description

there is an scenario when creating the product activations of a system, the FK does not exist

when running @system.activations.where(...).first_or_create, it generates an INSERT into the activations table using the system_id (@system.id) which does not exist

the operation fails with
  ActiveRecord::InvalidForeignKey (
    Mysql2::Error: Cannot add or update a child row: a foreign key
    constraint fails...
  )

this is due to a race condition, where a request is destroying the system record in the database and a different request is trying to run first_or_create on the same system but the request destroying the system successfully destroy the row from the database

* Related Issue / Ticket / Trello card: [bsc#1268301](https://bugzilla.suse.com/show_bug.cgi?id=1268301)

## How to test 

## Change Type

*Please select the correct option.*

- [X] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [X] I have documented the `MANUAL.md` file with any changes to the user experience.
- [X] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

