### PR TITLE
change data column type in profile table

### DIFF
--- a/db/migrate/20260626153118_change_data_type.rb
+++ b/db/migrate/20260626153118_change_data_type.rb
@@ -1,0 +1,12 @@
+class ChangeDataType < ActiveRecord::Migration[8.1]
+  def up
+    # change the column to MEDIUMTEXT (limit of 16 MB)
+    safety_assured do
+      change_column :profiles, :data, :text, limit: 16.megabytes
+    end
+  end
+
+  def down
+    change_column :profiles, :data, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -94,12 +94,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_26_153653) do
   end
 
   create_table "profiles", charset: "utf8mb4", collation: "utf8mb4_unicode_520_ci", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.text "data", size: :long, null: false
-    t.string "identifier", null: false
-    t.timestamp "last_synced_at"
     t.string "profile_type", null: false
-    t.datetime "updated_at", null: false
+    t.string "identifier", null: false
+    t.text "data", size: :long, null: false
+    t.timestamp "last_synced_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["profile_type", "identifier"], name: "index_profiles_on_profile_type_and_identifier", unique: true
   end
 
@@ -159,10 +159,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_26_153653) do
   end
 
   create_table "system_profiles", charset: "utf8mb4", collation: "utf8mb4_unicode_520_ci", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.bigint "profile_id", null: false
     t.bigint "system_id", null: false
-    t.datetime "updated_at", null: false
+    t.bigint "profile_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["profile_id"], name: "index_system_profiles_on_profile_id"
     t.index ["system_id", "profile_id"], name: "index_system_profiles_on_system_id_and_profile_id", unique: true
     t.index ["system_id"], name: "index_system_profiles_on_system_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_01_08_092033) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_26_153653) do
   create_table "activations", charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.bigint "service_id", null: false
@@ -94,12 +94,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_08_092033) do
   end
 
   create_table "profiles", charset: "utf8mb4", collation: "utf8mb4_unicode_520_ci", force: :cascade do |t|
-    t.string "profile_type", null: false
+    t.datetime "created_at", null: false
+    t.text "data", size: :long, null: false
     t.string "identifier", null: false
-    t.text "data", null: false
     t.timestamp "last_synced_at"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.string "profile_type", null: false
+    t.datetime "updated_at", null: false
     t.index ["profile_type", "identifier"], name: "index_profiles_on_profile_type_and_identifier", unique: true
   end
 
@@ -159,10 +159,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_08_092033) do
   end
 
   create_table "system_profiles", charset: "utf8mb4", collation: "utf8mb4_unicode_520_ci", force: :cascade do |t|
-    t.bigint "system_id", null: false
+    t.datetime "created_at", null: false
     t.bigint "profile_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.bigint "system_id", null: false
+    t.datetime "updated_at", null: false
     t.index ["profile_id"], name: "index_system_profiles_on_profile_id"
     t.index ["system_id", "profile_id"], name: "index_system_profiles_on_system_id_and_profile_id", unique: true
     t.index ["system_id"], name: "index_system_profiles_on_system_id"
@@ -184,7 +184,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_08_092033) do
     t.datetime "last_seen_at"
     t.string "login"
     t.string "password"
-    t.boolean "proxy_byos", default: false
     t.integer "proxy_byos_mode", default: 0
     t.string "pubcloud_reg_code"
     t.datetime "registered_at"


### PR DESCRIPTION
## Description

currently the data column type is TEXT

TEXT 65535 max length in bytes

and this changes the type to MEDIUMTEXT

MEDIUMTEXT 16777215 max length in bytes

which it could be less depending on the encoding

* Related Issue / Ticket / Trello card: [bsc#1268305](https://bugzilla.suse.com/show_bug.cgi?id=1268305)

## How to test 

Apply the change/migration, then inspect the table, that column should have the expected type (MEDIUMTEXT)

## Change Type

*Please select the correct option.*

- [X] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [X] I have documented the `MANUAL.md` file with any changes to the user experience.
- [X] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.


## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

