### PR TITLE
Refactor product param

### DIFF
--- a/engines/instance_verification/app/controllers/instance_verification/billing_check_controller.rb
+++ b/engines/instance_verification/app/controllers/instance_verification/billing_check_controller.rb
@@ -6,12 +6,10 @@ module InstanceVerification
       verification_provider = InstanceVerification.provider.new(
         logger,
         request,
-        nil,
+        { identifier: params[:identifier] },
         params[:metadata]
       )
-
-      iid = verification_provider.parse_instance_data
-      is_payg = verification_provider.payg_billing_code?(iid, params[:identifier])
+      is_payg = verification_provider.payg_billing_code?
 
       render status: :ok, json: { flavor: is_payg ? 'PAYG' : 'BYOS' }
     rescue InstanceVerification::Exception => e

--- a/engines/instance_verification/app/controllers/instance_verification/billing_check_controller.rb
+++ b/engines/instance_verification/app/controllers/instance_verification/billing_check_controller.rb
@@ -3,13 +3,12 @@ module InstanceVerification
     def check
       # return a string indicating if the instance metadata
       # belongs to a PAYG or BYOS instance
-      verification_provider = InstanceVerification.provider.new(
+      is_payg = InstanceVerification.provider.new(
         logger,
         request,
         { identifier: params[:identifier] },
         params[:metadata]
-      )
-      is_payg = verification_provider.payg_billing_code?
+      ).payg_billing_code?
 
       render status: :ok, json: { flavor: is_payg ? 'PAYG' : 'BYOS' }
     rescue InstanceVerification::Exception => e

--- a/engines/instance_verification/lib/instance_verification/providers/example.rb
+++ b/engines/instance_verification/lib/instance_verification/providers/example.rb
@@ -47,13 +47,14 @@ class InstanceVerification::Providers::Example < InstanceVerification::ProviderB
     { 'billingProducts' => ['foo'], 'marketplaceProductCodes' => ['bar'], 'example_id' => '1234' }
   end
 
-  def payg_billing_code?(iid, identifier)
+  def payg_billing_code?
+    iid = @instance_data
     instance_billing_info = {
       billing_product: iid['billingProducts']&.first,
       marketplace_code: iid['marketplaceProductCodes']&.first
     }
-    return true if (identifier.casecmp('sles').zero? && instance_billing_info[:billing_product] == SLES_PRODUCT_IDENTIFIER)
-    return true if (identifier.casecmp('sles_sap').zero? && SLES4SAP_PRODUCT_IDENTIFIER.include?(instance_billing_info[:marketplace_code]))
+    return true if (@product_hash[:identifier].casecmp('sles').zero? && instance_billing_info[:billing_product] == SLES_PRODUCT_IDENTIFIER)
+    return true if (@product_hash[:identifier].casecmp('sles_sap').zero? && SLES4SAP_PRODUCT_IDENTIFIER.include?(instance_billing_info[:marketplace_code]))
   end
 
   def instance_identifier

--- a/engines/instance_verification/spec/requests/instance_verification/billing_check_controller_spec.rb
+++ b/engines/instance_verification/spec/requests/instance_verification/billing_check_controller_spec.rb
@@ -8,13 +8,13 @@ module InstanceVerification
       context 'when system is SLES and PAYG and valid billing code' do
         let(:billing_info) do
           {
-            billing_product: '1234_SUSE_SLES',
-            marketplace_code: nil
+            billingProducts: ['1234_SUSE_SLES'],
+            marketplaceProductCodes: ['']
           }
         end
 
         it 'returns PAYG' do
-          get '/api/instance/check', params: { metadata: billing_info.to_s, identifier: 'SLES' }
+          get '/api/instance/check', params: { metadata: billing_info, identifier: 'SLES' }
           expect(JSON.parse(response.body)['flavor']).to eq('PAYG')
         end
       end
@@ -22,13 +22,13 @@ module InstanceVerification
       context 'when system is SLES4SAP and PAYG and valid billing code' do
         let(:billing_info) do
           {
-            billing_product: nil,
-            marketplace_code: ['6789_SUSE_SAP']
+            billingProducts: [''],
+            marketplaceProductCodes: ['6789_SUSE_SAP']
           }
         end
 
         it 'returns PAYG' do
-          get '/api/instance/check', params: { metadata: billing_info.to_s, identifier: 'SLES_SAP' }
+          get '/api/instance/check', params: { metadata: billing_info, identifier: 'SLES_SAP' }
           expect(JSON.parse(response.body)['flavor']).to eq('PAYG')
         end
       end
@@ -36,13 +36,13 @@ module InstanceVerification
       context 'when no valid billing code' do
         let(:billing_info) do
           {
-            billing_product: ['foo'],
-            marketplace_code: ['bar']
+            billingProduct: ['foo'],
+            marketplaceProductCodes: ['bar']
           }
         end
 
         it 'returns BYOS' do
-          get '/api/instance/check', params: { metadata: billing_info.to_s, identifier: 'SLES' }
+          get '/api/instance/check', params: { metadata: billing_info, identifier: 'SLES' }
           expect(JSON.parse(response.body)['flavor']).to eq('BYOS')
         end
       end
@@ -50,16 +50,16 @@ module InstanceVerification
       context 'when metadata can not be parsed' do
         let(:billing_info) do
           {
-            billing_product: ['foo'],
-            marketplace_code: ['bar']
+            billingProduct: ['foo'],
+            marketplaceProductCodes: ['bar']
           }
         end
         let(:plugin_double) { instance_double('InstanceVerification::Providers::Example') }
 
         it 'returns BYOS' do
           expect(InstanceVerification::Providers::Example).to receive(:new).at_least(:once).and_return(plugin_double)
-          allow(plugin_double).to receive(:parse_instance_data).and_raise(InstanceVerification::Exception, 'Malformed instance data')
-          get '/api/instance/check', params: { metadata: billing_info.to_s, identifier: 'SLES' }
+          allow(plugin_double).to receive(:payg_billing_code?).and_raise(InstanceVerification::Exception, 'Malformed instance data')
+          get '/api/instance/check', params: { metadata: billing_info, identifier: 'SLES' }
           expect(JSON.parse(response.body)['flavor']).to eq('BYOS')
           expect(response.message).to eq('Unprocessable Content')
           expect(response.code).to eq('422')


### PR DESCRIPTION
## Description

refactor check method and payg_billing_code interface

move the identifier in params to its right place, that way @product_hash has that value internally

remove iid from the signature of the payg_billing_code? method,
that method should be called internally and we do not have to expose
that method, check method does not have to know that
parse_instance_data is invoke or invoked from there


* Related Issue / Ticket / Trello card: <link reference>

## How to test 

after this change, the check endpoint should work as before

## Change Type

*Please select the correct option.*

- [ ] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [X] I have documented the `MANUAL.md` file with any changes to the user experience.
- [x] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

