### PR TITLE
Avoid dev-env looping infinitely on DB migrations

### DIFF
--- a/bin/compose-init.rb
+++ b/bin/compose-init.rb
@@ -3,9 +3,9 @@ begin
 rescue ::RMT::Db::TimeoutReachedError
   Rails.logger.error "Database connection timed out!"
   exit 1
-rescue ::RMT::Db::MigrationsCompleted
-  Rails.logger.info "Migrations completed successfully - restart service to detect updated migration state correctly"
-  exit 0
+rescue StandardError => e
+  Rails.logger.error "Database setup failed: #{e.message}"
+  exit 1
 end
 
 # Create the `/var/lib/rmt/system_uuid` file if it does not exist already. This

--- a/bin/compose-init.rb
+++ b/bin/compose-init.rb
@@ -3,6 +3,9 @@ begin
 rescue ::RMT::Db::TimeoutReachedError
   Rails.logger.error "Database connection timed out!"
   exit 1
+rescue ::RMT::Db::MigrationsCompleted
+  Rails.logger.info "Migrations completed successfully - restart service to detect updated migration state correctly"
+  exit 0
 end
 
 # Create the `/var/lib/rmt/system_uuid` file if it does not exist already. This

--- a/lib/rmt/db.rb
+++ b/lib/rmt/db.rb
@@ -50,6 +50,7 @@ module RMT
           unless system('bundle exec rake db:migrate')
             raise StandardError, 'Migration failed'
           end
+
           raise MigrationsCompleted
         when :missing
           Rails.logger.info 'Database missing: creating...'

--- a/lib/rmt/db.rb
+++ b/lib/rmt/db.rb
@@ -47,16 +47,17 @@ module RMT
           count += 5
         when :empty
           Rails.logger.info 'Database empty: migrating...'
-          unless system('bundle exec rake db:migrate')
-            raise StandardError, 'Migration failed'
-          end
+          raise StandardError, 'Migration failed' unless system('bundle exec rake db:migrate')
 
-          raise MigrationsCompleted
+          # `rake db:migrate` runs in a child process, so it never dirties this
+          # process' query cache -- and `rails runner` (see docker-compose.yml)
+          # wraps us in the Rails executor, which enables that cache for the
+          # whole script. Without this, the cached `schema_migrations` read in
+          # `migrations?` stays pre-migration and we'd migrate forever.
+          ActiveRecord::Base.connection_pool.clear_query_cache
         when :missing
           Rails.logger.info 'Database missing: creating...'
-          unless system('bundle exec rake db:create')
-            raise StandardError, 'Database creation failed'
-          end
+          raise StandardError, 'Database creation failed' unless system('bundle exec rake db:create')
         when :ready
           Rails.logger.info 'Database ready!'
           break
@@ -68,12 +69,6 @@ module RMT
 
     # Raised if any timeout reached
     class TimeoutReachedError < RuntimeError; end
-
-    # Raised after migrations have been completed, signaling that a
-    # restart is needed to pick to correctly detect that migrations
-    # have completed using the ActiveRecord::Base.connection_pool's
-    # migration_context which appears to cache stale state.
-    class MigrationsCompleted < RuntimeError; end
   end
 end
 # :nocov:

--- a/lib/rmt/db.rb
+++ b/lib/rmt/db.rb
@@ -47,10 +47,15 @@ module RMT
           count += 5
         when :empty
           Rails.logger.info 'Database empty: migrating...'
-          system('bundle exec rake db:migrate')
+          unless system('bundle exec rake db:migrate')
+            raise StandardError, 'Migration failed'
+          end
+          raise MigrationsCompleted
         when :missing
           Rails.logger.info 'Database missing: creating...'
-          system('bundle exec rake db:create')
+          unless system('bundle exec rake db:create')
+            raise StandardError, 'Database creation failed'
+          end
         when :ready
           Rails.logger.info 'Database ready!'
           break
@@ -62,6 +67,12 @@ module RMT
 
     # Raised if any timeout reached
     class TimeoutReachedError < RuntimeError; end
+
+    # Raised after migrations have been completed, signaling that a
+    # restart is needed to pick to correctly detect that migrations
+    # have completed using the ActiveRecord::Base.connection_pool's
+    # migration_context which appears to cache stale state.
+    class MigrationsCompleted < RuntimeError; end
   end
 end
 # :nocov:


### PR DESCRIPTION
## Description

The recent switch to using the ActiveRecord::Base.connection_pool to access the migration context unwittingly lead to a new infinite loop during the check to see if migrations are needed, and then repeatedly running the rake db:migrate task to apply migrations, even though all migrations have been successfully applied.

This caching of query results is due to the rails runner enabling query caching automatically when the compose-init.rb script is launched, and the solution is to tell the connection_pool to clear the query cache results before checking for DB migrations being needed again.

Also added checks to the rake db:create and rake db:migrate system() calls to fail with an StandardError if the commands didn't succeed.

AI-Assisted-By: Qwen 3.6 35B MoE (A3B)

Co-Authored-By: Thomas Schmidt <tschmidt@suse.de>

Fixes: SCC-953

## How to test 

Add a new dummy DB migration under db/migrate and verify that you can start the docker compose based RMT dev-env using `make server`.

If not sure how to do this a quick hack way of doing so is to copy the recent profiles data field update migration script to a new name, e.g.

```bash
% cp db/migrate/20260626153118_change_data_type.rb db/migrate/20260806153118_change_data_type_2.rb
```
Then edit the file to append a `2` after the `ChangeDataType` on the first line, and change the `16.megabytes` limit to `32.megabytes` or something similar, and change the downgrade action to restore the original `16.megabytes` limit, e.g. something like the following:
```bash
% cat db/migrate/20260806153118_change_data_type_2.rb
class ChangeDataType2 < ActiveRecord::Migration[8.1]
  def up
    # change the column to MEDIUMTEXT (limit of 32 MB)
    safety_assured do
      change_column :profiles, :data, :text, limit: 32.megabytes
    end
  end

  def down
    change_column :profiles, :data, :text, limit: 16.megabytes
  end
end
```

If you have edited things correctly then when you run `make server` you will see the successful run of `rake db:migrate`, followed by an info message saying that a restart is needed, followed by the docker compose infrastructure restarting the compose-init.rb script, and then the DB will be detected as ready and the rails RMT server will be successfully started.

To undo the dummy migration to your DB you should perform the following steps:
1. Stop the RMT service with a `docker compose down rmt` (or `docker-compose down rmt` if you are using `docker-compose`)
```bash
% docker compose down rmt
[+] down 2/2
 ✔ Container rmt-rmt-1 Removed                                                 0.4s
 ! Network rmt_default Resource is still in use
```
2. Show the DB migration status by running `docker compose run -it --remove-orphans rmt bundle exec rake db:migrate:status` to list all the applied migrations; the last one should be timestamp part of the migration script name above, e.g. `20260806153118`
```bash
% docker compose run -it --remove-orphans rmt bundle exec rake db:migrate:status
[+]  2/2t 2/22
 ✔ Container rmt-db-1                 Running                                                                                      0.0s
 ✔ Container rmt-rmt-run-4b0bac5f2491 Removed                                                                                      0.1s
Container rmt-rmt-run-9d6c6821ce0e Creating
Container rmt-rmt-run-9d6c6821ce0e Created

database: rmt

 Status   Migration ID    Migration Name
--------------------------------------------------
D, [2026-08-07T19:46:28.349239 #1] DEBUG -- :   ActiveRecord::SchemaMigration Load (0.2ms)  SELECT `schema_migrations`.`version` FROM `schema_migrations` ORDER BY `schema_migrations`.`version` ASC
   up     20180420145408  Init schema
   up     20181030125058  Add migration extra to products extensions
   up     20181204130210  Drop unused system columns
   up     20190102125933  Add hw infos extra
   up     20190118125927  Add friendly version to products
   up     20190320120959  Add index to systems login
   up     20190717114051  Remove friendly name from products
   up     20200108120334  Add regforwarding columns
   up     20200205123840  Backfill add migration extra to products extensions
   up     20200403075822  Migrate provisional to evaluation
   up     20200715151211  Remove uniqueness from downloaded files checksum
   up     20200723124836  Add uniqueness to downloaded files local path
   up     20200916104804  Make scc id unique
   up     20200916120607  Add friendly target to repositories
   up     20211006102307  Add subscription to activations
   up     20211017185107  Add proxy byos to systems
   up     20220113074644  Remove products negative
   up     20220405113737  Reset system sync
   up     20220711134852  Add system token to systems
   up     20220711143849  Remove uniqueness from systems login
   up     20220711150340  Add unique index to systems
   up     20220711152732  Add index to systems login and password
   up     20230717143633  Add system information to systems
   up     20230814105634  Move hw info to systems table
   up     20240111200053  Create system uptimes
   up     20240129140413  Remove obsolete res7 repositories
   up     20240620111456  Remove ltss 7 from products
   up     20240711154147  Add index to systems system token
   up     20240729103525  Add proxy byos mode to systems
   up     20240821114908  Change local path type
   up     20250121104357  Add regcode to systems
   up     20250319155325  Backfill add proxy byos mode to systems
   up     20251106161700  Create profiles
   up     20251106164009  Create system profiles
   up     20251113142033  Drop obsolete products
   up     20260108092033  Add index to systems hostname
   up     20260626153118  Change data type
   up     20260626153653  Remove proxy byos from systems
   up     20260806153118  Change data type 2
```
3. Next run `docker compose run -it --remove-orphans rmt bundle exec rake db:migrate:down VERSION=20260806153118` to downgrade that migration
```bash
% docker compose run -it --remove-orphans rmt bundle exec rake db:migrate:down VERSION=20260806153118
[+]  2/2t 2/22
 ✔ Container rmt-db-1                 Running                                  0.0s
 ✔ Container rmt-rmt-run-20aea743366d Removed                                  0.1s
Container rmt-rmt-run-8bf1a06e166d Creating
Container rmt-rmt-run-8bf1a06e166d Created
D, [2026-08-07T19:48:51.498958 #1] DEBUG -- :    (0.1ms)  SELECT GET_LOCK('1621337978320771095', 0)
D, [2026-08-07T19:48:51.502790 #1] DEBUG -- :   ActiveRecord::SchemaMigration Load (0.2ms)  SELECT `schema_migrations`.`version` FROM `schema_migrations` ORDER BY `schema_migrations`.`version` ASC
I, [2026-08-07T19:48:51.503065 #1]  INFO -- : Reverting ChangeDataType2 (20260806153118)
== 20260806153118 ChangeDataType2: reverting ==================================
D, [2026-08-07T19:48:51.503903 #1] DEBUG -- :    (0.1ms)  SELECT VERSION()
D, [2026-08-07T19:48:51.504563 #1] DEBUG -- :    (0.3ms)  SHOW VARIABLES LIKE 'lock_wait_timeout'
[strong_migrations] DANGER: Lock timeout is longer than 0 seconds: 86400
-- change_column(:profiles, :data, :text, {limit: 16777216})
D, [2026-08-07T19:48:51.518408 #1] DEBUG -- :    (12.3ms)  ALTER TABLE `profiles` CHANGE `data` `data` longtext COLLATE utf8mb4_unicode_520_ci NOT NULL
   -> 0.0140s
== 20260806153118 ChangeDataType2: reverted (0.0152s) =========================

D, [2026-08-07T19:48:51.520224 #1] DEBUG -- :   ActiveRecord::SchemaMigration Destroy (1.0ms)  DELETE FROM `schema_migrations` WHERE `schema_migrations`.`version` = '20260806153118'
D, [2026-08-07T19:48:51.520718 #1] DEBUG -- :    (0.1ms)  SELECT RELEASE_LOCK('1621337978320771095')
D, [2026-08-07T19:48:51.522237 #1] DEBUG -- :   ActiveRecord::SchemaMigration Load (0.1ms)  SELECT `schema_migrations`.`version` FROM `schema_migrations` ORDER BY `schema_migrations`.`version` ASC
```
4. You can check the migration status to verify that the migration is not applied:
```bash
% docker compose run -it --remove-orphans rmt bundle exec rake db:migrate:status
[+]  2/2t 2/22
 ✔ Container rmt-db-1                 Running                                                                                      0.0s
 ✔ Container rmt-rmt-run-8bf1a06e166d Removed                                                                                      0.1s
Container rmt-rmt-run-71afd86d7cd6 Creating
Container rmt-rmt-run-71afd86d7cd6 Created

database: rmt

 Status   Migration ID    Migration Name
--------------------------------------------------
D, [2026-08-07T19:50:14.561874 #1] DEBUG -- :   ActiveRecord::SchemaMigration Load (0.2ms)  SELECT `schema_migrations`.`version` FROM `schema_migrations` ORDER BY `schema_migrations`.`version` ASC
   up     20180420145408  Init schema
   up     20181030125058  Add migration extra to products extensions
   up     20181204130210  Drop unused system columns
   up     20190102125933  Add hw infos extra
   up     20190118125927  Add friendly version to products
   up     20190320120959  Add index to systems login
   up     20190717114051  Remove friendly name from products
   up     20200108120334  Add regforwarding columns
   up     20200205123840  Backfill add migration extra to products extensions
   up     20200403075822  Migrate provisional to evaluation
   up     20200715151211  Remove uniqueness from downloaded files checksum
   up     20200723124836  Add uniqueness to downloaded files local path
   up     20200916104804  Make scc id unique
   up     20200916120607  Add friendly target to repositories
   up     20211006102307  Add subscription to activations
   up     20211017185107  Add proxy byos to systems
   up     20220113074644  Remove products negative
   up     20220405113737  Reset system sync
   up     20220711134852  Add system token to systems
   up     20220711143849  Remove uniqueness from systems login
   up     20220711150340  Add unique index to systems
   up     20220711152732  Add index to systems login and password
   up     20230717143633  Add system information to systems
   up     20230814105634  Move hw info to systems table
   up     20240111200053  Create system uptimes
   up     20240129140413  Remove obsolete res7 repositories
   up     20240620111456  Remove ltss 7 from products
   up     20240711154147  Add index to systems system token
   up     20240729103525  Add proxy byos mode to systems
   up     20240821114908  Change local path type
   up     20250121104357  Add regcode to systems
   up     20250319155325  Backfill add proxy byos mode to systems
   up     20251106161700  Create profiles
   up     20251106164009  Create system profiles
   up     20251113142033  Drop obsolete products
   up     20260108092033  Add index to systems hostname
   up     20260626153118  Change data type
   up     20260626153653  Remove proxy byos from systems
  down    20260806153118  Change data type 2

```
5. Finally you can then delete the temporary hack migration script with `rm db/migrate/20260806153118_change_data_type_2.rb` and checking the migration status will show that the temporary hack migration script is no longer detected.
```bash
% rm db/migrate/20260806153118_change_data_type_2.rb
% docker compose run -it --remove-orphans rmt bundle exec rake db:migrate:status
[+]  2/2t 2/22
 ✔ Container rmt-db-1                 Running                                                                                      0.0s
 ✔ Container rmt-rmt-run-71afd86d7cd6 Removed                                                                                      0.1s
Container rmt-rmt-run-e8b83869cc17 Creating
Container rmt-rmt-run-e8b83869cc17 Created

database: rmt

 Status   Migration ID    Migration Name
--------------------------------------------------
D, [2026-08-07T19:53:23.528258 #1] DEBUG -- :   ActiveRecord::SchemaMigration Load (0.3ms)  SELECT `schema_migrations`.`version` FROM `schema_migrations` ORDER BY `schema_migrations`.`version` ASC
   up     20180420145408  Init schema
   up     20181030125058  Add migration extra to products extensions
   up     20181204130210  Drop unused system columns
   up     20190102125933  Add hw infos extra
   up     20190118125927  Add friendly version to products
   up     20190320120959  Add index to systems login
   up     20190717114051  Remove friendly name from products
   up     20200108120334  Add regforwarding columns
   up     20200205123840  Backfill add migration extra to products extensions
   up     20200403075822  Migrate provisional to evaluation
   up     20200715151211  Remove uniqueness from downloaded files checksum
   up     20200723124836  Add uniqueness to downloaded files local path
   up     20200916104804  Make scc id unique
   up     20200916120607  Add friendly target to repositories
   up     20211006102307  Add subscription to activations
   up     20211017185107  Add proxy byos to systems
   up     20220113074644  Remove products negative
   up     20220405113737  Reset system sync
   up     20220711134852  Add system token to systems
   up     20220711143849  Remove uniqueness from systems login
   up     20220711150340  Add unique index to systems
   up     20220711152732  Add index to systems login and password
   up     20230717143633  Add system information to systems
   up     20230814105634  Move hw info to systems table
   up     20240111200053  Create system uptimes
   up     20240129140413  Remove obsolete res7 repositories
   up     20240620111456  Remove ltss 7 from products
   up     20240711154147  Add index to systems system token
   up     20240729103525  Add proxy byos mode to systems
   up     20240821114908  Change local path type
   up     20250121104357  Add regcode to systems
   up     20250319155325  Backfill add proxy byos mode to systems
   up     20251106161700  Create profiles
   up     20251106164009  Create system profiles
   up     20251113142033  Drop obsolete products
   up     20260108092033  Add index to systems hostname
   up     20260626153118  Change data type
   up     20260626153653  Remove proxy byos from systems

```

## Change Type

*Please select the correct option.*

- [x] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [x] I have reviewed my own code and believe that it's ready for an external review.
- [x] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

