### PR TITLE
Update puma dependancy to 7.2.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -205,7 +205,7 @@ GEM
       date
       stringio
     public_suffix (7.0.5)
-    puma (7.1.0)
+    puma (7.2.1)
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.5)


### PR DESCRIPTION
## Description

The depfu #1477 moves forward to 8.0.2, but switching to 8.0.2 comes with a potentially breaking change to address setup/binding.

Updating 7.2.1 should be a non-breaking update to address the same security advisory concerns.
