### PR TITLE
Fix the RPM validation check for reserved paths

### DIFF
--- a/ci/rmt-validate-packaging
+++ b/ci/rmt-validate-packaging
@@ -46,7 +46,7 @@ while IFS= read -r RPM; do
 
   # Check for forbidden directory ownership
   for dir_pattern in "${FORBIDDEN_DIRS[@]}"; do
-    if rpm -qplv "$RPM" 2>/dev/null | grep -E "^d.*${dir_pattern}"; then
+    if rpm -qplv "$RPM" 2>/dev/null | grep -e "^d.*[[:space:]]${dir_pattern}"; then
       echo "  ✗ ERROR: Package claims ownership of ${dir_pattern}"
       echo "    Top-level directories should be owned by filesystem package"
       ((ERRORS++))


### PR DESCRIPTION
## Description

The existing regexp check generates false positives as it will match any path ending with the reserved paths, not just the specific reserved paths.

Fixed by adding match at least one whitespace (`[[:space:]]`) character before the start of the path.

This fixes the CI feature test issue being hit by PR #1538.