### PR TITLE
Ensure field width queries return 0 if no records found

### DIFF
--- a/lib/rmt/cli/systems.rb
+++ b/lib/rmt/cli/systems.rb
@@ -203,11 +203,21 @@ class RMT::CLI::Systems < RMT::CLI::Base
     # split the width for each cell equally
     # this makes the rendered table to add extra spaces for some columns
     # while it is not ideal, we have not found a better way
+    # use COALESCE(...) to ensure max length queries return a valid integer
+    # length, defaulting to zero if no records are found.
     date_length = Time.now.utc.to_s.length
-    max_hostname = ActiveRecord::Base.connection.execute('SELECT max(length(hostname)) FROM systems').to_a.flatten.first
-    max_login = ActiveRecord::Base.connection.execute('SELECT max(length(login)) FROM systems').to_a.flatten.first
-    max_identifier = ActiveRecord::Base.connection.execute('SELECT max(length(identifier)) FROM products').to_a.flatten.first
-    max_arch = ActiveRecord::Base.connection.execute('SELECT max(length(arch)) FROM products').to_a.flatten.first
+    max_hostname = ActiveRecord::Base.connection.execute(
+      'SELECT COALESCE(max(length(hostname)), 0) FROM systems'
+    ).to_a.flatten.first
+    max_login = ActiveRecord::Base.connection.execute(
+      'SELECT COALESCE(max(length(login)), 0) FROM systems'
+    ).to_a.flatten.first
+    max_identifier = ActiveRecord::Base.connection.execute(
+      'SELECT COALESCE(max(length(identifier)), 0) FROM products'
+    ).to_a.flatten.first
+    max_arch = ActiveRecord::Base.connection.execute(
+      'SELECT COALESCE(max(length(arch)), 0) FROM products'
+    ).to_a.flatten.first
     # max product width is the length of max identifier/ max version/ max arch
     product = max_identifier + 4 + max_arch + 2
     [max_login, max_hostname, date_length, date_length, product]

--- a/package/obs/rmt-server.changes
+++ b/package/obs/rmt-server.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Aug 18 21:37:21 UTC 2026 - Fergal Mc Carthy <fmccarthy@suse.com>
+
+- Version 3.2
+  * Avoid NoMethodError for rmt-cli systems list (bsc#1275439)
+
+-------------------------------------------------------------------
 Tue Aug 11 08:35:19 UTC 2026 - Jesús Bermúdez Velázquez <jesus.bv@suse.com>
 
 - Version 3.1


### PR DESCRIPTION
## Description

When determining the width for the display fields leverage the SQL COALESCE(...) function to ensure that the queries used will return a valid integer value, defaulting to zero when no matching records are found.

Fixes: SCC-976

AI-Assistance-By: Qwen 3.6 35B MoE (A3B)
Signed-off-by: Fergal Mc Carthy <fmccarthy@suse.com>

## How to test 

Follow the reproducer instructions in https://bugzilla.suse.com/show_bug.cgi?id=1275439

## Change Type

*Please select the correct option.*

- [x] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [x] I have reviewed my own code and believe that it's ready for an external review.
- [x] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [x] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

