### PR TITLE
Ensure server.pid file is removed by docker compose down

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
     depends_on:
       - db
     privileged: true
+    pre_stop:
+      - command: rm -f /srv/www/rmt/tmp/pids/server.pid
     command: bundle exec rails runner /srv/www/rmt/bin/compose-init.rb
 
   nginx:


### PR DESCRIPTION
## Description

Avoid rails RMT server startup errors triggered by a previous docker compose down leaving a stale tmp/pids/server.pid that is detected by a subsequent docker compose up.

Apply the same pre_stop directive solution that was used previously on the master branch.

Fixes: SCC-958

## How to test 

With this fix in place after running `docker compose down` or `docker compose down rmt` the `tmp/pids/server.pid` file should not exist.

## Change Type

*Please select the correct option.*

- [x] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [x] I have reviewed my own code and believe that it's ready for an external review.
- [x] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

