### PR TITLE
update nginx directive for HTTP

### DIFF
--- a/package/files/nginx-pubcloud/nginx-http.conf
+++ b/package/files/nginx-pubcloud/nginx-http.conf
@@ -1,6 +1,6 @@
 server {
-    listen 80   default;
-    listen [::]:80 default;
+    listen 80   default_server;
+    listen [::]:80 default_server;
     server_name rmt;
     access_log  /var/log/nginx/rmt_http_access.log;
     error_log   /var/log/nginx/rmt_http_error.log;


### PR DESCRIPTION
## Description

when a client tries to register and it reaches the update server through port 80, the request is blocked making the client hang for around 30 min

and getting a 'SMT certificate import failed' error in the log

update the directive on nginx
the keyword default is deprecated and invalid in modern versions of Nginx 
Nginx replaced it with default_server (already in use in https nginx config)

* Related Issue / Ticket / Trello card: <link reference>

## How to test 

without the fix 
```bash
$ registercloudguest
SMT certificate import failed
```

with the fix
```bash
$ registercloudguest

2026-09-01 10:52:07,814: INFO: Adding podman support
2026-09-01 10:52:07,817: INFO: Instance registry setup completed, all existing shell sessions require a restart !
2026-09-01 10:52:07,818: INFO: Registration succeeded
```

## Change Type

*Please select the correct option.*

- [X] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [X] I have documented the `MANUAL.md` file with any changes to the user experience.
- [X] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

