### PR TITLE
drop the column if exists

### DIFF
--- a/db/migrate/20260626153653_remove_proxy_byos_from_systems.rb
+++ b/db/migrate/20260626153653_remove_proxy_byos_from_systems.rb
@@ -1,5 +1,7 @@
 class RemoveProxyByosFromSystems < ActiveRecord::Migration[8.1]
   def change
-    safety_assured { remove_column :systems, :proxy_byos, :boolean, default: false }
+    if column_exists?(:systems, :proxy_byos)
+      remove_column :systems, :proxy_byos, :boolean, default: false
+    end
   end
 end

--- a/db/migrate/20260626153653_remove_proxy_byos_from_systems.rb
+++ b/db/migrate/20260626153653_remove_proxy_byos_from_systems.rb
@@ -1,7 +1,9 @@
 class RemoveProxyByosFromSystems < ActiveRecord::Migration[8.1]
   def change
-    if column_exists?(:systems, :proxy_byos)
-      remove_column :systems, :proxy_byos, :boolean, default: false
+    safety_assured do
+      if column_exists?(:systems, :proxy_byos)
+        remove_column :systems, :proxy_byos, :boolean, default: false
+      end
     end
   end
 end


### PR DESCRIPTION
## Description



* Related Issue / Ticket / Trello card: <link reference>

## How to test 

on an update server running 3.1, it failed to start sidekiq, once fixed and rmt-server is restarted
it fails as the column does not exist anymore

## Change Type

*Please select the correct option.*

- [X] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [X] I have documented the `MANUAL.md` file with any changes to the user experience.
- [X] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

