### PR TITLE
Update changelog for RMT 3.1 release

### DIFF
--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -1,9 +1,9 @@
 -------------------------------------------------------------------
 Tue Aug 11 08:35:19 UTC 2026 - Jesús Bermúdez Velázquez <jesus.bv@suse.com>
 
-- Version 3.1 (bsc#1274715)
+- Version 3.1
   * Set RMT version to 3.1
-  * Remove all errors and warnigs due to new Ruby and Ruby on Rails versions
+  * Remove all errors and warnigs due to new Ruby and Ruby on Rails versions (bsc#1274715)
 
 -------------------------------------------------------------------
 Fri Jun  5 16:15:34 UTC 2026 - Jesús Bermúdez Velázquez <jesus.bv@suse.com>


### PR DESCRIPTION
Adjusts the 3.1 changelog entry so the Bugzilla reference sits on the line item it describes instead of the `- Version` header:

```
- Version 3.1
  * Set RMT version to 3.1
  * Remove all errors and warnigs due to new Ruby and Ruby on Rails versions (bsc#1274715)
```

This matches how the rest of `rmt-server.changes` annotates references — see the 2.28 and 2.27 entries, which hang `bsc#`/`jsc#` off individual fixes.

No other lines are touched, and the submission tracker gate still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)