### PR TITLE
Track the agent skill and correct its RMT 3 delivery paths

### DIFF
--- a/.agents/skills/rmt-release-management/SKILL.md
+++ b/.agents/skills/rmt-release-management/SKILL.md
@@ -29,13 +29,41 @@ The release process differs between RMT 2 and RMT 3:
 - **Branch:** `rmt_3`
 - **Workflow:** Git-first with OBS integration
 - **Projects:** OBS `systemsmanagement:SCC:RMT` (the main project, now v3-only) and IBS `Devel:SCC:RMT`
-- **Repositories:**
-  - `src.opensuse.org` - openSUSE Factory, Tumbleweed, Leap builds
-  - `src.suse.de` - SLE-based builds (requires VPN/internal network)
-- **Process:** Git commits → OBS sync → builds. SLE maintenance is handled via the git-based flow (`src.suse.de`), not IBS `mr`.
+- **Package git repository:** `pool/rmt-server` — **not** `systemsmanagement/rmt-server`
+  - `gitea@src.suse.de:pool/rmt-server` - SLFO/SLE builds (requires VPN/internal network)
+  - `gitea@src.opensuse.org:pool/rmt-server` - public mirror (Factory/Leap branches)
+- **Branch → target mapping** (verified against `osc meta pkg`):
+
+  | Branch | Consumed by | Mechanism |
+  |---|---|---|
+  | `slfo-main` | `SUSE:SLFO:Main` → SLES **16.1** | `scmsync` |
+  | `slfo-1.2` | `SUSE:SLFO:1.2` → SLES **16.0** | `scmsync` |
+  | `factory`, `leap-16.0`, `leap-16.1` | openSUSE Factory / Leap 16.x | submit request |
+
+  Note the naming trap: `slfo-1.2` is the *older* product (16.0); `slfo-main` is the rolling branch that becomes 16.1.
+
+- **Two parallel delivery paths:**
+  - **SLFO / SLES 16** → fork PR against `pool/rmt-server` (`slfo-main`, `slfo-1.2`, **one source branch each**); the scmsync bot builds and forwards.
+  - **SLE 15 SP7** → OBS devel project `systemsmanagement:SCC:RMT`, then IBS `osc mr Devel:SCC:RMT rmt-server SUSE:SLE-15-SP7:Update`.
+- **Never commit to IBS `Devel:SCC:RMT` directly** — it is a `_link` to `openSUSE.org:systemsmanagement:SCC:RMT` and follows the OBS project automatically.
 - See [git-workflow.md](references/git-workflow.md) for details
 
 **Detailed Action Plans:** See [release-workflow.md](references/release-workflow.md) for phase-by-phase instructions.
+
+## Release Gates / Preconditions
+
+> **BLOCKING GATE — tracker reference required.** Before **any** submission (openSUSE Factory `osc sr`, SLE/SLFO submission, IBS maintenance request `osc mr`, or an agit PR to a product branch on `src.suse.de` / `src.opensuse.org`), `package/obs/rmt-server.changes` **must** contain an entry for the release version, and that entry **must** carry at least one valid tracker reference:
+>
+> - **Bugzilla:** `bsc#NNNNNNN`
+> - **Jira:** `jsc#XXX-NNN`
+> - **FATE:** `fate#NNNNNN`
+>
+> A changelog entry with no tracker reference is a **blocker**: do not submit until one is added. SUSE maintenance/QA tooling rejects submissions whose changelog has no trackable reference — the reference is what links the update to a bug/feature record for release notes and QA.
+>
+> **Verify before submitting:**
+> ```bash
+> head -20 package/obs/rmt-server.changes | grep -Eq 'bsc#[0-9]{6,7}|jsc#[A-Z]+-[0-9]+|fate#[0-9]+' && echo OK || echo "BLOCKER: no tracker reference"
+> ```
 
 ## Prerequisites & Dependencies
 
@@ -44,6 +72,7 @@ The release process differs between RMT 2 and RMT 3:
 - **`make`**: Required for `make dist`.
 - **`git`**: For version control, tagging, and GitHub releases.
 - **`git-obs`** (optional): CLI helper for git-based package workflows (fork, clone, PR management).
+- **`git-lfs`** (RMT 3.x): required — tarballs and man pages in `pool/rmt-server` are stored via LFS (see its `.gitattributes`). Without it you commit broken pointer files.
 
 ### Configuration (Project Memory)
 To streamline the process, ensure the following path is saved in the project memory:
@@ -59,11 +88,11 @@ To streamline the process, ensure the following path is saved in the project mem
 
 #### RMT 3.x (rmt_3 branch)
 - **Workflow:** Git-first with OBS integration
-- **Repository Locations:**
-  - **src.opensuse.org:** openSUSE Factory, Tumbleweed, Leap
-  - **src.suse.de:** SLE-based products (requires VPN)
+- **Repository Locations:** `pool/rmt-server` on both instances
+  - **src.suse.de:** SLFO / SLE-based products (requires VPN)
+  - **src.opensuse.org:** public mirror, Factory/Leap branches
 - **Sync:** Automatic bidirectional sync between .org and .de (within minutes)
-- **Target Products:** To be determined based on RMT 3 release schedule
+- **Target Streams:** `SUSE:SLFO:Main` and `SUSE:SLFO:1.2` (via `slfo-main` / `slfo-1.2` scmsync), plus `SUSE:SLE-15-SP7:Update` (via IBS `osc mr` from `Devel:SCC:RMT`)
 
 ### Access & Accounts
 
@@ -129,6 +158,13 @@ Run the following in the project root:
 make dist
 ```
 
+`make dist` uses `docker compose run -it`, which fails without a TTY (CI, background agents). In that case run the equivalent directly:
+```bash
+docker compose run --rm -v "$PWD":/srv/www/rmt rmt make build-tarball
+```
+
+Note that `build-tarball` depends on `clean`, which deletes `package/obs/*.tar.bz2` — back up the current tarball first if it is the only copy.
+
 **Output Artifacts:**
 - `package/obs/rmt-server-<VERSION>.tar.bz2`
 - `package/obs/rmt-cli.8.gz` (Man page)
@@ -162,14 +198,17 @@ make dist
 
 **Working Copy Setup:**
 ```bash
-# For Factory/Tumbleweed/Leap
-git clone gitea@src.opensuse.org:systemsmanagement/rmt-server
-osc -A https://api.opensuse.org co systemsmanagement:SCC:RMT rmt-server
+# Package git repository (SLFO/SLE — requires VPN)
+git clone gitea@src.suse.de:pool/rmt-server        # or your fork: gitea@src.suse.de:<user>/rmt-server
 
-# For SLE builds (requires VPN)
-git clone gitea@src.suse.de:systemsmanagement/rmt-server
-osc -A https://api.suse.de co Devel:SCC:RMT rmt-server
+# Public mirror (Factory/Leap branches)
+git clone gitea@src.opensuse.org:pool/rmt-server
+
+# OBS devel project (SLE 15 SP7 + openSUSE builds)
+osc -A https://api.opensuse.org co systemsmanagement:SCC:RMT rmt-server
 ```
+
+**Do not check out or commit `Devel:SCC:RMT` on IBS** — it is a `_link` to the OBS project and updates itself. Use it only as the *source* of a maintenance request.
 
 **Sync & Stage:**
 - Commit changes to git first (see [git-workflow.md](references/git-workflow.md))
@@ -224,9 +263,15 @@ After the git tag is pushed, create a GitHub Release via the web UI:
 
 For RMT 3.x releases, submit to openSUSE Factory to make the package available in Tumbleweed/Leap.
 
+> **Check the ground truth first.** As of the 3.1 release, `openSUSE:Factory` has **no** `rmt-server` package (`osc ls openSUSE:Factory rmt-server` → 404), and the `factory` / `leap-16.0` / `leap-16.1` branches of `pool/rmt-server` are stale at 2.18. A submission is therefore a **new-package** submission (legal/licensedigger review, staging), not a routine version update — treat it as its own piece of work, not a step in the release. Verify with `osc ls openSUSE:Factory rmt-server` before assuming otherwise.
+
 **Prerequisites:**
 - OBS workspace configured with `systemsmanagement:SCC:RMT/rmt-server` checked out
 - Package already committed and built in the source project
+- **BLOCKING GATE:** the `package/obs/rmt-server.changes` entry for this version contains at least one tracker reference (`bsc#NNNNNNN`, `jsc#XXX-NNN` or `fate#NNNNNN`) — see [Release Gates / Preconditions](#release-gates--preconditions). Do not run `osc sr` until this passes:
+  ```bash
+  head -20 package/obs/rmt-server.changes | grep -Eq 'bsc#[0-9]{6,7}|jsc#[A-Z]+-[0-9]+|fate#[0-9]+' && echo OK || echo "BLOCKER: no tracker reference"
+  ```
 
 **Submission Process:**
 
@@ -307,6 +352,51 @@ For RMT 3.x releases, submit to openSUSE Factory to make the package available i
 - **Missing dependencies**: Add required BuildRequires to `.spec` file
 - **License issues**: Verify License field uses correct SPDX format
 
+### 6b. SLFO and SLE 15 SP7 Submissions (RMT 3.x)
+
+**SLFO / SLES 16** — PR against `pool/rmt-server` from a **fork**. Both `slfo-main` (→ 16.1) and `slfo-1.2` (→ 16.0) need the update.
+
+> **CONSTRAINT — one source branch per pull request.** `autogits_workflow_pr_bot` auto-closes any PR whose source branch is shared with another open PR ("Pushing commits to a shared source branch … would affect the other pull request(s)"). Since SLFO needs two PRs, create **two branches** off the same commit, one per target. Verified the hard way during 3.1.0: PR #7 was auto-closed the moment PR #8 reused `release-3.1.0`.
+
+> **CONSTRAINT — agit push requires write access.** `git push origin <branch>:refs/for/<target>/<title>` against `pool/rmt-server` fails for non-maintainers with `User: <you> with Key: <key> is not authorized to write to pool/rmt-server.` Use the fork + `git-obs pr create` route below.
+
+```bash
+# in the fork clone (origin = gitea@src.suse.de:<you>/rmt-server, upstream = pool/rmt-server)
+git fetch --all --prune
+git checkout -b release-<version>-slfo-main upstream/slfo-main
+# ... copy package/obs artifacts, commit (git-lfs handles the tarball) ...
+
+# one branch per target, both at the same commit
+git branch release-<version>-slfo-1.2 release-<version>-slfo-main
+git push origin release-<version>-slfo-main release-<version>-slfo-1.2
+
+for t in slfo-main slfo-1.2; do
+  git-obs pr create \
+    --source <you>/rmt-server:release-<version>-$t \
+    --target pool/rmt-server:$t \
+    --title "Update to rmt-server <version>" \
+    --description "Version <version> (bsc#NNNNNNN)"
+done
+```
+`--source` / `--target` take `<owner>/<repo>:<branch>`. Add `--dry-run` to check first.
+
+After creating, **verify the bots did not close the PRs** — auto-close arrives within a minute or two and `git-obs pr create` reports success regardless:
+```bash
+git-obs pr get pool/rmt-server#<N>          # expect State: open
+```
+A healthy PR picks up `autogits_obs_staging_bot` (posts a `br.suse.de` build-results link for `SUSE:SLFO:<stream>:PullRequest:<id>`) and `autobuild-review` (group review; approve via a `@autobuild-review: approve` comment, not the Gitea review UI).
+
+Staging builds and forwarding to `SUSE:SLFO:Main` / `SUSE:SLFO:1.2` are handled by those bots.
+
+**SLE 15 SP7** — classic maintenance request from the OBS devel project via its IBS link:
+```bash
+osc -A https://api.suse.de maintained rmt-server           # confirm the codestream is live
+osc -A https://api.suse.de mr Devel:SCC:RMT rmt-server SUSE:SLE-15-SP7:Update
+```
+When asked whether to supersede an existing request, the answer is normally **no** — superseding cancels the release process for that codestream.
+
+**Both paths are gated** on the changelog tracker reference — see [Release Gates / Preconditions](#release-gates--preconditions).
+
 ### 7. Container Image & Helm Chart Updates
 **Container Image:**
 - The image build is automated via BCI pipelines but should be monitored at [devel:BCI:SLE-15-SP7/rmt-server-image](https://build.opensuse.org/package/show/devel:BCI:SLE-15-SP7/rmt-server-image).
@@ -324,16 +414,28 @@ For RMT 3.x releases, submit to openSUSE Factory to make the package available i
 ## Formatting Requirements
 
 ### Changelog Entries
-When submitting maintenance requests (SLES), ensure changelog entries reference relevant bugzilla, jira or fate entries:
-- **Bugzilla:** `bsc#123456`
-- **Jira:** `jsc#XXX-123456`
-- **FATE:** `fate#123456`
+Every changelog entry for a release **must** reference a relevant bugzilla, jira or fate entry:
+- **Bugzilla:** `bsc#NNNNNNN`
+- **Jira:** `jsc#XXX-NNN`
+- **FATE:** `fate#NNNNNN`
+
+**This is a blocking gate for all submissions** (Factory `osc sr`, SLE/SLFO submissions, IBS `osc mr`, agit PRs to product branches) — an entry without a tracker reference must be fixed before submitting. Verify with:
+```bash
+head -20 package/obs/rmt-server.changes | grep -Eq 'bsc#[0-9]{6,7}|jsc#[A-Z]+-[0-9]+|fate#[0-9]+' && echo OK || echo "BLOCKER: no tracker reference"
+```
 
 Use `osc vc` in the `package/obs/` directory to edit the `.changes` file with proper formatting.
 
-### Pull Requests (agit format)
-When contributing via forks, use the agit PR format:
-```bash
-git push origin <branch>:refs/for/<target-branch>/<pr-title>
-```
+### Pull Requests
+Two mechanisms exist; pick by access level:
+
+| | Maintainer (write access) | Contributor (fork) |
+|---|---|---|
+| Mechanism | agit push | fork + `git-obs pr create` |
+| Command | `git push origin <branch>:refs/for/<target>/<title>` | `git-obs pr create --source <you>/rmt-server:<branch> --target pool/rmt-server:<target>` |
+
+For `pool/rmt-server` the fork route is the normal one — agit push is rejected without write access.
+
+**One source branch per open PR.** Reusing a branch across two PRs gets the earlier one auto-closed by `autogits_workflow_pr_bot`. Name branches per target, e.g. `release-3.1.0-slfo-main` / `release-3.1.0-slfo-1.2`.
+
 See [git-workflow.md](references/git-workflow.md) for examples.

--- a/.agents/skills/rmt-release-management/SKILL.md
+++ b/.agents/skills/rmt-release-management/SKILL.md
@@ -395,6 +395,8 @@ osc -A https://api.suse.de mr Devel:SCC:RMT rmt-server SUSE:SLE-15-SP7:Update
 ```
 When asked whether to supersede an existing request, the answer is normally **no** — superseding cancels the release process for that codestream.
 
+> **CONSTRAINT — always submit against `SUSE:SLE-15-SP7:Update`, never against a `SUSE:Maintenance:<N>` incident.** This holds for corrections too: once a submission is accepted it becomes an incident, but the follow-up request still targets `SUSE:SLE-15-SP7:Update`, with no `--incident` flag. The maintenance team merges it into the open incident themselves. See [release-workflow.md](references/release-workflow.md) for the full correction procedure.
+
 **Both paths are gated** on the changelog tracker reference — see [Release Gates / Preconditions](#release-gates--preconditions).
 
 ### 7. Container Image & Helm Chart Updates

--- a/.agents/skills/rmt-release-management/references/git-workflow.md
+++ b/.agents/skills/rmt-release-management/references/git-workflow.md
@@ -1,0 +1,349 @@
+# SUSE Git-based Package Workflow
+
+This reference documents the git-based workflow for contributing to SUSE packages, including **RMT 3.x**. This workflow applies to packages that have been migrated from the traditional OBS-only approach to the new git-first model.
+
+**Important:** This workflow is for **RMT 3.x (rmt_3 branch)** only. RMT 2.x uses the traditional OBS-only workflow without git package management.
+
+## Repository Locations
+
+- **src.opensuse.org (external):** `https://src.opensuse.org` (public)
+  - **Purpose:** openSUSE Factory, Tumbleweed, Leap builds
+  - **Build Service:** OBS at `api.opensuse.org`
+  - **Access:** Public, no VPN required
+  
+- **src.suse.de (internal):** `https://src.suse.de` (SUSE internal)
+  - **Purpose:** SLE-based product builds
+  - **Build Service:** IBS at `api.suse.de`
+  - **Access:** Requires SUSE VPN or internal network
+  
+- **Syncing:** Packages sync automatically between .org and .de instances within minutes (bidirectional)
+
+## Prerequisites
+
+### SSH Access
+Always use SSH with the `gitea@` user for write access:
+```bash
+# General format
+git clone gitea@src.opensuse.org:ORGANIZATION/PACKAGE_NAME    # For Factory/Tumbleweed/Leap
+git clone gitea@src.suse.de:ORGANIZATION/PACKAGE_NAME          # For SLE builds (VPN required)
+```
+
+For RMT 3.x the package lives in the **`pool`** organization — not `systemsmanagement`:
+```bash
+# SLFO/SLE builds (requires VPN) — the authoritative one
+git clone gitea@src.suse.de:pool/rmt-server
+
+# Public mirror (Factory/Leap branches)
+git clone gitea@src.opensuse.org:pool/rmt-server
+```
+
+**Which repository to use:**
+- Working on **Factory/Tumbleweed/Leap**? → Use `src.opensuse.org`
+- Working on **SLE products**? → Use `src.suse.de` (VPN required)
+
+### git-lfs is mandatory
+
+`pool/rmt-server` stores `*.tar.bz2`, `*.gz` and other binaries via LFS (see its `.gitattributes`). Install `git-lfs` before cloning or committing, otherwise you will commit unusable pointer files. Confirm a staged tarball became a pointer:
+```bash
+git show HEAD:rmt-server-<version>.tar.bz2 | head -3   # expect: version https://git-lfs.github.com/spec/v1
+```
+
+### Branch Mapping
+
+**For RMT 3.x** (verified via `osc meta pkg <project> rmt-server`):
+
+| Branch | Consumed by | Mechanism |
+|---|---|---|
+| `slfo-main` | `SUSE:SLFO:Main` | `scmsync` |
+| `slfo-1.2` | `SUSE:SLFO:1.2` | `scmsync` |
+| `factory` | openSUSE Factory | submit request |
+| `leap-16.0`, `leap-16.1` | openSUSE Leap 16.x | submit request |
+
+SLE 15 SP7 is **not** in this repository — it is served by the OBS devel project `systemsmanagement:SCC:RMT` and an IBS maintenance request from `Devel:SCC:RMT`.
+
+**Resources:**
+- Branch-to-product mapping: [https://src.suse.de/pool](https://src.suse.de/pool)
+- Package explorer: [https://src.suse.de](https://src.suse.de) or [https://src.opensuse.org](https://src.opensuse.org)
+
+## Contribution Workflow
+
+### 1. Fork-Based Workflow (Non-Maintainers)
+
+If you don't have write permissions to the main repository:
+
+#### 1.1. Fork via OBS
+```bash
+# Fork the package in OBS to create your branch project
+osc fork systemsmanagement:SCC:RMT rmt-server
+
+# This creates: home:YourUser:branches:systemsmanagement:SCC:RMT
+
+# Checkout your fork
+osc co home:YourUser:branches:systemsmanagement:SCC:RMT rmt-server
+```
+
+#### 1.2. Clone Your Fork
+```bash
+# The fork will have its own git repository
+# For Factory/Tumbleweed/Leap
+git clone gitea@src.opensuse.org:YourUser/rmt-server
+
+# For SLE builds (VPN required)
+git clone gitea@src.suse.de:YourUser/rmt-server
+
+cd rmt-server
+```
+
+#### 1.3. Make Changes
+```bash
+# Create/checkout your working branch
+git checkout -b feature-branch
+
+# Make your code changes
+vim lib/rmt.rb
+
+# Update the changelog
+cd package/obs/
+osc vc  # This opens the .changes file editor
+cd ../..
+
+# Stage and commit
+git add lib/rmt.rb package/obs/rmt-server.changes
+git commit -m "Description of changes"
+```
+
+#### 1.4. Build and Test
+```bash
+# Run service files (download sources, generate files, etc.)
+osc service mr
+
+# Local build verification
+osc build --alternative-project=systemsmanagement:SCC:RMT
+
+# Check build results
+osc results -w home:YourUser:branches:systemsmanagement:SCC:RMT rmt-server
+```
+
+#### 1.5. Submit Pull Request (agit format)
+
+**BLOCKING GATE (PRs to product branches):** verify the changelog carries a tracker reference (`bsc#NNNNNNN`, `jsc#XXX-NNN` or `fate#NNNNNN`) before pushing — see [Changelog Format Requirements](#changelog-format-requirements):
+```bash
+head -20 package/obs/rmt-server.changes | grep -Eq 'bsc#[0-9]{6,7}|jsc#[A-Z]+-[0-9]+|fate#[0-9]+' && echo OK || echo "BLOCKER: no tracker reference"
+```
+
+agit push works **only with write access to the target repository**. For `pool/rmt-server` a non-maintainer gets:
+```
+error: User: <id>:<you> with Key: <id>:<key> is not authorized to write to pool/rmt-server.
+```
+So from a fork, push the branch to your fork and open the PR with `git-obs`:
+```bash
+git push origin feature-branch
+git-obs pr create \
+  --source <you>/rmt-server:feature-branch \
+  --target pool/rmt-server:slfo-main \
+  --title "Your PR title" \
+  --description "... (bsc#NNNNNNN)"
+```
+To update the PR afterwards, push more commits to the same fork branch — no need to recreate it.
+
+**agit PR Format** (maintainers, or forks of repos you can write to):
+- Target: `refs/for/<target-branch>/<pr-title>`
+- See [https://docs.gitea.com/usage/agit](https://docs.gitea.com/usage/agit) for full documentation
+
+### One source branch per open pull request
+
+`autogits_workflow_pr_bot` closes any PR whose source branch is already used by another open PR:
+
+> This pull request's source branch `X` is also used by another open pull request: pool/rmt-server!N. Pushing commits to a shared source branch (e.g. via "Edit by Maintainers") would affect the other pull request(s), so this pull request is being closed. Please push this change to a uniquely named branch and open a new pull request.
+
+This bites whenever one change targets several product branches — the usual SLFO case, where `slfo-main` and `slfo-1.2` both need the same commit. Create one branch per target off the same commit:
+```bash
+git branch release-<version>-slfo-1.2 release-<version>-slfo-main
+git push origin release-<version>-slfo-main release-<version>-slfo-1.2
+```
+The bot fires a minute or two *after* creation, and `git-obs pr create` reports success either way, so always re-check:
+```bash
+git-obs pr get pool/rmt-server#<N>   # expect State: open
+```
+
+### PR bots on pool/rmt-server
+
+| Bot | Role |
+|---|---|
+| `autogits_workflow_pr_bot` | Structural checks; auto-closes shared-source-branch PRs |
+| `autogits_obs_staging_bot` | Creates `SUSE:SLFO:<stream>:PullRequest:<id>`, posts a `br.suse.de` build-results link |
+| `autobuild-review` | Group review. Approve with a comment `@autobuild-review: approve`, request changes with `@autobuild-review: decline` plus justification. **Do not use the Gitea review UI** for this group; comment edits are ignored, post a new comment to change state. |
+
+### Inspecting PR state via the API
+
+`git-obs pr get` shows state but not comments — auto-close reasons live in the comments:
+```bash
+TOKEN=$(python3 -c "import yaml;c=yaml.safe_load(open('$HOME/.config/tea/config.yml'));[print(l['token']) for l in c['logins'] if l['name']=='ibs']")
+curl -s -H "Authorization: token $TOKEN" \
+  https://src.suse.de/api/v1/repos/pool/rmt-server/issues/<N>/comments |
+  python3 -c "import json,sys;[print('--',c['user']['login'],':',c['body']) for c in json.load(sys.stdin)]"
+```
+
+### 2. Direct Push Workflow (Maintainers)
+
+If you have write permissions:
+
+```bash
+# Clone the main repository
+# For Factory/Tumbleweed/Leap
+git clone gitea@src.opensuse.org:pool/rmt-server
+
+# For SLE builds (VPN required)
+git clone gitea@src.suse.de:pool/rmt-server
+
+cd rmt-server
+
+# Create feature branch
+git checkout -b feature-branch
+
+# Make changes, commit
+git add .
+git commit
+
+# Push directly
+git push origin feature-branch
+
+# Or push to main (after review)
+git push origin main
+```
+
+### 3. Using git-obs Tool
+
+The `git-obs` CLI provides shortcuts for common operations:
+
+#### Fork and Clone
+```bash
+# Fork a package
+git-obs repo fork pool/rmt-server
+
+# Clone with SSH
+git-obs repo clone pool/rmt-server
+```
+
+#### Pull Request Operations
+```bash
+# Create a PR
+git-obs pr create --title="Fix version handling" --description="..." --target-branch=main
+
+# Checkout an existing PR
+git-obs pr checkout <PR_NUMBER>
+
+# Review a PR
+git-obs pr review pool/rmt-server#<PR_NUMBER>
+
+# View PR details
+git-obs pr get pool/rmt-server#<PR_NUMBER>
+```
+
+## Release-Specific Workflow
+
+### Phase 2 Integration (OBS Update)
+
+When performing a release, the git workflow integrates with OBS as follows:
+
+1. **Make changes in git:**
+   ```bash
+   # Update version in git repository
+   vim lib/rmt.rb
+   vim package/obs/rmt-server.spec
+   
+   # Update changelog using osc vc in package/obs/
+   cd package/obs/
+   osc vc
+   cd ../..
+   
+   # Generate tarball
+   make dist
+   ```
+
+2. **Sync to OBS working copy:**
+   ```bash
+   # Navigate to your OBS checkout
+   cd ~/obs_workspace/systemsmanagement:SCC:RMT/rmt-server
+   
+   # Delete old tarballs
+   rm rmt-server-*.tar.bz2
+   
+   # Copy new artifacts from git repo
+   cp /path/to/rmt/package/obs/* .
+   
+   # Stage changes
+   osc addremove
+   osc status
+   ```
+
+3. **Commit after git merge:**
+   ```bash
+   # Only commit to OBS after the git PR is merged
+   osc ci
+   ```
+
+### Changelog Format Requirements
+
+Changelog entries must reference tracking systems:
+- **Bugzilla:** `bsc#NNNNNNN`
+- **Jira:** `jsc#XXX-NNN`
+- **FATE:** `fate#NNNNNN`
+
+> **BLOCKING GATE:** Before **any** submission (Factory `osc sr`, SLE/SLFO submission, IBS `osc mr`, or an agit PR to a product branch on `src.suse.de` / `src.opensuse.org`), the `package/obs/rmt-server.changes` entry for the release version **must** carry at least one of the references above. An entry without one is a blocker — SUSE maintenance/QA tooling rejects submissions with no trackable reference. Verify:
+>
+> ```bash
+> head -20 package/obs/rmt-server.changes | grep -Eq 'bsc#[0-9]{6,7}|jsc#[A-Z]+-[0-9]+|fate#[0-9]+' && echo OK || echo "BLOCKER: no tracker reference"
+> ```
+
+Example:
+```
+-------------------------------------------------------------------
+Mon Jun 22 10:00:00 UTC 2026 - user@suse.com
+
+- Update to version 2.28
+  * Fix authentication issue (bsc#1234567)
+  * Add new feature (jsc#SCC-12345)
+```
+
+## Troubleshooting
+
+### "Branching is not allowed because: This package is developed in git..."
+
+This error occurs when trying to use `osc bco` on a git-migrated package:
+```
+Server returned an error: HTTP Error 403: Forbidden
+Branching is not allowed because: This package is developed in git at
+https://src.opensuse.org/systemsmanagement/rmt-server for devel project
+systemsmanagement:SCC:RMT -- see https://en.opensuse.org/openSUSE:OBS_to_Git
+```
+
+**Solution:** Use the git-based fork workflow instead (see Section 1.1).
+
+### Sync Delays
+
+If changes don't appear between src.suse.de and src.opensuse.org:
+- Wait 5-10 minutes for automatic bidirectional sync
+- **Factory sync direction:** External (src.opensuse.org) → Internal (src.suse.de)
+- **SLE sync direction:** Internal (src.suse.de) → External (src.opensuse.org)
+- For pool/slfo-main, ensure source and target branches are correct in your PR
+
+### SSH Permission Denied
+
+If you get "Permission denied (publickey)" when using SSH:
+- Ensure your SSH key is added to your Gitea profile
+- Use the `gitea@` user (not `git@`)
+- Verify the URL format: `gitea@src.opensuse.org:org/package`
+
+## Best Practices
+
+1. **Choose the correct repository:**
+   - **Factory/Tumbleweed/Leap** → `src.opensuse.org` + `api.opensuse.org`
+   - **SLE products** → `src.suse.de` + `api.suse.de` (VPN required)
+2. **Always use SSH clones** with `gitea@` for packages you need to modify
+3. **Update .changes file** before generating distribution tarballs
+4. **Test builds** using `osc build` before submitting
+5. **Fork from the correct branch** for the target product (check /pool mapping)
+6. **Use agit PR format** for all pull requests from forks
+7. **Include tracker references** (`bsc#NNNNNNN`, `jsc#XXX-NNN`, `fate#NNNNNN`) in changelog entries — this is a blocking gate for every submission, not a nicety
+8. **Wait for sync** if working across .org and .de instances (5-10 minutes)

--- a/.agents/skills/rmt-release-management/references/release-workflow.md
+++ b/.agents/skills/rmt-release-management/references/release-workflow.md
@@ -175,15 +175,15 @@ This reference documents the release lifecycle of **rmt-server**, visualizing th
 
 **2a. Correcting an SP7 submission after the fact:**
 
-Once the `mr` is accepted it becomes a `SUSE:Maintenance:<N>` incident, and the maintenance team files their own `maintenance_release` request from that incident. At that point the submission is no longer yours to supersede:
+> **RULE — always submit against `SUSE:SLE-15-SP7:Update`. Never submit against a `SUSE:Maintenance:<N>` incident.** Once the `mr` is accepted an incident is created and the maintenance team files their own `maintenance_release` request from it. Corrections go to the codestream exactly the way the original submission did, and **the maintenance team takes care of merging them into the open incident.** (Maintenance team guidance, 2026-08-13.)
 
-*   `osc mr ... --supersede <release-request>` fails with `HTTP Error 403: You have no role in request <N>`. Note that `osc mr` **still creates the new request** before the supersede call fails — check for a stray duplicate and revoke it with `osc -A https://api.suse.de request revoke <id> -m "..."`.
-*   The only way in is a new request against the existing incident:
+*   Submit the correction the same way as the original request — no incident-specific flags:
     ```bash
-    osc -A https://api.suse.de mr Devel:SCC:RMT rmt-server SUSE:SLE-15-SP7:Update \
-      --incident <N> -m "..."
+    osc -A https://api.suse.de mr Devel:SCC:RMT rmt-server SUSE:SLE-15-SP7:Update -m "..."
     ```
-*   This leaves the team's release request pointing at the previous `srcmd5`; it has to be revoked and re-created by maintenance, which resets the QAM review clock. Comment on the release request so they know, and weigh the delay against how substantive the correction is — a changelog reword is rarely worth disrupting an already-approved release.
+*   **Do not pass `--incident <N>`.** Targeting the incident directly is what the maintenance team has asked us not to do; it is their queue to manage.
+*   **Do not try to supersede their release request.** `osc mr ... --supersede <release-request>` fails with `HTTP Error 403: You have no role in request <N>` — a release request belongs to maintenance, not to us. Note that `osc mr` **still creates the new request** before the supersede call fails, so check for a stray duplicate and revoke it with `osc -A https://api.suse.de request revoke <id> -m "..."`.
+*   Comment on the incident so maintenance know a correction is on its way.
 
 **3. openSUSE Factory Submission (OBS):**
 

--- a/.agents/skills/rmt-release-management/references/release-workflow.md
+++ b/.agents/skills/rmt-release-management/references/release-workflow.md
@@ -24,6 +24,10 @@ This reference documents the release lifecycle of **rmt-server**, visualizing th
     *   **Action:** Change to `package/obs/` directory.
     *   **Action:** Run `osc vc` to edit the `.changes` file with version notes.
     *   **Format:** Include references (e.g., `bsc#123456`, `jsc#XXX-123456`)
+    *   **BLOCKING GATE (precondition for every later submission):** the entry for this version **must** contain at least one tracker reference — `bsc#NNNNNNN`, `jsc#XXX-NNN` or `fate#NNNNNN`. An entry without one blocks Factory/SLE/IBS submission. Verify:
+        ```bash
+        head -20 package/obs/rmt-server.changes | grep -Eq 'bsc#[0-9]{6,7}|jsc#[A-Z]+-[0-9]+|fate#[0-9]+' && echo OK || echo "BLOCKER: no tracker reference"
+        ```
     *   **Note:** This must be done before generating the tarball as the `.changes` file is included in the distribution.
 3.  **Generate Distribution Tarball:**
     *   **Pre-flight Check:** Ensure `public/repo` exists: `mkdir -p public/repo`.
@@ -31,26 +35,36 @@ This reference documents the release lifecycle of **rmt-server**, visualizing th
     *   **Action:** Run `make dist`.
 
 #### RMT 3.x (rmt_3 branch) - Git-Based
-1.  **Clone/Update Git Repository:**
-    *   **For Factory/Tumbleweed/Leap:** `git clone gitea@src.opensuse.org:systemsmanagement/rmt-server`
-    *   **For SLE builds (VPN required):** `git clone gitea@src.suse.de:systemsmanagement/rmt-server`
-    *   **Note:** Use SSH with `gitea@` for write access
-2.  **Update Version Strings:**
+
+**Two repositories are involved — don't conflate them:**
+
+*   **Source:** `github.com/SUSE/rmt`, branch `rmt_3` — where `lib/rmt.rb`, `package/obs/rmt-server.spec` and `package/obs/rmt-server.changes` are edited and reviewed. Steps 2–4 below happen here.
+*   **Packaging:** `pool/rmt-server` on `src.suse.de` / `src.opensuse.org` — receives the built artifacts (tarball, man page, spec, changes) per product branch. Step 5 and Phase 4 happen here.
+
+1.  **Clone/Update the packaging repository** (needed later, in Phase 4):
+    *   **SLFO/SLE (VPN required):** `git clone gitea@src.suse.de:pool/rmt-server` — or your fork, with `pool/rmt-server` added as `upstream`
+    *   **Public mirror:** `git clone gitea@src.opensuse.org:pool/rmt-server`
+    *   **Note:** Use SSH with `gitea@` for write access, and have `git-lfs` installed
+2.  **Update Version Strings** (in the source repo, on `rmt_3`):
     *   Modify `lib/rmt.rb` to reflect the new version.
     *   Modify `package/obs/rmt-server.spec` to match.
 3.  **Update Changelog:**
     *   **Action:** Change to `package/obs/` directory.
     *   **Action:** Run `osc vc` to edit the `.changes` file with version notes.
     *   **Format:** Include references (e.g., `bsc#123456`, `jsc#XXX-123456`)
-    *   **Note:** This must be done before generating the tarball as the `.changes` file is included in the distribution.
+    *   **BLOCKING GATE (precondition for every later submission):** the entry for this version **must** contain at least one tracker reference — `bsc#NNNNNNN`, `jsc#XXX-NNN` or `fate#NNNNNN`. An entry without one blocks the Factory submit request and any agit PR to a product branch. Verify:
+        ```bash
+        head -20 package/obs/rmt-server.changes | grep -Eq 'bsc#[0-9]{6,7}|jsc#[A-Z]+-[0-9]+|fate#[0-9]+' && echo OK || echo "BLOCKER: no tracker reference"
+        ```
+    *   **Note:** Update the changelog before generating the tarball, so the packaging artifacts and the git state describe the same release.
 4.  **Generate Distribution Tarball:**
     *   **Pre-flight Check:** Ensure `public/repo` exists: `mkdir -p public/repo`.
-    *   **Environment:** Use appropriate Ruby version for RMT 3.x.
+    *   **Environment:** Built in the Docker container; use `docker compose run --rm -v "$PWD":/srv/www/rmt rmt make build-tarball` when there is no TTY for `make dist`.
     *   **Action:** Run `make dist`.
-5.  **Commit to Git:**
-    *   **Action:** `git add lib/rmt.rb package/obs/rmt-server.spec package/obs/rmt-server.changes`
-    *   **Action:** `git commit -m "Release version X.Y.Z"`
-    *   **Push/PR:** Push directly or create PR depending on permissions (see [git-workflow.md](git-workflow.md))
+    *   **Caution:** `build-tarball` runs `clean`, which deletes `package/obs/*.tar.bz2` — back up the existing tarball if it is the only copy.
+5.  **Merge the release branch on GitHub:**
+    *   The version bump, spec change and changelog entry go through a normal PR against `rmt_3`.
+    *   Everything downstream (OBS, `pool/rmt-server`, the tag) is built from the merged commit, so rebuild the tarball if further commits land on `rmt_3` after the first build.
 
 ### Phase 2: Open Build Service (OBS) Update
 
@@ -104,8 +118,15 @@ This reference documents the release lifecycle of **rmt-server**, visualizing th
 
 ### Phase 4: Submissions (Factory & SLES)
 
+> **BLOCKING GATE — run before any submission below.** `package/obs/rmt-server.changes` must have an entry for the release version carrying at least one tracker reference (`bsc#NNNNNNN`, `jsc#XXX-NNN` or `fate#NNNNNN`). SUSE maintenance/QA tooling rejects submissions with no trackable reference. If this check fails, stop and add the reference first.
+>
+> ```bash
+> head -20 package/obs/rmt-server.changes | grep -Eq 'bsc#[0-9]{6,7}|jsc#[A-Z]+-[0-9]+|fate#[0-9]+' && echo OK || echo "BLOCKER: no tracker reference"
+> ```
+
 #### RMT 2.x - SLES (IBS, from `Devel:SCC:RMT2`)
 1.  **SLES Maintenance Update:**
+    *   **Pre-check (blocking):** Run the tracker-reference check above — `osc mr` must not be run until it prints `OK`.
     *   **Network Requirement:** Must be on the internal SUSE network or VPN (`api.suse.de`).
     *   **Action:** Identify maintained codestreams: `osc -A https://api.suse.de maintained rmt-server`.
     *   **Target Streams:** SLE 15 SP4, SP5, SP6, SP7
@@ -118,9 +139,56 @@ This reference documents the release lifecycle of **rmt-server**, visualizing th
         ```
     *   **Note:** Ensure changelog entries include references (e.g., `bsc#123456`, `jsc#XXX-123456`).
 
-#### RMT 3.x - Factory + SLES
+#### RMT 3.x - SLFO + SLE 15 SP7 (+ Factory)
 
-**1. openSUSE Factory Submission (OBS):**
+**1. SLFO / SLES 16 (fork PR against `pool/rmt-server`):**
+
+*   **Pre-check (blocking):** Run the tracker-reference check above — no PR may be opened until it prints `OK`.
+*   **Network Requirement:** Must be on VPN for `src.suse.de`.
+*   **Access:** Non-maintainers cannot agit-push to `pool/rmt-server` (`not authorized to write to pool/rmt-server`). Work from a fork; `origin` = `<you>/rmt-server`, `upstream` = `pool/rmt-server`.
+*   **Prepare:** Branch off `upstream/slfo-main`, replace the packaging files from `package/obs/` (delete the previous tarball first), commit. `git-lfs` must be installed.
+*   **Submit:** `slfo-main` (→ 16.1) and `slfo-1.2` (→ 16.0) each need a PR, and **each PR needs its own source branch** — see below.
+    ```bash
+    git branch release-<version>-slfo-1.2 release-<version>-slfo-main
+    git push origin release-<version>-slfo-main release-<version>-slfo-1.2
+
+    for t in slfo-main slfo-1.2; do
+      git-obs pr create --source <you>/rmt-server:release-<version>-$t \
+                        --target pool/rmt-server:$t \
+                        --title "Update to rmt-server <version>" \
+                        --description "Version <version> (bsc#NNNNNNN)"
+    done
+    ```
+*   **Do not share one source branch between the two PRs.** `autogits_workflow_pr_bot` auto-closes the older PR when a second one reuses its branch. This happened during the 3.1.0 release (PR #7 closed when #8 reused `release-3.1.0`).
+*   **Verify after creating:** the bot fires a minute or two later and `git-obs pr create` reports success regardless. `git-obs pr get pool/rmt-server#<N>` must show `State: open`; a healthy PR then attracts `autogits_obs_staging_bot` (build-results link) and `autobuild-review` (group review, approved by an `@autobuild-review: approve` comment).
+*   Staging builds and forwarding to `SUSE:SLFO:Main` / `SUSE:SLFO:1.2` are handled by the bots.
+
+**2. SLE 15 SP7 Maintenance Update (IBS):**
+
+*   **Pre-check (blocking):** Run the tracker-reference check above — `osc mr` must not be run until it prints `OK`.
+*   **Pre-check:** The OBS devel project must hold the final version and have built successfully; `Devel:SCC:RMT` follows it automatically through its `_link`.
+    ```bash
+    osc -A https://api.suse.de cat Devel:SCC:RMT rmt-server rmt-server.changes | head -8
+    osc -A https://api.suse.de mr Devel:SCC:RMT rmt-server SUSE:SLE-15-SP7:Update
+    ```
+*   **Note:** When asked whether to supersede an existing request, answer **no** — superseding cancels the release process for that codestream.
+
+**2a. Correcting an SP7 submission after the fact:**
+
+Once the `mr` is accepted it becomes a `SUSE:Maintenance:<N>` incident, and the maintenance team files their own `maintenance_release` request from that incident. At that point the submission is no longer yours to supersede:
+
+*   `osc mr ... --supersede <release-request>` fails with `HTTP Error 403: You have no role in request <N>`. Note that `osc mr` **still creates the new request** before the supersede call fails — check for a stray duplicate and revoke it with `osc -A https://api.suse.de request revoke <id> -m "..."`.
+*   The only way in is a new request against the existing incident:
+    ```bash
+    osc -A https://api.suse.de mr Devel:SCC:RMT rmt-server SUSE:SLE-15-SP7:Update \
+      --incident <N> -m "..."
+    ```
+*   This leaves the team's release request pointing at the previous `srcmd5`; it has to be revoked and re-created by maintenance, which resets the QAM review clock. Comment on the release request so they know, and weigh the delay against how substantive the correction is — a changelog reword is rarely worth disrupting an already-approved release.
+
+**3. openSUSE Factory Submission (OBS):**
+
+*   **Reality check:** `openSUSE:Factory` currently has **no** `rmt-server` package and the `factory`/`leap-16.x` branches are stale at 2.18 — this is a new-package submission, not a routine release step. Confirm with `osc -A https://api.opensuse.org ls openSUSE:Factory rmt-server` before starting.
+*   **Pre-check (blocking):** Run the tracker-reference check above — `osc sr` must not be run until it prints `OK`.
 
 *   **Pre-check:** Check for existing submit requests:
     ```bash
@@ -147,11 +215,7 @@ This reference documents the release lifecycle of **rmt-server**, visualizing th
     4. Commit to OBS: `osc -A https://api.opensuse.org ci -m "Fix: <issue>"`
     5. Resubmit with `--supersede <old-request-id>`
 
-**2. SLES Maintenance Update (git-based flow):**
-
-*   **Network Requirement:** Must be on VPN for `src.suse.de`.
-*   **Approach:** For v3, SLE maintenance is handled through the git-based flow on `src.suse.de` (product branches + agit PRs), **not** IBS `mr` from `Devel:SCC:RMT`. See [git-workflow.md](git-workflow.md) for branch mapping and agit PR format.
-*   **Note:** Ensure changelog entries include references (e.g., `bsc#123456`, `jsc#XXX-123456`).
+See [git-workflow.md](git-workflow.md) for the branch mapping, the fork PR mechanics, and the PR bots.
 
 ### Phase 5: Container & Helm Chart Updates
 1.  **Container Image:**
@@ -191,11 +255,14 @@ graph TD
     end
 
     subgraph Phase4 [Phase 4: Downstream Distribution]
-        Art2 --> D1[osc sr to Factory]
-        D1 --> Art4(openSUSE Factory Package)
-        
-        Art2 --> D2[osc mr to IBS]
-        D2 --> Art5(SLES Maintenance Update)
+        Art1 --> D0[fork PRs to pool/rmt-server<br/>slfo-main + slfo-1.2<br/>one branch each]
+        D0 --> Art8(SUSE:SLFO:Main / :1.2 via scmsync)
+
+        Art2 --> D2[osc mr Devel:SCC:RMT<br/>-> SUSE:SLE-15-SP7:Update]
+        D2 --> Art5(SLES 15 SP7 Maintenance Update)
+
+        Art2 -.new package, not routine.-> D1[osc sr to Factory]
+        D1 -.-> Art4(openSUSE Factory Package)
     end
 
     subgraph Phase5 [Phase 5: Containers & Helm]

--- a/.claude/skills/rmt-release-management
+++ b/.claude/skills/rmt-release-management
@@ -1,0 +1,1 @@
+../../.agents/skills/rmt-release-management

--- a/.gitignore
+++ b/.gitignore
@@ -53,9 +53,12 @@ locale/*/*.edit.po
 ansible/*.retry
 
 # Agent/AI related files
-.agents/
+# .agents/ holds the shared skill sources; .claude/skills/ symlinks into it, so
+# both are tracked. Only the local settings files stay ignored -- they hold
+# machine-specific paths and credentials.
+.claude/settings.json
+.claude/settings.local.json
 .gemini/
-.claude/
 
 ansible/.molecule/
 ansible/.cache/


### PR DESCRIPTION
## Description

<!--
Please describe your change and provide as much context as needed including a link to the reference issue / ticket / Trello card. 
-->

The `rmt-release-management` agent skill described a single git-based flow for RMT 3 at `systemsmanagement/rmt-server` — a repository that does not exist. This corrects the skill against what the 3.1.0 release actually required, and starts tracking it in the repo so it is shared rather than living on one machine.

Documentation-only: no application code, spec file or changelog is touched.

**Skill corrections**

- The package git repository is `pool/rmt-server`, not `systemsmanagement/rmt-server`.
- RMT 3 ships through **two parallel paths**, not one: fork PRs to `slfo-main` / `slfo-1.2` for SLES 16.1 / 16.0, and an IBS maintenance request from `Devel:SCC:RMT` for SLE 15 SP7. Includes the naming trap that `slfo-1.2` is the *older* product.
- `Devel:SCC:RMT` is a `_link` to the OBS project and must never be committed to directly.
- Adds the blocking tracker-reference gate (`bsc#`/`jsc#`/`fate#`) that applies before every submission.
- Adds the `git-lfs` requirement for `pool/rmt-server` tarballs, the one-source-branch-per-PR bot rule, and a TTY-less `make dist` fallback for CI/agent runs.
- Records how to correct an SP7 submission after its maintenance incident exists — notably that `--supersede` against the maintenance team's release request is rejected with a 403.
- `openSUSE:Factory` has no `rmt-server` package, so a Factory submission is new-package work rather than a routine release step.

**Tracking change**

`.agents/` and `.claude/` are no longer ignored, so the skill source and the `.claude/skills/rmt-release-management` symlink are versioned. `.claude/settings.json` and `.claude/settings.local.json` remain ignored — they hold machine-specific paths and credentials and must not be committed.

* Related Issue / Ticket / Trello card: follow-up to #1539

## How to test 

<!-- Describe the steps how verify your change -->

1. Check out the branch and confirm the symlink survives the clone and resolves:
   ```bash
   git checkout skill-docs-rmt3-delivery-paths
   readlink .claude/skills/rmt-release-management   # ../../.agents/skills/rmt-release-management
   cat .claude/skills/rmt-release-management/SKILL.md | head
   ```
2. Confirm no credentials became tracked:
   ```bash
   git ls-files .claude   # only .claude/skills/rmt-release-management
   git check-ignore -v .claude/settings.json .claude/settings.local.json
   ```
3. Spot-check the corrected claims against the build services (VPN required for the `.de` ones):
   ```bash
   git ls-remote gitea@src.suse.de:pool/rmt-server | grep -E 'slfo-main|slfo-1.2'
   osc -A https://api.suse.de meta pkg Devel:SCC:RMT rmt-server   # shows the _link
   osc -A https://api.opensuse.org ls openSUSE:Factory rmt-server # 404, as documented
   ```

## Change Type

*Please select the correct option.*

- [ ] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [x] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [x] I have reviewed my own code and believe that it's ready for an external review.
- [x] I have provided comments for any hard-to-understand code.
- [x] I have documented the `MANUAL.md` file with any changes to the user experience. — n/a, no user-facing change
- [x] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`. — n/a, internal tooling docs only

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 
