### PR TITLE
Implement declarative repository configuration

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -312,6 +312,34 @@ The `web_server` section lets you tune the performance of your RMT server.
 The `scc` section contains your organization credentials for mirroring SUSE repositories from SUSE Customer Center.
 Your organization credentials can be obtained from the [SUSE Customer Center](https://scc.suse.com/).
 
+**Settings for declarative product / repository configuration**
+
+Instead of managing enabled products and custom repositories using the command line (the default behavior), it's possible to define them in the configuration file instead. This is useful for configuration management. If used (the settings mentioned below are defined in the configuration file, and they are not empty), `rmt-server` will make sure the enabled products / custom repositories match the ones defined in the configuration upon startup. Be aware that this means changes on the command line will be lost upon restarting `rmt-server`!
+
+  * `products` setting:
+     List of product strings to enforce.
+     Unlike on the command line, dependent products must be listed here as well.
+
+     Example:
+     ```
+     products:
+       - Leap/16.0/x86_64
+       - SLES/15.7/x86_64
+       - sle-module-basesystem/15.7/x86_64
+       - sle-module-python3/15.7/x86_64
+       - sle-module-server-applications/15.7/x86_64
+       - sle-module-systems-management/15.7/x86_64
+    ```
+
+  * `custom_repositories` setting:
+    Mapping of repository names to URLs to enforce.
+
+    Example:
+    ```
+    custom_repositories:
+      opensuse_tumbleweed_oss: https://cdn.opensuse.org/tumbleweed/repo/oss/
+    ```
+
 
 ## FEEDBACK
 

--- a/app/services/declarative_config_service.rb
+++ b/app/services/declarative_config_service.rb
@@ -1,0 +1,65 @@
+class DeclarativeConfigService
+  def self.enforce!
+    configured_products = Settings.try(:products)
+    if configured_products.present?
+      Rails.logger.info('Applying products configuration')
+      enforce_products!(configured_products)
+    end
+
+    configured_custom_repositories = Settings.try(:custom_repositories)
+    if configured_custom_repositories.present?
+      Rails.logger.info('Applying custom repositories configuration')
+      enforce_custom_repositories!(configured_custom_repositories)
+    end
+  end
+
+  def self.enforce_products!(configured_products)
+    configured_products.each do |target|
+      products = Product.get_by_target!(target)
+
+      products.each do |product|
+        RepositoryService.new.change_mirroring_by_product!(true, product)
+      end
+    end
+
+    Product.all.each do |product|
+      unless configured_products.include?(product.product_string)
+        RepositoryService.new.change_mirroring_by_product!(false, product)
+      end
+    end
+  end
+
+  def self.enforce_custom_repositories!(configured_repositories)
+    configured_names = configured_repositories.keys.map(&:to_s)
+
+    repository_service = RepositoryService.new
+
+    configured_repositories.each do |name, url|
+      name_str = name.to_s
+      url_str = url.to_s
+
+      # update_or_create_repository will only match based on url,
+      # hence we first check if the url for an existing entry matched by name changed
+      existing_repo = Repository.only_custom.find_by(friendly_id: name_str)
+      if existing_repo && existing_repo.external_url != url_str
+        existing_repo.update!(
+          external_url: url_str,
+          local_path: Repository.make_local_path(url_str)
+        )
+      end
+
+      repository_service.update_or_create_repository!(
+        nil,
+        url_str,
+        { name: name_str, id: name_str, enabled: true, mirroring_enabled: true },
+        custom: true
+      )
+    end
+
+    Repository.only_custom.each do |repository|
+      unless configured_names.include?(repository.friendly_id)
+        repository.destroy!
+      end
+    end
+  end
+end

--- a/config/initializers/declarative_config.rb
+++ b/config/initializers/declarative_config.rb
@@ -1,0 +1,7 @@
+Rails.application.config.after_initialize do
+  if ActiveRecord::Base.connection.active? && ActiveRecord::Base.connection.table_exists?('products')
+    DeclarativeConfigService.enforce!
+  end
+rescue ActiveRecord::NoDatabaseError, Mysql2::Error::ConnectionError
+  Rails.logger.warn('Database not ready, skipping declarative configuration enforcement')
+end

--- a/config/rmt.yml
+++ b/config/rmt.yml
@@ -56,3 +56,6 @@ connect_api:
 
 redis:
   url: <%= ENV.fetch('REDIS_URL', nil) %>
+
+products: []
+custom_repositories: {}

--- a/spec/services/declarative_config_service_spec.rb
+++ b/spec/services/declarative_config_service_spec.rb
@@ -1,0 +1,107 @@
+require 'rails_helper'
+
+RSpec.describe DeclarativeConfigService do
+  describe '.enforce!' do
+    let(:repository_service) { instance_double(RepositoryService) }
+
+    before do
+      allow(RepositoryService).to receive(:new).and_return(repository_service)
+      allow(repository_service).to receive(:change_mirroring_by_product!)
+      allow(repository_service).to receive(:update_or_create_repository!)
+      allow(Rails.logger).to receive(:info)
+    end
+
+    context 'when products is defined and not empty' do
+      let(:configured_product_string) { 'SLES/15/x86_64' }
+      let(:configured_product) { instance_double(Product, product_string: configured_product_string) }
+      let(:unconfigured_product_string) { 'SLED/15/x86_64' }
+      let(:unconfigured_product) { instance_double(Product, product_string: unconfigured_product_string) }
+
+      before do
+        allow(Settings).to receive(:try).with(:products).and_return([configured_product_string])
+        allow(Settings).to receive(:try).with(:custom_repositories).and_return(nil)
+
+        allow(Product).to receive(:get_by_target!).with(configured_product_string).and_return([configured_product])
+        allow(Product).to receive(:all).and_return([configured_product, unconfigured_product])
+      end
+
+      it 'logs the application of products configuration' do
+        expect(Rails.logger).to receive(:info).with('Applying products configuration')
+        described_class.enforce!
+      end
+
+      it 'enables the configured but not yet enabled product' do
+        expect(repository_service).to receive(:change_mirroring_by_product!).with(true, configured_product)
+        described_class.enforce!
+      end
+
+      it 'disables products that are not present in the configuration' do
+        expect(repository_service).to receive(:change_mirroring_by_product!).with(false, unconfigured_product)
+        described_class.enforce!
+      end
+    end
+
+    context 'when custom_repositories is defined and not empty' do
+      let(:configured_repos) { { my_repo: 'http://example.com/repo' } }
+      let(:custom_repos_relation) { instance_double(ActiveRecord::Relation) }
+      let(:existing_repo) { instance_double(Repository, friendly_id: 'my_repo', external_url: 'http://old.com/repo') }
+      let(:obsolete_repo) { instance_double(Repository, friendly_id: 'old_repo') }
+
+      before do
+        allow(Settings).to receive(:try).with(:products).and_return(nil)
+        allow(Settings).to receive(:try).with(:custom_repositories).and_return(configured_repos)
+
+        allow(Repository).to receive(:only_custom).and_return(custom_repos_relation)
+        allow(custom_repos_relation).to receive(:find_by).with(friendly_id: 'my_repo').and_return(existing_repo)
+        allow(custom_repos_relation).to receive(:each).and_yield(existing_repo).and_yield(obsolete_repo)
+
+        allow(Repository).to receive(:make_local_path).with('http://example.com/repo').and_return('/path/to/repo')
+
+        allow(existing_repo).to receive(:update!)
+        allow(obsolete_repo).to receive(:destroy!)
+      end
+
+      it 'logs the application of custom repositories configuration' do
+        expect(Rails.logger).to receive(:info).with('Applying custom repositories configuration')
+        described_class.enforce!
+      end
+
+      it 'updates the external_url and local_path if the url of an existing repository changed' do
+        expect(existing_repo).to receive(:update!).with(
+          external_url: 'http://example.com/repo',
+          local_path: '/path/to/repo'
+        )
+        described_class.enforce!
+      end
+
+      it 'delegates creation or updating to the repository service' do
+        expect(repository_service).to receive(:update_or_create_repository!).with(
+          nil,
+          'http://example.com/repo',
+          { name: 'my_repo', id: 'my_repo', enabled: true, mirroring_enabled: true },
+          custom: true
+        )
+        described_class.enforce!
+      end
+
+      it 'destroys custom repositories that are not in the configuration' do
+        expect(obsolete_repo).to receive(:destroy!)
+        expect(existing_repo).not_to receive(:destroy!)
+        described_class.enforce!
+      end
+    end
+
+    context 'when settings are nil or empty' do
+      before do
+        allow(Settings).to receive(:try).with(:products).and_return(nil)
+        allow(Settings).to receive(:try).with(:custom_repositories).and_return(nil)
+      end
+
+      it 'does not log anything or alter configurations' do
+        expect(Rails.logger).not_to receive(:info)
+        expect(repository_service).not_to receive(:change_mirroring_by_product!)
+        described_class.enforce!
+      end
+    end
+  end
+end


### PR DESCRIPTION
For configuration management, the cli/database driven approach is complicated, as for idempotency one needs to build custom logic comparing cli output with the expected state.
Allow to define products and custom repositories in the configuration file instead.
If the new options are defined, the objects will be enforced at startup. If they are not defined, the existing behavior applies. The "products" part is not fully perfect, as one needs to list dependent products in addition to the main one for the configuration to take effect, but it's deemed a good start.

## Description

<!--
Please describe your change and provide as much context as needed including a link to the reference issue / ticket / Trello card. 
-->

* Related Issue / Ticket / Trello card: <link reference>

## How to test 

<!-- Describe the steps how verify your change -->

## Change Type

*Please select the correct option.*

- [ ] **Bug Fix** (a non-breaking change which fixes an issue)
- [x] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [x] I have reviewed my own code and believe that it's ready for an external review.
- [ ] I have provided comments for any hard-to-understand code.
- [x] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

