### PR TITLE
Attempt to address flapping lockfile feature test

### DIFF
--- a/features/lockfile_spec.rb
+++ b/features/lockfile_spec.rb
@@ -7,6 +7,8 @@ describe 'rmt-cli' do
       parent_pid = fork do
         system "/usr/bin/rmt-cli sync > /dev/null"
       end
+      # Give the forked process time to start and acquire the lock
+      sleep 1
       example.run
       # wait for the parent process to finish, so the lock is released
       Process.wait(parent_pid)


### PR DESCRIPTION
## Description

Avoid a potential race when creating a child process to acquire the lockfile by sleeping in the main process to allow the child process time to start up and acquire the lock.

AI-Assistance-By: Qwen 3.6 35B MoE (A3B)

Fixes: SCC-964