### PR TITLE
Fix broken dev-env startup for RMT v3.x stream

### DIFF
--- a/lib/rmt/db.rb
+++ b/lib/rmt/db.rb
@@ -19,7 +19,8 @@ module RMT
       :missing
     rescue Mysql2::Error
       :down
-    rescue StandardError
+    rescue StandardError => e
+      Rails.logger.error "Unexpected error: #{e.message}"
       :unknown
     end
 
@@ -29,7 +30,7 @@ module RMT
       ActiveRecord::Base.connection
       return unless ActiveRecord::Base.connection.table_exists? 'schema_migrations'
 
-      !ActiveRecord::Base.connection.migration_context.needs_migration?
+      !ActiveRecord::Base.connection_pool.migration_context.needs_migration?
     end
 
     def self.setup!
@@ -37,6 +38,9 @@ module RMT
 
       loop do
         case ::RMT::Db.ping
+        when :unknown
+          Rails.logger.error 'Unknown error accessing db. Exiting...'
+          raise StandardError.new 'Unknown error accessing db. Exiting...'
         when :down
           Rails.logger.info 'Database not ready yet. Waiting...'
           sleep WAIT_INTERVAL


### PR DESCRIPTION
## Description

The migration_context has moved to connection_pool in recent Rails versions, so fix the broken reference in the lib/rmt/db.rb code.

Also add support in the ::RMT:Db.setup! method for handling the :unknown status returned by the ::RMT::Db.ping method when this error occurred, helping to avoid the problematic infinite tight loop that previously occurred in this case.

Update the ::RMT:Db.ping method to log the error message that triggers the :unknown status to be returned.

Fixes: SCC-937

## How to test 

`make build` followed by `make server` should bring up an docker compose based RMT server.

## Change Type

*Please select the correct option.*

- [x] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [ ] I have reviewed my own code and believe that it's ready for an external review.
- [ ] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

