### PR TITLE
PubCloud RMT Dev Env Enhancements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,8 @@ SCC_PASSWORD=
 
 # nginx
 EXTERNAL_PORT=8080
+
+# Uncomment to enable PubCloud engine loading
+# NOTE: Only do this if you want to test PubCloud engines and beware
+# that many normal spec tests will fail if this is enabled.
+#RMT_LOAD_ENGINES=1

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,72 +1,11 @@
 ## Development Setup
 
-1. Install the system dependencies:
-    ```
-    sudo zypper in libxml2-devel libxslt-devel libmariadb-devel sqlite3-devel gcc libyaml-devel libffi-devel
-    ```
-2. Install the ruby version specified in the `.ruby-version` [file](.ruby-version).
+The following development environment setup modes are possible:
+* [docker compose based setup](development-setup---docker-compose)
+* [local system services based setup](development-Setup---local-system-services)
 
-   2.1 Mise
-
-   if you are using mise and you want mise to use the same version of .ruby-version,
-   point mise to read that file with the following command:
-   ```
-   mise settings add idiomatic_version_file_enable_tools ruby
-   ```
-   see [here](https://mise.jdx.dev/lang/ruby.html#ruby-version-and-gemfile-support)
-
-3. Install and setup the database:
-
-   **Default: MariaDB or MySQL server**
-    ```
-    sudo zypper in mariadb
-    sudo systemctl enable mariadb
-    sudo systemctl start mariadb
-    ```
-    Log into the MariaDB or MySQL server as root and create the RMT database user:
-    ```
-    mysql -u root -p <<EOFF
-    GRANT ALL PRIVILEGES ON \`rmt%\`.* TO rmt@localhost IDENTIFIED BY 'rmt';
-    FLUSH PRIVILEGES;
-    EOFF
-    ```
-
-    **Experimental: SQLite**
-
-    For development purposes it can be easier to run with SQLite, to avoid extra dependencies.
-    To run RMT with SQLite, switch the database adapter in `config/rmt.yml` to `sqlite3`.
-
-4. **Background jobs:** If you plan on implementing background jobs (via [Active Job](https://guides.rubyonrails.org/v6.1/active_job_basics.html)), you will need to install or utilize a service compatible with the Redis API. We recommend [Valkey](https://valkey.io/), a BSD-licensed server, which is packaged for (open)SUSE distributions:
-
-    ```
-    sudo zypper in valkey
-    sudo systemctl enable --now valkey
-    ```
-
-5. Clone the RMT repository:
-    ```
-    git clone git@github.com:SUSE/rmt.git
-    ```
-6. Install the ruby dependencies:
-    ```
-    cd rmt
-    bundle install
-    ```
-7. Copy the file `config/rmt.yml` to `config/rmt.local.yml`. With this file, override the following default settings:
-    * Add your organization credentials to `scc` section.
-    * Ensure that the `database` section is correct.
-8. Create the directory `/var/lib/rmt` and ensure that your current user owns it.
-    ```
-    sudo mkdir /var/lib/rmt
-    sudo chown -R $(id -u):$(id -g) /var/lib/rmt
-    ```
-9. Create the development database:
-    ```
-    bin/rails db:create db:migrate
-    ```
-10. Verify that RMT works:
-    * Run the command `bin/rails server -b 0.0.0.0` to start the web server.
-    * Run the command `bin/rmt-cli sync` to sync RMT with SCC.
+NOTE: See [PubCloud RMT Development](#pubcloud-rmt-development) for additional
+information about developing for PubCloud RMT deployments.
 
 ### Development Setup - docker-compose
 
@@ -136,6 +75,96 @@ $ docker-compose exec rmt /bin/bash
 All in all, the code you might be working on sits as a volume inside of the
 Docker container. Thus, you will be able to code as usual and the Docker
 container will behave as if you were working entirely locally.
+
+### Development Setup - local system services
+
+1. Install the system dependencies:
+    ```
+    sudo zypper in libxml2-devel libxslt-devel libmariadb-devel sqlite3-devel gcc libyaml-devel libffi-devel
+    ```
+2. Install the ruby version specified in the `.ruby-version` [file](.ruby-version).
+
+   2.1 Mise
+
+   if you are using mise and you want mise to use the same version of .ruby-version,
+   point mise to read that file with the following command:
+   ```
+   mise settings add idiomatic_version_file_enable_tools ruby
+   ```
+   see [here](https://mise.jdx.dev/lang/ruby.html#ruby-version-and-gemfile-support)
+
+3. Install and setup the database:
+
+   **Default: MariaDB or MySQL server**
+    ```
+    sudo zypper in mariadb
+    sudo systemctl enable mariadb
+    sudo systemctl start mariadb
+    ```
+    Log into the MariaDB or MySQL server as root and create the RMT database user:
+    ```
+    mysql -u root -p <<EOFF
+    GRANT ALL PRIVILEGES ON \`rmt%\`.* TO rmt@localhost IDENTIFIED BY 'rmt';
+    FLUSH PRIVILEGES;
+    EOFF
+    ```
+
+    **Experimental: SQLite**
+
+    For development purposes it can be easier to run with SQLite, to avoid extra dependencies.
+    To run RMT with SQLite, switch the database adapter in `config/rmt.yml` to `sqlite3`.
+
+4. **Background jobs:** If you plan on implementing background jobs (via [Active Job](https://guides.rubyonrails.org/v6.1/active_job_basics.html)), you will need to install or utilize a service compatible with the Redis API. We recommend [Valkey](https://valkey.io/), a BSD-licensed server, which is packaged for (open)SUSE distributions:
+
+    ```
+    sudo zypper in valkey
+    sudo systemctl enable --now valkey
+    ```
+
+5. Clone the RMT repository:
+    ```
+    git clone git@github.com:SUSE/rmt.git
+    ```
+6. Install the ruby dependencies:
+    ```
+    cd rmt
+    bundle install
+    ```
+7. Copy the file `config/rmt.yml` to `config/rmt.local.yml`. With this file, override the following default settings:
+    * Add your organization credentials to `scc` section.
+    * Ensure that the `database` section is correct.
+8. Create the directory `/var/lib/rmt` and ensure that your current user owns it.
+    ```
+    sudo mkdir /var/lib/rmt
+    sudo chown -R $(id -u):$(id -g) /var/lib/rmt
+    ```
+9. Create the development database:
+    ```
+    bin/rails db:create db:migrate
+    ```
+10. Verify that RMT works:
+    * Run the command `bin/rails server -b 0.0.0.0` to start the web server.
+    * Run the command `bin/rmt-cli sync` to sync RMT with SCC.
+
+## PubCloud RMT Development
+
+To enable the PubCloud engines to be loaded when the RMT server starts
+up, ensure that `RMT_LOAD_ENGINES=1` is set in the environment. See
+[.env.example](.env.example) for an example.
+
+NOTE: For basic PAYG and BYOS lifecycle testing the
+[SUSE/connect-ng/cmd/public-api-demo] tool can be used to simulate
+client instances.
+
+See also the engine specific documentation for more details on how to test:
+* [scc_proxy README.md](engines/scc_proxy/README.md)
+* [strict_authentication README.md](engines/strict_authentication/README.md)
+* [scc_suma_api README.md](engines/scc_suma_api/README.md)
+* [data_export README.md](engines/data_export/README.md)
+* [registration_sharing README.md](engines/registration_sharing/README.md)
+* [instance_verification README.md](engines/instance_verification/README.md) and [TESTING.md](engines/instance_verification/TESTING.md)
+* [registry README.md](engines/registry/README.md)
+* [zypper_auth README.md](engines/zypper_auth/README.md)
 
 ## API documentation
 

--- a/engines/instance_verification/lib/instance_verification/providers/example.rb
+++ b/engines/instance_verification/lib/instance_verification/providers/example.rb
@@ -27,6 +27,7 @@ class InstanceVerification::Providers::Example < InstanceVerification::ProviderB
   end
 
   def parse_instance_data
+    return nil unless @instance_data
     # :nocov:
     if @product_hash && @product_hash[:identifier] == 'Raise error'
       raise InstanceVerification::Exception, 'Missing signature'
@@ -57,7 +58,7 @@ class InstanceVerification::Providers::Example < InstanceVerification::ProviderB
   end
 
   def instance_identifier
-    nil
+    parse_instance_data&.[]('example_id')
   end
 
   def allowed_extension?

--- a/engines/instance_verification/spec/requests/api/connect/v3/subscriptions/systems_controller_spec.rb
+++ b/engines/instance_verification/spec/requests/api/connect/v3/subscriptions/systems_controller_spec.rb
@@ -10,7 +10,7 @@ describe Api::Connect::V3::Subscriptions::SystemsController, type: :request do
         data = response.parsed_body
         system = System.find_by(login: data['login'])
         expect(system.instance_data).to eq(instance_data)
-        expect(system.login).to start_with('SCC_')
+        expect(system.login).to eq('1234')
         expect(system.proxy_byos_mode).to eq('payg')
       end
     end

--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -106,7 +106,7 @@ module SccProxy
     end
 
     def announce_system_scc(auth, params, system_token, logger)
-      uri, http = parse_url(announce_url)
+      uri, http = parse_url(ANNOUNCE_URL)
       scc_request = prepare_scc_announce_request(uri.path, auth, params, system_token)
       response = http.request(scc_request)
       begin
@@ -125,7 +125,7 @@ module SccProxy
     end
 
     def scc_activate_product(system, product, auth, params, mode)
-      uri, http = parse_url(systems_products_url)
+      uri, http = parse_url(SYSTEMS_PRODUCTS_URL)
       scc_request = prepare_scc_request(uri.path, product, auth, params, mode)
       response = http.request(scc_request)
       unless response.code_type == Net::HTTPCreated
@@ -146,7 +146,7 @@ module SccProxy
     end
 
     def deactivate_product_scc(auth, product, params, logger)
-      uri, http = parse_url(systems_products_url)
+      uri, http = parse_url(SYSTEMS_PRODUCTS_URL)
       scc_request = Net::HTTP::Delete.new(uri.path, headers(auth, params))
       scc_request.body = {
         identifier: product.identifier,
@@ -165,7 +165,7 @@ module SccProxy
     end
 
     def deregister_system_scc(auth, system)
-      uri, http = parse_url(deregister_system_url)
+      uri, http = parse_url(DEREGISTER_SYSTEM_URL)
       scc_request = Net::HTTP::Delete.new(uri.path, headers(auth, system.system_token))
       response = http.request(scc_request)
       unless response.code_type == Net::HTTPNoContent
@@ -185,7 +185,7 @@ module SccProxy
     end
 
     def get_scc_activations(auth, system)
-      uri, http = parse_url(systems_activations_url)
+      uri, http = parse_url(SYSTEMS_ACTIVATIONS_URL)
       uri.query = URI.encode_www_form({ byos_mode: system.proxy_byos_mode })
       scc_request = Net::HTTP::Get.new(uri.path, headers(auth, system.system_token))
       response = http.request(scc_request)
@@ -276,7 +276,7 @@ module SccProxy
     end
 
     def scc_upgrade(auth, product, system, logger)
-      uri, http = parse_url(systems_products_url)
+      uri, http = parse_url(SYSTEMS_PRODUCTS_URL)
       scc_request = prepare_scc_upgrade_request(uri.path, product, auth, system.system_token, system.proxy_byos_mode)
       response = http.request(scc_request)
       unless response.code_type == Net::HTTPCreated

--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -1,10 +1,6 @@
 require 'json'
 require 'net/http'
 
-ANNOUNCE_URL = 'https://scc.suse.com/connect/subscriptions/systems'.freeze
-SYSTEMS_PRODUCTS_URL = 'https://scc.suse.com/connect/systems/products'.freeze
-SYSTEMS_ACTIVATIONS_URL = 'https://scc.suse.com/connect/systems/activations'.freeze
-DEREGISTER_SYSTEM_URL = 'https://scc.suse.com/connect/systems'.freeze
 NET_HTTP_ERRORS = [
   Errno::EINVAL,
   Errno::ECONNRESET,
@@ -95,10 +91,35 @@ module SccProxy
       scc_request
     end
 
-    def announce_system_scc(auth, params, system_token, logger)
-      uri = URI.parse(ANNOUNCE_URL)
+    def scc_host_base_url
+      (ENV['SCC_HOST']&.strip || 'https://scc.suse.com/connect').freeze
+    end
+
+    def announce_url
+      "#{scc_host_base_url}/subscriptions/systems".freeze
+    end
+
+    def systems_products_url
+      "#{scc_host_base_url}/systems/products".freeze
+    end
+
+    def systems_activations_url
+      "#{scc_host_base_url}/systems/activations".freeze
+    end
+
+    def deregister_system_url
+      "#{scc_host_base_url}/systems".freeze
+    end
+
+    def parse_url(url)
+      uri = URI.parse(url)
       http = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl = true
+      http.use_ssl = uri.scheme == 'https'
+      [uri, http]
+    end
+
+    def announce_system_scc(auth, params, system_token, logger)
+      uri, http = parse_url(announce_url)
       scc_request = prepare_scc_announce_request(uri.path, auth, params, system_token)
       response = http.request(scc_request)
       begin
@@ -117,9 +138,7 @@ module SccProxy
     end
 
     def scc_activate_product(system, product, auth, params, mode)
-      uri = URI.parse(SYSTEMS_PRODUCTS_URL)
-      http = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl = true
+      uri, http = parse_url(systems_products_url)
       scc_request = prepare_scc_request(uri.path, product, auth, params, mode)
       response = http.request(scc_request)
       unless response.code_type == Net::HTTPCreated
@@ -140,9 +159,7 @@ module SccProxy
     end
 
     def deactivate_product_scc(auth, product, params, logger)
-      uri = URI.parse(SYSTEMS_PRODUCTS_URL)
-      http = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl = true
+      uri, http = parse_url(systems_products_url)
       scc_request = Net::HTTP::Delete.new(uri.path, headers(auth, params))
       scc_request.body = {
         identifier: product.identifier,
@@ -161,9 +178,7 @@ module SccProxy
     end
 
     def deregister_system_scc(auth, system)
-      uri = URI.parse(DEREGISTER_SYSTEM_URL)
-      http = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl = true
+      uri, http = parse_url(deregister_system_url)
       scc_request = Net::HTTP::Delete.new(uri.path, headers(auth, system.system_token))
       response = http.request(scc_request)
       unless response.code_type == Net::HTTPNoContent
@@ -183,9 +198,7 @@ module SccProxy
     end
 
     def get_scc_activations(auth, system)
-      uri = URI.parse(SYSTEMS_ACTIVATIONS_URL)
-      http = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl = true
+      uri, http = parse_url(systems_activations_url)
       uri.query = URI.encode_www_form({ byos_mode: system.proxy_byos_mode })
       scc_request = Net::HTTP::Get.new(uri.path, headers(auth, system.system_token))
       response = http.request(scc_request)
@@ -276,9 +289,7 @@ module SccProxy
     end
 
     def scc_upgrade(auth, product, system, logger)
-      uri = URI.parse(SYSTEMS_PRODUCTS_URL)
-      http = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl = true
+      uri, http = parse_url(systems_products_url)
       scc_request = prepare_scc_upgrade_request(uri.path, product, auth, system.system_token, system.proxy_byos_mode)
       response = http.request(scc_request)
       unless response.code_type == Net::HTTPCreated

--- a/engines/scc_proxy/lib/scc_proxy/engine.rb
+++ b/engines/scc_proxy/lib/scc_proxy/engine.rb
@@ -23,6 +23,13 @@ NET_HTTP_ERRORS = [
 # rubocop:disable Metrics/ModuleLength
 module SccProxy
   class << self
+    SCC_BASE_URL            = ENV.fetch('SCC_BASE_URL', 'https://scc.suse.com/connect').freeze
+
+    ANNOUNCE_URL            = "#{SCC_BASE_URL}/subscriptions/systems".freeze
+    SYSTEMS_PRODUCTS_URL    = "#{SCC_BASE_URL}/systems/products".freeze
+    SYSTEMS_ACTIVATIONS_URL = "#{SCC_BASE_URL}/systems/activations".freeze
+    DEREGISTER_SYSTEM_URL   = "#{SCC_BASE_URL}/systems".freeze
+
     def headers(auth, system_token)
       {
         'accept' => 'application/json,application/vnd.scc.suse.com.v4+json',
@@ -89,26 +96,6 @@ module SccProxy
         byos_mode: mode
       }.to_json
       scc_request
-    end
-
-    def scc_host_base_url
-      (ENV['SCC_HOST']&.strip || 'https://scc.suse.com/connect').freeze
-    end
-
-    def announce_url
-      "#{scc_host_base_url}/subscriptions/systems".freeze
-    end
-
-    def systems_products_url
-      "#{scc_host_base_url}/systems/products".freeze
-    end
-
-    def systems_activations_url
-      "#{scc_host_base_url}/systems/activations".freeze
-    end
-
-    def deregister_system_url
-      "#{scc_host_base_url}/systems".freeze
     end
 
     def parse_url(url)

--- a/engines/scc_proxy/spec/lib/scc_proxy_spec.rb
+++ b/engines/scc_proxy/spec/lib/scc_proxy_spec.rb
@@ -1,0 +1,75 @@
+require 'rails_helper'
+
+describe SccProxy do
+  describe '.scc_host_base_url' do
+    context 'when SCC_HOST is not set' do
+      before { ENV.delete('SCC_HOST') }
+
+      it 'uses the default SUSE cloud URL' do
+        expect(described_class.scc_host_base_url).to eq('https://scc.suse.com/connect')
+      end
+    end
+
+    context 'when SCC_HOST is set' do
+      before { ENV['SCC_HOST'] = 'http://localhost:8080/connect' }
+
+      it 'uses the configured host' do
+        expect(described_class.scc_host_base_url).to eq('http://localhost:8080/connect')
+      end
+    end
+  end
+
+  describe '.announce_url' do
+    before { ENV.delete('SCC_HOST') }
+
+    it 'appends /subscriptions/systems to the base URL' do
+      expect(described_class.announce_url).to eq('https://scc.suse.com/connect/subscriptions/systems')
+    end
+  end
+
+  describe '.systems_products_url' do
+    before { ENV.delete('SCC_HOST') }
+
+    it 'appends /systems/products to the base URL' do
+      expect(described_class.systems_products_url).to eq('https://scc.suse.com/connect/systems/products')
+    end
+  end
+
+  describe '.systems_activations_url' do
+    before { ENV.delete('SCC_HOST') }
+
+    it 'appends /systems/activations to the base URL' do
+      expect(described_class.systems_activations_url).to eq('https://scc.suse.com/connect/systems/activations')
+    end
+  end
+
+  describe '.deregister_system_url' do
+    before { ENV.delete('SCC_HOST') }
+
+    it 'appends /systems to the base URL' do
+      expect(described_class.deregister_system_url).to eq('https://scc.suse.com/connect/systems')
+    end
+  end
+
+  describe '.parse_url' do
+    let(:url) { 'https://scc.suse.com/connect/systems/products' }
+
+    it 'returns a URI and a configured Net::HTTP' do
+      uri, http = described_class.parse_url(url)
+      expect(uri).to be_a(URI::HTTPS)
+      expect(http).to be_a(Net::HTTP)
+      expect(http.use_ssl?).to be true
+    end
+
+    context 'with http URL' do
+      let(:url) { 'http://localhost:8080/connect/systems/products' }
+
+      it 'returns a URI and a configured Net::HTTP' do
+        uri, http = described_class.parse_url(url)
+        expect(uri).to be_a(URI::HTTP)
+        expect(http).to be_a(Net::HTTP)
+        expect(http.use_ssl?).to be false
+      end
+    end
+  end
+end

--- a/engines/scc_proxy/spec/requests/api/connect/v4/systems/products_controller_spec.rb
+++ b/engines/scc_proxy/spec/requests/api/connect/v4/systems/products_controller_spec.rb
@@ -189,7 +189,7 @@ product_type: 'module')
           it 'reports an error' do
             data = response.parsed_body
             expect(data['error']).to eq("{\"error\": \"Error'\"}")
-            expect(SccProxy).to have_received(:headers).with(headers['HTTP_AUTHORIZATION'], nil)
+            expect(SccProxy).to have_received(:headers).with(headers['HTTP_AUTHORIZATION'], '1234')
           end
         end
 

--- a/engines/scc_suma_api/app/controllers/scc_suma_api/scc_suma_api_controller.rb
+++ b/engines/scc_suma_api/app/controllers/scc_suma_api/scc_suma_api_controller.rb
@@ -2,8 +2,17 @@ require 'base64'
 require 'json'
 
 module SccSumaApi
-  REPOSITORY_URL = 'https://scc.suse.com/suma/'.freeze
   CACHED_PRODUCT_TREE_JSON = '/usr/share/rmt/public/suma/product_tree.json'.freeze
+
+  class << self
+    def suma_base_url
+      (ENV['SCC_HOST']&.strip&.delete_suffix('/connect') || 'https://scc.suse.com').freeze
+    end
+
+    def repository_url
+      "#{suma_base_url}/suma/".freeze
+    end
+  end
 
 
   class SccSumaApiController < ::ApplicationController
@@ -74,7 +83,7 @@ module SccSumaApi
     def download_file_from_scc
       tmp_dir = Rails.root.join('tmp')
       downloading_paths = {
-        base_url: URI.join(REPOSITORY_URL),
+        base_url: URI.join(SccSumaApi.repository_url),
         base_dir: tmp_dir,
         cache_dir: tmp_dir
       }

--- a/engines/scc_suma_api/spec/lib/scc_suma_api_spec.rb
+++ b/engines/scc_suma_api/spec/lib/scc_suma_api_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+describe SccSumaApi do
+  describe '.suma_base_url' do
+    context 'when SCC_HOST is not set' do
+      before { ENV.delete('SCC_HOST') }
+
+      it 'uses the default SUSE cloud URL' do
+        expect(described_class.suma_base_url).to eq('https://scc.suse.com')
+      end
+    end
+
+    context 'when SCC_HOST includes /connect' do
+      before { ENV['SCC_HOST'] = 'http://localhost:8080/connect' }
+
+      it 'strips /connect' do
+        expect(described_class.suma_base_url).to eq('http://localhost:8080')
+      end
+    end
+
+    context 'when SCC_HOST includes trailing whitespace' do
+      before { ENV['SCC_HOST'] = 'https://scc.example.com/connect  ' }
+
+      it 'strips whitespace before removing /connect' do
+        expect(described_class.suma_base_url).to eq('https://scc.example.com')
+      end
+    end
+  end
+
+  describe '.repository_url' do
+    before { ENV.delete('SCC_HOST') }
+
+    it 'appends /suma/ to the base URL' do
+      expect(described_class.repository_url).to eq('https://scc.suse.com/suma/')
+    end
+  end
+end


### PR DESCRIPTION
## Description

Enhancements to support testing the PubCloud engines using the RMT dev-env optionally with an SCC dev-env.

Added a commented out entry for the RMT_LOAD_ENGINES=1 env var setting to the .env.example file.

instance_verification:
======================
Update the Example provider in the instance_verification engine so that it's instance_identifier returns a meaningful value rather than nil if instance_data is provided that contains specified values.

This allows the Example provider to be used in a PubCloud enabled RMT dev-env setup to support simulated PAYG or BYOS testing.

scc_proxy:
==========
Add SCC host configurability support to the PubCloud scc_proxy engine. This allows the SCC_HOST environment variable to be used to specify a custom SCC endpoint for PubCloud enabled RMT dev-env testing.

To support this a parse_url helper is defined to assist in setting up the http settings based upon the provide URL, conditionally setting up SSL based upon the URI scheme of the provided URL.

Update the scc_proxy tests to reflect that the Example provider now returns a meaningful value for instance_identifier.

Add tests for the new SCC_HOST env var derived URL construction and parse_url helper methods.

Updated DEVELOPMENT.md with some related PubCloud RMT dev-env setup related details and where to find out more info. Also moved the docker compose based setup instructions to come first with an initial section identifying the possible dev-env setup modes and referencing the new PubCloud specific setup section.

scc_suma_api:
=============
Add SCC host configurability support to the PubCloud scc_suma_api engine, similar to what was done for the scc_proxy engine, though the /connect path is stripped and replaced with /suma/ to match the original REPOSITORY_URL value.

Add tests for the new SCC_HOST env var derived URL construction methods.

AI-Assisted-By: Qwen 3.6 35B Moe (A3B)
Signed-off-by: Fergal Mc Carthy <fmccarthy@suse.com>

Relates-To: jsc#SCC-822

## How to test 

Stand-up an RMT dev-env with PubCloud engines loaded by ensuring RMT_LOAD_ENGINES=1 is specified in the environment. See the [commented out .env.example entry](.env.example) for an example of setting this.

Leverage the [SUSE/connect-ng PR#431](github.com/SUSE/connect-ng#431] updates to run the public-api-demo to simulate a BYOS client instance with token handling disabled, using a valid regcode, by running a command line the following:

```bash
% TEST_REGCODE="<valid_testing_regcode>"
% env DISABLE_TOKEN_HANDLING=true RMT_HOST=http://localhost:8080/ PROFILES_DIR=cmd/public-api-demo/examples/profiles REGCODE="${TEST_REGCODE}" out/public-api-demo SLES 15.7 x86_64 cmd/public-api-demo/examples/system_information_with_arch_specs.json
```

If you want t
## Change Type

*Please select the correct option.*

- [ ] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [x] I have reviewed my own code and believe that it's ready for an external review.
- [x] I have provided comments for any hard-to-understand code.
- [ ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 