### PR TITLE
Fix rmt-cli systems scc-sync uninitialized constant

### DIFF
--- a/lib/suse/connect/api.rb
+++ b/lib/suse/connect/api.rb
@@ -2,6 +2,7 @@ require 'rmt'
 require 'rmt/http_request'
 require 'rmt/logger'
 require 'json'
+require 'suse/connect/system_serializer'
 
 module SUSE
   module Connect

--- a/lib/suse/connect/system_serializer.rb
+++ b/lib/suse/connect/system_serializer.rb
@@ -1,5 +1,10 @@
 require 'active_model_serializers'
 
+module SUSE
+  module Connect
+  end
+end
+
 # Serializes a system to be consumed by the SCC Api
 class SUSE::Connect::SystemSerializer < ActiveModel::Serializer
   # RMT has two modes of sending system information to SCC


### PR DESCRIPTION
## Description

Address rmt-cli systems scc-sync failure due to uninitialized constant SUSE by adding a missing requires for suse/connect/systems_serializer to lib/suse/connect/api.rb; the Rails RMT server leverages Zeitwerk auto-loading to handle resolving it but the rmt-cli needs an explicit requires.

Add explicit module SUSE/Connect wrappers to system_serializer.rb so the class definition works in both Rails and rmt-cli contexts.

AI-Assistant: Qwen 3.6 35B MoE (A3B)

Fixes: SCC-957

## How to test 

Attempt to run `rmt-cli systems scc-sync` for an `rmt_3` branch based RMT deployment when at least one unsynced client is registered, and it should successfully sync client systems without an error.

## Change Type

*Please select the correct option.*

- [x] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [x] I have reviewed my own code and believe that it's ready for an external review.
- [ ] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

