### PR TITLE
add index for the purge command

### DIFF
--- a/db/migrate/20260902112523_add_index_to_systems_last_seen_at.rb
+++ b/db/migrate/20260902112523_add_index_to_systems_last_seen_at.rb
@@ -1,0 +1,19 @@
+class AddIndexToSystemsLastSeenAt < ActiveRecord::Migration[8.1]
+  def up
+    # 'rmt-cli systems purge' filters on last_seen_at, which was unindexed and
+    # forced a full scan of Systems table on every batch
+    #
+    # Single column on purpose: InnoDB appends the primary key to every
+    # secondary index, so [:last_seen_at, :id] would be identical on disk
+    #
+    # choosing :inplace on purpose
+    # on a table this size a silent fallback to a full table
+    # copy would lock it for hours
+    # this makes the ALTER fail immediately instead
+    add_index :systems, :last_seen_at, algorithm: :inplace
+  end
+
+  def down
+    remove_index :systems, :last_seen_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_26_153653) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_02_112523) do
   create_table "activations", charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.bigint "service_id", null: false
@@ -193,6 +193,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_26_153653) do
     t.string "system_token"
     t.datetime "updated_at", null: false
     t.index ["hostname"], name: "index_systems_on_hostname"
+    t.index ["last_seen_at"], name: "index_systems_on_last_seen_at"
     t.index ["login", "password", "system_token"], name: "index_systems_on_login_and_password_and_system_token", unique: true
     t.index ["login", "password"], name: "index_systems_on_login_and_password"
     t.index ["system_token"], name: "index_systems_on_system_token"


### PR DESCRIPTION
## Description



* Related Issue / Ticket / Trello card: <link reference>

## How to test 

run this command

```bash
robert-test-rmt-ec2-1-us-east-1a:~ # time rmt-cli systems purge --no-confirmation --before 2019-04-13 --quiet
No systems to be purged on this RMT instance. All systems have contacted RMT after 2019-04-13.

real	0m0.519s
user	0m0.428s
sys	0m0.088s
```

it should take ~1 or under a second (on a database with ~42 M systems)

before this change, the full scan of the table took 46 minutes

## Change Type

*Please select the correct option.*

- [ ] **Bug Fix** (a non-breaking change which fixes an issue)
- [X] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [X] I have documented the `MANUAL.md` file with any changes to the user experience.
- [X] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

