### PR TITLE
Update OBS and IBS project references to RMT2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ package/obs/*.tar.bz2
 package/obs/.osc
 package/obs/rmt-cli.8.gz
 package/obs/_link
-package/systemsmanagement:SCC:RMT
+package/systemsmanagement:SCC:RMT2
 /public/repo/
 registry
 

--- a/PACKAGE.md
+++ b/PACKAGE.md
@@ -1,10 +1,12 @@
 ## rmt-server Packaging
 
+Note: These instructions are specific to the SLE 15 codestream and the RMT v2.x releases.
+
 Note: Never push changes to the internal build service `ibs://Devel:SCC:RMT2`!
           The repository links to `systemsmanagement:SCC:RMT2` and gets updated
           automatically.
 
-Note: Look below for direction on publishing to registry.
+Note: Look below for directions on publishing to registry.
 
 
 * The package is built in OBS at: https://build.opensuse.org/package/show/systemsmanagement:SCC:RMT2/rmt-server
@@ -41,7 +43,7 @@ Note: Look below for direction on publishing to registry.
     ```
 2. On github, submit a release for the tag. See https://help.github.com/en/articles/creating-releases for assistance.
 
-#### Submit Requests to openSUSE Factory and SLES
+#### Requirements for submissions to SLES and openSUSE Factory
 
 To get a maintenance request accepted, each changelog entry needs to have at
 least one reference to a bug or feature request like `bsc#123` or `fate#123`.
@@ -52,42 +54,40 @@ Note: If you want to disable automatic changes made by osc (e.g. License string)
       use the `--no-cleanup` switch. Can be used with commands like `osc mr`, `osc sr`
       and `osc ci`.
 
-##### Factory First
+##### Factory First (no longer possible)
 
-To submit a request to openSUSE Factory, issue this commands in the console:
-
-```bash
-osc sr systemsmanagement:SCC:RMT2 rmt-server openSUSE:Factory
-```
+Normally rmt-server updates should be submitted to openSUSE:Factory
+before submitting them to the SLES codestreams. However, this is no
+longer possible for the RMT v2.x release submissions, as Factory no
+longer provides a Ruby v2.x based application ecosystem.
 
 ##### Submit maintenance updates for SLES to the Internal Build Service
 
 ###### Get target codestreams where to submit
 
-To check out which codestreams RMT is currently maintained, see https://smelt.suse.de/maintained/?q=rmt-server.
+To check out which codestreams RMT is currently maintained for, see https://smelt.suse.de/maintained/?q=rmt-server.
+
+Alterntaively you can use the `osc maintained` command, filtering for active code streams:
+
+```bash
+$ osc -A https://api.suse.de maintained rmt-server | grep -e 'SUSE:SLE-15-SP[4-7]'
+SUSE:SLE-15-SP4:Update/rmt-server
+SUSE:SLE-15-SP5:Update/rmt-server
+SUSE:SLE-15-SP7:Update/rmt-server
+```
 
 ###### Submit updates
 
-For each maintained codestream you need to create a new maintenance request:
+For each maintained codestream identified you need to create a new maintenance request:
 
 ```bash
-osc -A https://api.suse.de mr Devel:SCC:RMT2 rmt-server SUSE:SLE-15:Update
+osc -A https://api.suse.de mr Devel:SCC:RMT2 rmt-server SUSE:SLE-15-SP7:Update
+Using target project 'SUSE:Maintenance'
+17362323
 ```
 
 Note: In case the `mr` (maintenance request) command is not working properly,
       try `sr` (submit request) command.
-
-
-Example:
-
-```bash
-$ osc -A https://api.suse.de maintained rmt-server
-SUSE:SLE-15:Update/rmt-server
-
-$ osc -A https://api.suse.de mr Devel:SCC:RMT2 rmt-server SUSE:SLE-15:Update
-Using target project 'SUSE:Maintenance'
-17362323
-```
 
 **Note:**
 

--- a/PACKAGE.md
+++ b/PACKAGE.md
@@ -1,13 +1,13 @@
 ## rmt-server Packaging
 
-Note: Never push changes to the internal build service `ibs://Devel:SCC:RMT`!
-          The repository links to `systemsmanagement:SCC:RMT` and gets updated
+Note: Never push changes to the internal build service `ibs://Devel:SCC:RMT2`!
+          The repository links to `systemsmanagement:SCC:RMT2` and gets updated
           automatically.
 
 Note: Look below for direction on publishing to registry.
 
 
-* The package is built in OBS at: https://build.opensuse.org/package/show/systemsmanagement:SCC:RMT/rmt-server
+* The package is built in OBS at: https://build.opensuse.org/package/show/systemsmanagement:SCC:RMT2/rmt-server
 * To update the version of RMT, you will have to change the following files:
   * `lib/rmt.rb`
   * `package/obs/rmt-server.spec`
@@ -17,11 +17,11 @@ Note: Look below for direction on publishing to registry.
           ```
           mkdir ~/obs
           cd ~/obs
-          osc co systemsmanagement:SCC:RMT rmt-server
+          osc co systemsmanagement:SCC:RMT2 rmt-server
           ```
       * Alternatively, if an OBS working copy is already checked out, update the working copy by running `osc up`
 2. Run `make dist` in your RMT working directory to build a tarball.
-3. Copy the files from the `package/obs` directory to the OBS working directory `systemsmanagement:SCC:RMT/rmt-server`.
+3. Copy the files from the `package/obs` directory to the OBS working directory `systemsmanagement:SCC:RMT2/rmt-server`.
 4. Examine the changes by running `osc status` and `osc diff`.
 5. Stage the changes by running `osc addremove`.
 6. Build the package with osc:
@@ -57,7 +57,7 @@ Note: If you want to disable automatic changes made by osc (e.g. License string)
 To submit a request to openSUSE Factory, issue this commands in the console:
 
 ```bash
-osc sr systemsmanagement:SCC:RMT rmt-server openSUSE:Factory
+osc sr systemsmanagement:SCC:RMT2 rmt-server openSUSE:Factory
 ```
 
 ##### Submit maintenance updates for SLES to the Internal Build Service
@@ -71,7 +71,7 @@ To check out which codestreams RMT is currently maintained, see https://smelt.su
 For each maintained codestream you need to create a new maintenance request:
 
 ```bash
-osc -A https://api.suse.de mr Devel:SCC:RMT rmt-server SUSE:SLE-15:Update
+osc -A https://api.suse.de mr Devel:SCC:RMT2 rmt-server SUSE:SLE-15:Update
 ```
 
 Note: In case the `mr` (maintenance request) command is not working properly,
@@ -84,7 +84,7 @@ Example:
 $ osc -A https://api.suse.de maintained rmt-server
 SUSE:SLE-15:Update/rmt-server
 
-$ osc -A https://api.suse.de mr Devel:SCC:RMT rmt-server SUSE:SLE-15:Update
+$ osc -A https://api.suse.de mr Devel:SCC:RMT2 rmt-server SUSE:SLE-15:Update
 Using target project 'SUSE:Maintenance'
 17362323
 ```
@@ -93,7 +93,7 @@ Using target project 'SUSE:Maintenance'
 
 * When asked whether or not to supersede a request, the answer is usually "no". Saying "yes" would overwrite the previous request made, cancelling the release process for its codestream.
 
-You can check the status of your requests [here](https://build.opensuse.org/package/requests/systemsmanagement:SCC:RMT/rmt-server) and [here](https://build.suse.de/package/requests/Devel:SCC:RMT/rmt-server).
+You can check the status of your requests [here](https://build.opensuse.org/package/requests/systemsmanagement:SCC:RMT2/rmt-server) and [here](https://build.suse.de/package/requests/Devel:SCC:RMT2/rmt-server).
 
 After your requests have been accepted, they still have to pass maintenance testing before they are released to customers. You can check their progress at [maintenance.suse.de](https://maintenance.suse.de/search/?q=rmt-server). If you still need help, the maintenance team can be reached at [maint-coord@suse.de](maint-coord@suse.de) or #maintenance on irc.suse.de.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -49,7 +49,7 @@ More information can be found [here](https://documentation.suse.com/sles/15-SP7/
 ## Installation on SLE 15
 
 1. If your server isn't activated yet, activate it with the command `SUSEConnect -r <regcode>`.
-2. Activate the Server Applications Module for your version of SLE 15 is not already activated:
+2. Activate the Server Applications Module for your version of SLE 15 if not already activated:
     * SLE 15 SP7 - `SUSEConnect -p sle-module-server-applications/15.7/x86_64`
     * SLE 15 SP6 - `SUSEConnect -p sle-module-server-applications/15.6/x86_64`
     * SLE 15 SP5 - `SUSEConnect -p sle-module-server-applications/15.5/x86_64`

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,6 +1,6 @@
-# Installation of RMT
+# Installation of RMT v2.x
 
-RMT is tested on SLES and openSUSE. We recommend installing RMT on either operating system, however, you always have the option to install it manually elsewhere.
+RMT v2.x releases are tested on the SLE 15 codestreams. We recommend installing RMT on an actively supported SLE 15 service pack, however, you always have the option to install it manually elsewhere.
 
 **Notes:**
 
@@ -19,11 +19,11 @@ app:
     username: <your_proxy_username>
     password: <your_proxy_password>
     products_enable:
-      - SLES/15.3/x86_64
-      - sle-module-python2/15.3/x86_64
+      - SLES/15.7/x86_64
+      - sle-module-desktop-applications/15.7/x86_64
     products_disable:
-      - sle-module-legacy/15.3/x86_64
-      - sle-module-cap-tools/15.3/x86_64
+      - sle-module-legacy/15.7/x86_64
+      - sle-we/15.7/x86_64
 ingress:
   enabled: true
   hosts:
@@ -40,31 +40,31 @@ EOF
 
 and run
 
-`helm install rmtsle oci://registry.suse.com/suse/rmt-helm -f helm_values.yml`
+```bash
+$ helm install rmtsle oci://registry.suse.com/suse/rmt-helm -f helm_values.yml
+```
 
-More information can be found [here](https://documentation.suse.com/sles/15-SP4/html/SLES-all/cha-rmt-installation.html#sec-rmt-deploy-kubernetes).
+More information can be found [here](https://documentation.suse.com/sles/15-SP7/html/SLES-all/cha-rmt-installation.html#sec-rmt-deploy-kubernetes).
 
 ## Installation on SLE 15
 
 1. If your server isn't activated yet, activate it with the command `SUSEConnect -r <regcode>`.
-2. Activate the Server Applications Module for your version of SLE:
-    * SLE 15 SP2 - `SUSEConnect -p sle-module-server-applications/15.2/x86_64`
-    * SLE 15 SP1 - `SUSEConnect -p sle-module-server-applications/15.1/x86_64`
-    * SLE 15 - `SUSEConnect -p sle-module-server-applications/15/x86_64`
+2. Activate the Server Applications Module for your version of SLE 15 is not already activated:
+    * SLE 15 SP7 - `SUSEConnect -p sle-module-server-applications/15.7/x86_64`
+    * SLE 15 SP6 - `SUSEConnect -p sle-module-server-applications/15.6/x86_64`
+    * SLE 15 SP5 - `SUSEConnect -p sle-module-server-applications/15.5/x86_64`
+    * SLE 15 SP4 - `SUSEConnect -p sle-module-server-applications/15.4/x86_64`
 3. Install RMT and its YaST installation wizard with the command `zypper in rmt-server yast2-rmt`.
 4. Run the RMT installation wizard with the command `yast2 rmt` and configure your instance.
 
-## Installation on openSUSE Leap 15
-
-1. Install RMT and its YaST installation wizard with the command `zypper in rmt-server yast2-rmt`.
-2. Run the RMT installation wizard with the command `yast2 rmt` and configure your instance.
-
 ## Manual installation and configuration
 
-RMT currently gets built [in OBS](https://build.opensuse.org/package/show/systemsmanagement:SCC:RMT2/rmt-server) for these distributions: `SLE_15`, `SLE_15_SP1`, `openSUSE_Leap_15.0`, `openSUSE_Leap_15.1`, `openSUSE_Tumbleweed`.
-To add the repository, call: (replace `<dist>` with your distribution)
+RMT currently gets built [in OBS](https://build.opensuse.org/package/show/systemsmanagement:SCC:RMT2/rmt-server) for these active distributions: `SLE_15_SP4`, `SLE_15_SP5`, `SLE_15_SP6`, `SLE_15_SP7`.
+To add an appropriate zypper repository, run: (replace `<dist>` with your distribution)
 
-`zypper ar -f https://download.opensuse.org/repositories/systemsmanagement:/SCC:/RMT/<dist>/systemsmanagement:SCC:RMT2.repo`
+```bash
+$ zypper ar -f https://download.opensuse.org/repositories/systemsmanagement:/SCC:/RMT2/<dist>/systemsmanagement:SCC:RMT2.repo
+```
 
 To install RMT, run: `zypper in rmt-server`
 
@@ -81,7 +81,7 @@ After installation configure your RMT instance:
     FLUSH PRIVILEGES;
     EOFF
     ```
-* See [RMT Configuration Files](https://www.suse.com/documentation/sles-15/book_rmt/data/sec_rmt_config.html)
+* See [RMT Configuration Files](https://documentation.suse.com/sles/15-SP7/html/SLES-all/cha-rmt-tools.html#sec-rmt-config)
   in the official RMT documentation for information about `/etc/rmt.conf`.
 * Start RMT by running `systemctl start rmt-server`. This will start the RMT server at http://localhost:4224.
 * By default, mirrored repositories are saved under `/usr/share/rmt/public`, which is a symlink that points to

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -61,10 +61,10 @@ More information can be found [here](https://documentation.suse.com/sles/15-SP4/
 
 ## Manual installation and configuration
 
-RMT currently gets built [in OBS](https://build.opensuse.org/package/show/systemsmanagement:SCC:RMT/rmt-server) for these distributions: `SLE_15`, `SLE_15_SP1`, `openSUSE_Leap_15.0`, `openSUSE_Leap_15.1`, `openSUSE_Tumbleweed`.
+RMT currently gets built [in OBS](https://build.opensuse.org/package/show/systemsmanagement:SCC:RMT2/rmt-server) for these distributions: `SLE_15`, `SLE_15_SP1`, `openSUSE_Leap_15.0`, `openSUSE_Leap_15.1`, `openSUSE_Tumbleweed`.
 To add the repository, call: (replace `<dist>` with your distribution)
 
-`zypper ar -f https://download.opensuse.org/repositories/systemsmanagement:/SCC:/RMT/<dist>/systemsmanagement:SCC:RMT.repo`
+`zypper ar -f https://download.opensuse.org/repositories/systemsmanagement:/SCC:/RMT/<dist>/systemsmanagement:SCC:RMT2.repo`
 
 To install RMT, run: `zypper in rmt-server`
 


### PR DESCRIPTION
Future RMT v2.x stream development will leverage the new RMT v2.x specific OBS systemsmanagement:SCC:RMT2 and IBS Devel:SCC:RMT projects for submissions to the SLE 15 streams.

Addresses: SCC-848

