### PR TITLE
remove proxy_byos column

### DIFF
--- a/db/migrate/20260626153653_remove_proxy_byos_from_systems.rb
+++ b/db/migrate/20260626153653_remove_proxy_byos_from_systems.rb
@@ -1,0 +1,5 @@
+class RemoveProxyByosFromSystems < ActiveRecord::Migration[8.1]
+  def change
+    safety_assured { remove_column :systems, :proxy_byos, :boolean, default: false }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_01_08_092033) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_26_153653) do
   create_table "activations", charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.bigint "service_id", null: false
@@ -184,7 +184,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_08_092033) do
     t.datetime "last_seen_at"
     t.string "login"
     t.string "password"
-    t.boolean "proxy_byos", default: false
     t.integer "proxy_byos_mode", default: 0
     t.string "pubcloud_reg_code"
     t.datetime "registered_at"

--- a/engines/data_export/spec/requests/api/connect/v3/systems/systems_controller_spec.rb
+++ b/engines/data_export/spec/requests/api/connect/v3/systems/systems_controller_spec.rb
@@ -80,7 +80,6 @@ RSpec.describe Api::Connect::V3::Systems::SystemsController do
           'updated_at',
           'scc_registered_at',
           'scc_system_id',
-          'proxy_byos',
           'system_token',
           'system_information',
           'instance_data',

--- a/engines/registration_sharing/app/controllers/registration_sharing/rmt_to_rmt_controller.rb
+++ b/engines/registration_sharing/app/controllers/registration_sharing/rmt_to_rmt_controller.rb
@@ -14,13 +14,6 @@ module RegistrationSharing
         )
         system.update(system_params)
 
-        # TODO: remove this block when proxy_byos column gets dropped
-        if !params.key?(:proxy_byos_mode) && system.attribute_names.include?('proxy_byos_mode')
-          # the info comes from a sibling that does not have proxy_byos_mode
-          # to a sibling does have proxy_byos_mode
-          system.proxy_byos_mode = system.proxy_byos ? :byos : :payg
-        end
-        # end todo
         system.activations = []
         params[:activations].each do |activation|
           product = Product.find_by(id: activation[:product_id])
@@ -46,7 +39,7 @@ module RegistrationSharing
 
     def system_params
       params.permit(
-        :login, :password, :hostname, :proxy_byos, :proxy_byos_mode,
+        :login, :password, :hostname, :proxy_byos_mode,
         :system_token, :registered_at, :created_at, :last_seen_at,
         :instance_data, :pubcloud_reg_code
 )

--- a/engines/registration_sharing/lib/registration_sharing/client.rb
+++ b/engines/registration_sharing/lib/registration_sharing/client.rb
@@ -21,7 +21,7 @@ class RegistrationSharing::Client
   def peer_register_system(system)
     params = {}
 
-    %w[login password hostname proxy_byos proxy_byos_mode system_token registered_at created_at last_seen_at instance_data
+    %w[login password hostname proxy_byos_mode system_token registered_at created_at last_seen_at instance_data
        pubcloud_reg_code].each do |attribute|
       params[attribute] = system.send(attribute)
     end

--- a/engines/registration_sharing/spec/lib/registration_sharing/client_spec.rb
+++ b/engines/registration_sharing/spec/lib/registration_sharing/client_spec.rb
@@ -32,7 +32,6 @@ describe RegistrationSharing::Client do
         'login' => system.login,
         'password' => system.password,
         'hostname' => system.hostname,
-        'proxy_byos' => system.byos?,
         'proxy_byos_mode' => system.proxy_byos_mode,
         'system_token' => system.system_token,
         'registered_at' => system.registered_at,

--- a/engines/registration_sharing/spec/requests/registration_sharing/rmt_to_rmt_controller_spec.rb
+++ b/engines/registration_sharing/spec/requests/registration_sharing/rmt_to_rmt_controller_spec.rb
@@ -35,7 +35,7 @@ module RegistrationSharing
             created_at: created_at,
             registered_at: registered_at,
             last_seen_at: last_seen_at,
-            proxy_byos: true,
+            proxy_byos_mode: :byos,
             pubcloud_reg_code: pubcloud_reg_code,
             activations: [
               {
@@ -99,7 +99,7 @@ module RegistrationSharing
             created_at: created_at,
             registered_at: registered_at,
             last_seen_at: last_seen_at,
-            proxy_byos: false,
+            proxy_byos_mode: :payg,
             pubcloud_reg_code: pubcloud_reg_code,
             activations: [
               {
@@ -164,7 +164,6 @@ module RegistrationSharing
 
           it { is_expected.not_to eq(nil) }
           its(:proxy_byos_mode) { is_expected.to eq('hybrid') }
-          its(:proxy_byos) { is_expected.to eq(false) }
           it 'saves instance data' do
             expect(system.instance_data).to eq(instance_data)
           end

--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -328,7 +328,6 @@ module SccProxy
               auth_header, request.request_parameters, instance_identifier, logger
             )
             system_values[:proxy_byos_mode] = :byos
-            system_values[:proxy_byos] = true
             if scc_response.present?
               system_values[:scc_system_id] = scc_response['id']
               system_values[:password] = scc_response['password']

--- a/engines/scc_proxy/spec/requests/api/connect/v3/subscriptions/systems_controller_spec.rb
+++ b/engines/scc_proxy/spec/requests/api/connect/v3/subscriptions/systems_controller_spec.rb
@@ -54,7 +54,6 @@ describe Api::Connect::V3::Subscriptions::SystemsController, type: :request do
 
           system = System.find_by(login: 'i-12345-payg')
           expect(system.proxy_byos_mode).to eq('byos')
-          expect(system.proxy_byos).to eq(true)
           expect(system.instance_data).to eq(instance_data)
         end
 


### PR DESCRIPTION
## Description

all the update servers in production have the new column proxy_byos_mode, after a period of adjustment having both columns should be safe to switch to the new column and remove the old one
* Related Issue / Ticket / Trello card: <link reference>

## How to test 

after applying the migration, the proxy_byos column should not be present
and regular RMT operations should work without any issue

## Change Type

*Please select the correct option.*

- [ ] **Bug Fix** (a non-breaking change which fixes an issue)
- [X] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [X] I have documented the `MANUAL.md` file with any changes to the user experience.
- [X] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

