### PR TITLE
Fix mirror 1276939

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -62,6 +62,13 @@ Naming/MethodParameterName:
   - to
   - id
 
+Naming/VariableNumber:
+  inherit_mode:
+    merge:
+      - AllowedIdentifiers
+  AllowedIdentifiers:
+    - httpv1_1
+
 RSpec/NestedGroups:
   Max: 4
 

--- a/lib/rmt/http_request.rb
+++ b/lib/rmt/http_request.rb
@@ -23,6 +23,7 @@ class RMT::HttpRequest < Typhoeus::Request
     options[:low_speed_limit] = Settings.try(:http_client).try(:low_speed_limit) || 512
     options[:low_speed_time] = Settings.try(:http_client).try(:low_speed_time) || 120
     options[:accept_encoding] = 'gzip'
+    options[:http_version]    = :httpv1_1
   end
 
 end

--- a/lib/rmt/http_request.rb
+++ b/lib/rmt/http_request.rb
@@ -23,7 +23,12 @@ class RMT::HttpRequest < Typhoeus::Request
     options[:low_speed_limit] = Settings.try(:http_client).try(:low_speed_limit) || 512
     options[:low_speed_time] = Settings.try(:http_client).try(:low_speed_time) || 120
     options[:accept_encoding] = 'gzip'
-    options[:http_version]    = :httpv1_1
+    # HTTP/2 multiplexes several streams into one curl_multi_perform frame, so
+    # libcurl can fire callbacks for multiple easy handles while its own frames
+    # are live, RMT::FiberRequest resumes fibers from those callbacks, which
+    # corrupts the heap
+    # Set the HTTP version to 1.1 until that is fixed, see bsc#1276939
+    options[:http_version] = (Settings.try(:http_client).try(:http_version) || 'httpv1_1').to_sym
   end
 
 end

--- a/lib/rmt/http_request.rb
+++ b/lib/rmt/http_request.rb
@@ -28,7 +28,7 @@ class RMT::HttpRequest < Typhoeus::Request
     # are live, RMT::FiberRequest resumes fibers from those callbacks, which
     # corrupts the heap
     # Set the HTTP version to 1.1 until that is fixed, see bsc#1276939
-    options[:http_version] = (Settings.try(:http_client).try(:http_version) || 'httpv1_1').to_sym
+    options[:http_version] = :httpv1_1
   end
 
 end

--- a/package/obs/rmt.conf
+++ b/package/obs/rmt.conf
@@ -30,6 +30,7 @@ http_client:
   proxy_password:
   low_speed_limit: 512
   low_speed_time: 120
+  http_version: httpv1_1
 
 log_level:
   rails: info

--- a/package/obs/rmt.conf
+++ b/package/obs/rmt.conf
@@ -30,7 +30,6 @@ http_client:
   proxy_password:
   low_speed_limit: 512
   low_speed_time: 120
-  http_version: httpv1_1
 
 log_level:
   rails: info

--- a/spec/lib/rmt/http_request_spec.rb
+++ b/spec/lib/rmt/http_request_spec.rb
@@ -31,6 +31,10 @@ RSpec.describe RMT::HttpRequest do
 
     its([:low_speed_limit]) { is_expected.to eq(1337) }
     its([:low_speed_time]) { is_expected.to eq(42) }
+
+    it 'uses HTTP/1.1' do
+      expect(request.options[:http_version]).to eq(:httpv1_1)
+    end
   end
 
   describe 'when request is too slow' do


### PR DESCRIPTION
## Description

fix for mirroring

libcurl uses HTTP/2 as default, because of that
RMT resumes a Fiber from inside an FFI callback
that libcurl called while its own C frames are
live on the stack
the Fiber switch swaps the machine stack out
from under those frames, arbitrary/random Ruby runs
and then the next allocation trips a GC that finds a corrupt heap

that behaviour produces the traceback observed in the bugzilla entry



force HTTP/1.1 for Typhoeus

Fixes bsc#1276939

* Related Issue / Ticket / Trello card: [bsc#1276939](https://bugzilla.suse.com/show_bug.cgi?id=1276939)

## How to test 

re run the mirror command, no bug should be raised and mirroring should complete fine

## Change Type

*Please select the correct option.*

- [X] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [X] I have documented the `MANUAL.md` file with any changes to the user experience.
- [X] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

