### PR TITLE
fix log warning about RMT directories

### DIFF
--- a/.github/workflows/lint-unit.yml
+++ b/.github/workflows/lint-unit.yml
@@ -94,3 +94,19 @@ jobs:
           echo "::group::Version verification checks"
           ruby ci/check-version-matches.rb
           echo "::endgroup::"
+
+      - name: Check service files for missing HOME with ProtectHome
+        run: |
+          failed=0
+          for service in package/files/systemd/*.service engines/*/package/*.service; do
+            if grep -q "ProtectHome=true" "$service"; then
+              if grep -qE "ExecStart=.*(ruby|bundle|rails|rmt-cli|sidekiq|rake)" "$service"; then
+                if ! grep -q "HOME=" "$service"; then
+                  echo "FAIL: $service has ProtectHome=true with Ruby invocation but missing HOME="
+                  failed=1
+                fi
+              fi
+            fi
+          done
+          exit $failed
+

--- a/engines/registration_sharing/package/rmt-server-regsharing.service
+++ b/engines/registration_sharing/package/rmt-server-regsharing.service
@@ -16,7 +16,7 @@ ProtectControlGroups=true
 RestrictRealtime=true
 Type=simple
 Restart=no
-Environment=RAILS_ENV=production
+Environment="RAILS_ENV=production" "HOME=/var/lib/rmt" "BUNDLE_USER_HOME=/var/lib/rmt/.bundle"
 WorkingDirectory=/usr/share/rmt
 ExecStart=/usr/bin/bundle.ruby3.4 exec rake regsharing:sync
 

--- a/engines/registration_sharing/package/rmt-server-regsharing.service
+++ b/engines/registration_sharing/package/rmt-server-regsharing.service
@@ -16,7 +16,7 @@ ProtectControlGroups=true
 RestrictRealtime=true
 Type=simple
 Restart=no
-Environment="RAILS_ENV=production" "HOME=/var/lib/rmt" "BUNDLE_USER_HOME=/var/lib/rmt/.bundle"
+Environment="RAILS_ENV=production" "HOME=/var/lib/rmt"
 WorkingDirectory=/usr/share/rmt
 ExecStart=/usr/bin/bundle.ruby3.4 exec rake regsharing:sync
 

--- a/package/files/systemd/rmt-server-migration.service
+++ b/package/files/systemd/rmt-server-migration.service
@@ -17,7 +17,7 @@ ProtectControlGroups=true
 RestrictRealtime=true
 Type=oneshot
 User=_rmt
-Environment="LOG_TO_JOURNALD=1" "LANG=en"
+Environment="LOG_TO_JOURNALD=1" "LANG=en" "HOME=/var/lib/rmt" "BUNDLE_USER_HOME=/var/lib/rmt/.bundle"
 WorkingDirectory=/usr/share/rmt
 ExecStart=/usr/share/rmt/bin/rails db:create db:migrate RAILS_ENV=production
 

--- a/package/files/systemd/rmt-server-migration.service
+++ b/package/files/systemd/rmt-server-migration.service
@@ -17,7 +17,7 @@ ProtectControlGroups=true
 RestrictRealtime=true
 Type=oneshot
 User=_rmt
-Environment="LOG_TO_JOURNALD=1" "LANG=en" "HOME=/var/lib/rmt" "BUNDLE_USER_HOME=/var/lib/rmt/.bundle"
+Environment="LOG_TO_JOURNALD=1" "LANG=en" "HOME=/var/lib/rmt"
 WorkingDirectory=/usr/share/rmt
 ExecStart=/usr/share/rmt/bin/rails db:create db:migrate RAILS_ENV=production
 

--- a/package/files/systemd/rmt-server-mirror.service
+++ b/package/files/systemd/rmt-server-mirror.service
@@ -16,7 +16,7 @@ ProtectControlGroups=true
 RestrictRealtime=true
 Type=simple
 Restart=no
-Environment="LOG_TO_JOURNALD=1" "LANG=en"
+Environment="LOG_TO_JOURNALD=1" "LANG=en" "HOME=/var/lib/rmt" "BUNDLE_USER_HOME=/var/lib/rmt/.bundle"
 ExecStart=/usr/share/rmt/bin/rmt-cli mirror
 
 [Install]

--- a/package/files/systemd/rmt-server-mirror.service
+++ b/package/files/systemd/rmt-server-mirror.service
@@ -16,7 +16,7 @@ ProtectControlGroups=true
 RestrictRealtime=true
 Type=simple
 Restart=no
-Environment="LOG_TO_JOURNALD=1" "LANG=en" "HOME=/var/lib/rmt" "BUNDLE_USER_HOME=/var/lib/rmt/.bundle"
+Environment="LOG_TO_JOURNALD=1" "LANG=en" "HOME=/var/lib/rmt"
 ExecStart=/usr/share/rmt/bin/rmt-cli mirror
 
 [Install]

--- a/package/files/systemd/rmt-server-sync.service
+++ b/package/files/systemd/rmt-server-sync.service
@@ -16,7 +16,7 @@ ProtectControlGroups=true
 RestrictRealtime=true
 Type=simple
 Restart=no
-Environment="LOG_TO_JOURNALD=1" "LANG=en" "HOME=/var/lib/rmt" "BUNDLE_USER_HOME=/var/lib/rmt/.bundle"
+Environment="LOG_TO_JOURNALD=1" "LANG=en" "HOME=/var/lib/rmt"
 ExecStart=/usr/share/rmt/bin/rmt-cli sync
 
 [Install]

--- a/package/files/systemd/rmt-server-sync.service
+++ b/package/files/systemd/rmt-server-sync.service
@@ -16,7 +16,7 @@ ProtectControlGroups=true
 RestrictRealtime=true
 Type=simple
 Restart=no
-Environment="LOG_TO_JOURNALD=1" "LANG=en"
+Environment="LOG_TO_JOURNALD=1" "LANG=en" "HOME=/var/lib/rmt" "BUNDLE_USER_HOME=/var/lib/rmt/.bundle"
 ExecStart=/usr/share/rmt/bin/rmt-cli sync
 
 [Install]

--- a/package/files/systemd/rmt-server-systems-scc-sync.service
+++ b/package/files/systemd/rmt-server-systems-scc-sync.service
@@ -16,7 +16,7 @@ ProtectControlGroups=true
 RestrictRealtime=true
 Type=simple
 Restart=no
-Environment="LOG_TO_JOURNALD=1" "LANG=en"
+Environment="LOG_TO_JOURNALD=1" "LANG=en" "HOME=/var/lib/rmt" "BUNDLE_USER_HOME=/var/lib/rmt/.bundle"
 ExecStart=/usr/share/rmt/bin/rmt-cli systems scc-sync
 
 [Install]

--- a/package/files/systemd/rmt-server-systems-scc-sync.service
+++ b/package/files/systemd/rmt-server-systems-scc-sync.service
@@ -16,7 +16,7 @@ ProtectControlGroups=true
 RestrictRealtime=true
 Type=simple
 Restart=no
-Environment="LOG_TO_JOURNALD=1" "LANG=en" "HOME=/var/lib/rmt" "BUNDLE_USER_HOME=/var/lib/rmt/.bundle"
+Environment="LOG_TO_JOURNALD=1" "LANG=en" "HOME=/var/lib/rmt"
 ExecStart=/usr/share/rmt/bin/rmt-cli systems scc-sync
 
 [Install]

--- a/package/files/systemd/rmt-server.service
+++ b/package/files/systemd/rmt-server.service
@@ -19,7 +19,7 @@ RestrictRealtime=true
 Type=simple
 User=_rmt
 PrivateTmp=yes
-Environment="LOG_TO_JOURNALD=1" "LANG=en"
+Environment="LOG_TO_JOURNALD=1" "LANG=en" "HOME=/var/lib/rmt" "BUNDLE_USER_HOME=/var/lib/rmt/.bundle"
 WorkingDirectory=/usr/share/rmt
 ExecStart=/usr/share/rmt/bin/rails server -e production -b 127.0.0.1
 Restart=always

--- a/package/files/systemd/rmt-server.service
+++ b/package/files/systemd/rmt-server.service
@@ -19,7 +19,7 @@ RestrictRealtime=true
 Type=simple
 User=_rmt
 PrivateTmp=yes
-Environment="LOG_TO_JOURNALD=1" "LANG=en" "HOME=/var/lib/rmt" "BUNDLE_USER_HOME=/var/lib/rmt/.bundle"
+Environment="LOG_TO_JOURNALD=1" "LANG=en" "HOME=/var/lib/rmt"
 WorkingDirectory=/usr/share/rmt
 ExecStart=/usr/share/rmt/bin/rails server -e production -b 127.0.0.1
 Restart=always

--- a/package/files/systemd/rmt-sidekiq.service
+++ b/package/files/systemd/rmt-sidekiq.service
@@ -19,7 +19,7 @@ User=_rmt
 StandardOutput=journal
 StandardError=journal
 TimeoutStopSec=30
-Environment="RAILS_ENV=production" "HOME=/var/lib/rmt" "BUNDLE_USER_HOME=/var/lib/rmt/.bundle"
+Environment="RAILS_ENV=production" "HOME=/var/lib/rmt"
 WorkingDirectory=/usr/share/rmt
 ExecStart=/usr/share/rmt/bin/sidekiq -C /usr/share/rmt/config/sidekiq.yml
 Restart=always

--- a/package/files/systemd/rmt-sidekiq.service
+++ b/package/files/systemd/rmt-sidekiq.service
@@ -19,7 +19,7 @@ User=_rmt
 StandardOutput=journal
 StandardError=journal
 TimeoutStopSec=30
-Environment="RAILS_ENV=production"
+Environment="RAILS_ENV=production" "HOME=/var/lib/rmt" "BUNDLE_USER_HOME=/var/lib/rmt/.bundle"
 WorkingDirectory=/usr/share/rmt
 ExecStart=/usr/share/rmt/bin/sidekiq -C /usr/share/rmt/config/sidekiq.yml
 Restart=always


### PR DESCRIPTION
## Description

when restarting RMT 3.1 I can see the following in the logs:

- Azure 
2026-08-06T15:33:36.800783+00:00 test-rmt-azure-1-westus3 rails[10531]: `/usr/share/rmt` is not writable.

- GCE 
2026-08-06T15:09:57.155078+00:00 test-rmt-gce-1-us-west1-b rails[5321]: [5321] === puma shutdown: 2026-08-06 15:09:57 +0000 === 2026-08-06T15:09:57.157040+00:00 test-rmt-gce-1-us-west1-b rails[5321]: [5321] - Goodbye! 2026-08-06T15:09:57.158051+00:00 test-rmt-gce-1-us-west1-b rails[5321]: [5321] - Gracefully shutting down workers... 2026-08-06T15:09:58.045231+00:00 test-rmt-gce-1-us-west1-b rails[5321]: Exiting 2026-08-06T15:10:01.162833+00:00 test-rmt-gce-1-us-west1-b rails[5516]: `/usr/share/rmt` is not writable.

- AWS 
2026-08-06T10:29:53.513400+00:00 test-rmt-ec2-1-eu-central-1a rails[30586]: [30586] === puma shutdown: 2026-08-06 10:29:53 +0000 === 2026-08-06T10:29:53.513541+00:00 test-rmt-ec2-1-eu-central-1a rails[30586]: [30586] - Goodbye! 2026-08-06T10:29:53.513566+00:00 test-rmt-ec2-1-eu-central-1a rails[30586]: [30586] - Gracefully shutting down workers... 2026-08-06T10:30:23.747833+00:00 test-rmt-ec2-1-eu-central-1a rails[30586]: Exiting 2026-08-06T10:30:24.486768+00:00 test-rmt-ec2-1-eu-central-1a rails[31759]: `/home/_rmt` is not a directory.

or for rmt-sidekiq.service

Aug 06 16:19:26 test-rmt-ec2-1-eu-central-1a systemd[1]: Started RMT Sidekiq Background Worker.
Aug 06 16:19:26 test-rmt-ec2-1-eu-central-1a sidekiq[23777]: `/home/_rmt` is not a directory.
Aug 06 16:19:26 test-rmt-ec2-1-eu-central-1a sidekiq[23777]: Bundler will use `/tmp/bundler20260806-23777-6eek8723777' as your home directory temporarily.

why did we not see this in 2.28 ?

in Rails 6.1 (Ruby 2.X/ Bundler 2.2), if an environment variable like HOME=/home/_rmt pointed to a path that did not physically exist on disk, OR like in _this case_, DOES EXIST but the Protecthome setting in the service makes the directory inaccessible, older versions of Bundler often caught that failure early or relied on internal Ruby fallback APIs that quietly bypassed it. It would silently swap to a temporary working path or evaluate a different user directory without alerting

in Rails 8.1 (Ruby 3.4/ Bundler 2.6+), Bundler explicitly forces validation directly against Gem.user_home, if HOME is defined in the system setup as /home/_rmt, Bundler will not look any further or silently fail over, it hits the string, evaluates File.directory?('/home/_rmt'), sees it is missing on the server or is not accessible, and explicitly prints the warning to the log

* Related Issue / Ticket / Trello card: <link reference>

## How to test 

restart rmt-server.service or rmt-sidekiq.service and not see those warnings in the logs


## Change Type

*Please select the correct option.*

- [X] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [X] I have documented the `MANUAL.md` file with any changes to the user experience.
- [X] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

