### PR TITLE
Avoid registration and update request handling failure due to profiles handling errors

### DIFF
--- a/app/controllers/api/connect/v3/subscriptions/systems_controller.rb
+++ b/app/controllers/api/connect/v3/subscriptions/systems_controller.rb
@@ -1,16 +1,16 @@
 class Api::Connect::V3::Subscriptions::SystemsController < Api::Connect::BaseController
 
   def announce_system
-    # Construct the system creation parameters
-    create_params = {
-      hostname: params[:hostname],
-      system_information: info_params(:hwinfo)[:hwinfo].to_json
-    }
+    @system = System.create!(hostname: params[:hostname], system_information: info_params(:hwinfo)[:hwinfo].to_json)
 
-    # Check if any profiles have been provided
-    process_system_profiles(create_params)
+    # Extract any complete profiles, setting the profile response header
+    # if invalid or incomplete profiles are detected.
+    profile_params = {}
+    extract_complete_profiles(profile_params)
 
-    @system = create_system_retry_if_profiles_provided(create_params)
+    # Update with any provided profiles, just setting the response header
+    # if and logging a message if any errors occur.
+    update_system_profiles(profile_params)
 
     logger.info("System '#{@system.hostname}' announced")
     respond_with(@system, serializer: ::V3::SystemSerializer, location: nil)
@@ -18,24 +18,19 @@ class Api::Connect::V3::Subscriptions::SystemsController < Api::Connect::BaseCon
 
   private
 
-  def create_system_retry_if_profiles_provided(params)
-    System.create!(**params)
+  def update_system_profiles(profile_params)
+    # do nothing if profile_params is empty
+    return unless profile_params.any?
+
+    @system.update!(**profile_params)
   rescue StandardError => e
-    # Only retry if profiles were present or haven't already been stripped;
-    # prevents infinite retry loops for errors not related to profiles.
-    # In the event of a retry set the response header telling the client
-    # to send full profiles next time.
-    if params[:complete_profiles]
-      logger.warn("System creation failed with profiles, retrying without: #{e.message}")
-      params.delete(:complete_profiles)
-      response.headers['X-System-Profiles-Action'] = 'clear-cache'
-      System.create!(**params)
-    else
-      raise
-    end
+    # If any errors occur while updating the profiles, log a warning
+    # and set the response header but do not fail the request.
+    logger.warn("System '#{@system.hostname}' profile update failed: #{e.message}")
+    response.headers['X-System-Profiles-Action'] = 'clear-cache'
   end
 
-  def process_system_profiles(create_params)
+  def extract_complete_profiles(profile_params)
     if params.key?(:system_profiles)
       profiles = info_params(:system_profiles)[:system_profiles]
 
@@ -52,11 +47,11 @@ class Api::Connect::V3::Subscriptions::SystemsController < Api::Connect::BaseCon
         response.headers['X-System-Profiles-Action'] = 'clear-cache'
       end
 
-      # Include the complete profiles in create_params only if
+      # Include the complete profiles in profile_params only if
       # complete profiles were actually provided
       if complete.any?
         logger.debug("valid complete profiles detected: #{complete.keys}")
-        create_params[:complete_profiles] = complete
+        profile_params[:complete_profiles] = complete
       end
     end
   end

--- a/app/controllers/api/connect/v3/subscriptions/systems_controller.rb
+++ b/app/controllers/api/connect/v3/subscriptions/systems_controller.rb
@@ -10,7 +10,22 @@ class Api::Connect::V3::Subscriptions::SystemsController < Api::Connect::BaseCon
     # Check if any profiles have been provided
     process_system_profiles(create_params)
 
-    @system = System.create!(**create_params)
+    # Retry system creation without profiles if initial attempt fails
+    begin
+      @system = System.create!(**create_params)
+    rescue StandardError => e
+      # Only retry if profiles were present or haven't already been stripped;
+      # prevents infinite retry loops for errors not related to profiles.
+      # In the event of a retry set the response header telling the client
+      # to send full profiles next time.
+      if create_params[:complete_profiles]
+        logger.warn("System creation failed with profiles, retrying without: #{e.message}")
+        create_params.delete(:complete_profiles)
+        response.headers['X-System-Profiles-Action'] = 'clear-cache'
+        retry
+      end
+      raise
+    end
 
     logger.info("System '#{@system.hostname}' announced")
     respond_with(@system, serializer: ::V3::SystemSerializer, location: nil)

--- a/app/controllers/api/connect/v3/subscriptions/systems_controller.rb
+++ b/app/controllers/api/connect/v3/subscriptions/systems_controller.rb
@@ -10,28 +10,30 @@ class Api::Connect::V3::Subscriptions::SystemsController < Api::Connect::BaseCon
     # Check if any profiles have been provided
     process_system_profiles(create_params)
 
-    # Retry system creation without profiles if initial attempt fails
-    begin
-      @system = System.create!(**create_params)
-    rescue StandardError => e
-      # Only retry if profiles were present or haven't already been stripped;
-      # prevents infinite retry loops for errors not related to profiles.
-      # In the event of a retry set the response header telling the client
-      # to send full profiles next time.
-      if create_params[:complete_profiles]
-        logger.warn("System creation failed with profiles, retrying without: #{e.message}")
-        create_params.delete(:complete_profiles)
-        response.headers['X-System-Profiles-Action'] = 'clear-cache'
-        retry
-      end
-      raise
-    end
+    @system = create_system_retry_if_profiles_provided(create_params)
 
     logger.info("System '#{@system.hostname}' announced")
     respond_with(@system, serializer: ::V3::SystemSerializer, location: nil)
   end
 
   private
+
+  def create_system_retry_if_profiles_provided(params)
+    System.create!(**params)
+  rescue StandardError => e
+    # Only retry if profiles were present or haven't already been stripped;
+    # prevents infinite retry loops for errors not related to profiles.
+    # In the event of a retry set the response header telling the client
+    # to send full profiles next time.
+    if params[:complete_profiles]
+      logger.warn("System creation failed with profiles, retrying without: #{e.message}")
+      params.delete(:complete_profiles)
+      response.headers['X-System-Profiles-Action'] = 'clear-cache'
+      System.create!(**params)
+    else
+      raise
+    end
+  end
 
   def process_system_profiles(create_params)
     if params.key?(:system_profiles)

--- a/app/controllers/api/connect/v3/systems/systems_controller.rb
+++ b/app/controllers/api/connect/v3/systems/systems_controller.rb
@@ -21,37 +21,16 @@ class Api::Connect::V3::Systems::SystemsController < Api::Connect::BaseControlle
     @system.hostname = params[:hostname]
 
     # If a system_profiles param has been provided, process
-    # the provided profiles
+    # the provided profiles; if an error occurs log it and
+    # set the response header to tell the client to send full
+    # profiles next time, and continue on with the request
+    # handling
     if params.key?(:system_profiles)
-      profiles = info_params(:system_profiles)[:system_profiles]
-
-      # Partition profiles into three categories, namely complete,
-      # incomplete (missing the data field), and invalid (missing
-      # the identifier field)
-      complete, incomplete, invalid = Profile.filter_profiles(profiles.to_h)
-
-      # Further refine the incomplete profiles to identify any that
-      # are known, and retrieve complete versions of them
-      known_incomplete = Profile.identify_known_profiles(incomplete)
-
-      # Determine the unknown profiles in incomplete group, if any
-      unknown_incomplete_types = incomplete.keys - known_incomplete.keys
-
-      # If any of the provided profiles is invalid or if any of the
-      # incomplete profiles aren't known, set the response header
-      if invalid.any? || unknown_incomplete_types.any?
-        logger.debug("problematic invalid (missing identifier field) profiles detected: #{invalid.keys}") if invalid.any?
-        logger.debug("problematic unrecognised incomplete (missing data field) profiles detected: #{unknown_incomplete_types}") if unknown_incomplete_types.any?
+      begin
+        process_system_profiles(info_params(:system_profiles)[:system_profiles])
+      rescue StandardError => e
+        logger.warn("System profiles updates failed, continuing without them: #{e.message}")
         response.headers['X-System-Profiles-Action'] = 'clear-cache'
-      end
-
-      # Aggregate the provided complete profiles with the retrieved
-      # complete profiles associated with known incompletes, updating
-      # the system if applicable.
-      aggregated_completes = complete.merge(known_incomplete)
-      if aggregated_completes.any?
-        logger.debug("valid aggregated complete profiles detected: #{aggregated_completes.keys}")
-        @system.update(complete_profiles: aggregated_completes)
       end
     end
 
@@ -72,6 +51,37 @@ class Api::Connect::V3::Systems::SystemsController < Api::Connect::BaseControlle
   end
 
   private
+
+  def process_system_profiles(profiles)
+    # Partition profiles into three categories, namely complete,
+    # incomplete (missing the data field), and invalid (missing
+    # the identifier field)
+    complete, incomplete, invalid = Profile.filter_profiles(profiles.to_h)
+
+    # Further refine the incomplete profiles to identify any that
+    # are known, and retrieve complete versions of them
+    known_incomplete = Profile.identify_known_profiles(incomplete)
+
+    # Determine the unknown profiles in incomplete group, if any
+    unknown_incomplete_types = incomplete.keys - known_incomplete.keys
+
+    # If any of the provided profiles is invalid or if any of the
+    # incomplete profiles aren't known, set the response header
+    if invalid.any? || unknown_incomplete_types.any?
+      logger.debug("problematic invalid (missing identifier field) profiles detected: #{invalid.keys}") if invalid.any?
+      logger.debug("problematic unrecognised incomplete (missing data field) profiles detected: #{unknown_incomplete_types}") if unknown_incomplete_types.any?
+      response.headers['X-System-Profiles-Action'] = 'clear-cache'
+    end
+
+    # Aggregate the provided complete profiles with the retrieved
+    # complete profiles associated with known incompletes, updating
+    # the system if applicable.
+    aggregated_completes = complete.merge(known_incomplete)
+    if aggregated_completes.any?
+      logger.debug("valid aggregated complete profiles detected: #{aggregated_completes.keys}")
+      @system.update(complete_profiles: aggregated_completes)
+    end
+  end
 
   def info_params(key)
     # Allow all attributes without validating the key structure

--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -314,13 +314,14 @@ module SccProxy
             # it is a unique value per instance across all CSPs
             login: instance_identifier
           }
+          profile_params = {}
           if has_no_regcode?(auth_header)
             # NON BYOS case
             # no token sent to check with SCC
             system_values[:proxy_byos_mode] = :payg
 
             # Check if any profiles have been provided
-            process_system_profiles(system_values)
+            extract_complete_profiles(profile_params)
           else
             request.request_parameters['proxy_byos_mode'] = 'byos'
             scc_response, scc_response_headers = SccProxy.announce_system_scc(
@@ -337,6 +338,7 @@ module SccProxy
           end
           @system, error = create_system(system_values, logger)
           if @system.present?
+            update_system_profiles(profile_params)
             logger.info("System '#{@system.hostname}' announced")
             respond_with(@system, serializer: ::V3::SystemSerializer, location: nil)
           else
@@ -373,7 +375,7 @@ module SccProxy
           attempts = 0
           begin
             attempts += 1
-            [create_system_retry_if_profiles_provided(system_values), nil]
+            [System.create!(system_values), nil]
           rescue ActiveRecord::RecordInvalid => e
             # The to-be-announced system is already in the database
             # This could mean it got de-registered on another update infrastructure server a short time ago

--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -373,7 +373,7 @@ module SccProxy
           attempts = 0
           begin
             attempts += 1
-            [System.create!(system_values), nil]
+            [create_system_retry_if_profiles_provided(system_values), nil]
           rescue ActiveRecord::RecordInvalid => e
             # The to-be-announced system is already in the database
             # This could mean it got de-registered on another update infrastructure server a short time ago

--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -3,6 +3,7 @@ Tue Aug 18 21:37:21 UTC 2026 - Fergal Mc Carthy <fmccarthy@suse.com>
 
 - Version 3.2
   * Avoid NoMethodError for rmt-cli systems list (bsc#1275439)
+  * Avoid profiles related registration and keepalive failures (jsc#SCC-822)
 
 -------------------------------------------------------------------
 Tue Aug 11 08:35:19 UTC 2026 - Jesús Bermúdez Velázquez <jesus.bv@suse.com>

--- a/spec/requests/api/connect/v3/subscriptions/systems_controller_spec.rb
+++ b/spec/requests/api/connect/v3/subscriptions/systems_controller_spec.rb
@@ -173,5 +173,17 @@ RSpec.describe Api::Connect::V3::Subscriptions::SystemsController do
         end.to raise_error(StandardError, 'Another DB Error')
       end
     end
+
+    context 'with system_profiles parameters and a creation error when no profiles are present' do
+      before do
+        allow(System).to receive(:create!).and_raise(StandardError.new('Unique constraint violation'))
+      end
+
+      it 're-raises the error when no profiles were present' do
+        expect do
+          post url, params: { hostname: 'testhost' }.to_json, headers: headers
+        end.to raise_error(StandardError, 'Unique constraint violation')
+      end
+    end
   end
 end

--- a/spec/requests/api/connect/v3/subscriptions/systems_controller_spec.rb
+++ b/spec/requests/api/connect/v3/subscriptions/systems_controller_spec.rb
@@ -142,5 +142,36 @@ RSpec.describe Api::Connect::V3::Subscriptions::SystemsController do
         ).to match(profile_set_mixed_complete)
       end
     end
+
+    context 'with system_profiles parameters and a profile creation error' do
+      before do
+        allow(Profile).to receive(:ensure_profile_exists).and_raise(StandardError.new('DB Error'))
+      end
+
+      it 'retries system creation without profiles on error' do
+        post url, params: { system_profiles: profile_set_all, hostname: 'testhost' }.to_json, headers: headers
+
+        expect(response).to be_successful
+        expect(response).to have_http_status(:created)
+        expect(response.headers['X-System-Profiles-Action']).to eq('clear-cache')
+
+        system = System.find_by(login: json_response[:login])
+
+        expect(system.profiles.count).to eq(0)
+      end
+    end
+
+    context 'with system_profiles parameters and a profile creation error on retry' do
+      before do
+        allow(Profile).to receive(:ensure_profile_exists).and_raise(StandardError.new('DB Error'))
+        allow(System).to receive(:create!).and_raise(StandardError.new('Another DB Error'))
+      end
+
+      it 're-raises when retry also fails after profiles are stripped' do
+        expect do
+          post url, params: { system_profiles: profile_set_all, hostname: 'testhost' }.to_json, headers: headers
+        end.to raise_error(StandardError, 'Another DB Error')
+      end
+    end
   end
 end

--- a/spec/requests/api/connect/v3/subscriptions/systems_controller_spec.rb
+++ b/spec/requests/api/connect/v3/subscriptions/systems_controller_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe Api::Connect::V3::Subscriptions::SystemsController do
         allow(Profile).to receive(:ensure_profile_exists).and_raise(StandardError.new('DB Error'))
       end
 
-      it 'retries system creation without profiles on error' do
+      it 'creates system but fails profile update, setting header to clear-cache' do
         post url, params: { system_profiles: profile_set_all, hostname: 'testhost' }.to_json, headers: headers
 
         expect(response).to be_successful
@@ -167,7 +167,7 @@ RSpec.describe Api::Connect::V3::Subscriptions::SystemsController do
         allow(System).to receive(:create!).and_raise(StandardError.new('Another DB Error'))
       end
 
-      it 're-raises when retry also fails after profiles are stripped' do
+      it 're-raises when system creation fails' do
         expect do
           post url, params: { system_profiles: profile_set_all, hostname: 'testhost' }.to_json, headers: headers
         end.to raise_error(StandardError, 'Another DB Error')

--- a/spec/requests/api/connect/v3/systems/systems_controller_spec.rb
+++ b/spec/requests/api/connect/v3/systems/systems_controller_spec.rb
@@ -428,6 +428,25 @@ RSpec.describe Api::Connect::V3::Systems::SystemsController do
         expect(response.headers).not_to include('System-Token')
       end
     end
+
+    context 'with profiles and a profile creation error' do
+      let(:profiles) { profile_set_all }
+      let(:payload) { { hostname: 'test', hwinfo: hwinfo, system_profiles: profiles } }
+
+      before do
+        allow(Profile).to receive(:ensure_profile_exists).and_raise(StandardError.new('DB Error'))
+      end
+
+      it 'continues request processing without profiles on error' do
+        update_action
+
+        expect(response).to be_successful
+        expect(response).to have_http_status(:no_content)
+        expect(response.headers['X-System-Profiles-Action']).to eq('clear-cache')
+
+        expect(system.profiles.count).to eq(0)
+      end
+    end
   end
 
   describe '#deregister' do


### PR DESCRIPTION
## Description

Rework the announce_system request handling workflow to create the system record first, without including any profiles, and then, if profiles are provided, update the system record with any provided complete profiles. As before, if any issues are identified while processing the profiles the response header will be set. Additionally any failures that occur while updating the system record will be logged, but request processing will continue as normal.

As part of update request handling log any errors that occur during the system profiles updates, set the response header indicating that clients should send complete profiles next time, and continue with normal processing.

Refactored the update request handler to split out the processing of system profiles to a separate routine to address rubocop complexity concerns.

Updated spec tests for both announce_system and update requests to exercise the modified processing scenarios.

Created placeholder v3.2 entry in the rmt-server.changes to hold a changelog entry for these changes.

AI-Assistance-By: Qwen 3.6 35B MoE (A3B)

Fixes: SCC-822

## How to test 

To assist in testing this scenario I've SUSE/connect-ng's `public-api-demo` to add support for specifying profiles via a PROFILES_DIR env var. See [public-api-demo/README.md](https://github.com/SUSE/connect-ng/blob/main/cmd/public-api-demo/README.md) for more details.

However, there seems to be a limitation in the `public-api-demo` command, or possibly the SUSE/connect-ng client request setup where profiles larger than approx 1MiB in size cause an error when creating the client HTTP request. Therefore test this I had to temporarily reduce the max size of the data field in my local RMT's profiles table to a smaller value to allow me to submit profiles that were too large.

## Change Type

*Please select the correct option.*

- [x] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [x] I have reviewed my own code and believe that it's ready for an external review.
- [x] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [x] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change.