### PR TITLE
fix race condition for 1274090

### DIFF
--- a/app/controllers/api/connect/v3/systems/systems_controller.rb
+++ b/app/controllers/api/connect/v3/systems/systems_controller.rb
@@ -4,6 +4,40 @@ class Api::Connect::V3::Systems::SystemsController < Api::Connect::BaseControlle
   after_action :refresh_system_token, only: [:update], if: -> { request.headers.key?(SYSTEM_TOKEN_HEADER) }
 
   def update
+    System.transaction do
+      # SELECT ... FOR UPDATE: blocks a concurrent deregistration until this
+      # request commits, and raises RecordNotFound if it already committed
+      # Locked by id rather than `@system.lock!`: `lock!` rejects a record with
+      # unpersisted changes, and `after_initialize :init` dirties any system
+      # with a NULL registered_at
+      begin
+        System.lock.find(@system.id)
+      rescue ActiveRecord::RecordNotFound
+        raise system_deregistered_error
+      end
+
+      perform_update
+    end
+
+    respond_with(@system, serializer: ::V3::SystemSerializer)
+  rescue ActiveRecord::InvalidForeignKey
+    raise system_deregistered_error
+  end
+
+  def deregister
+    respond_with(@system.destroy, serializer: ::V3::SystemSerializer)
+  end
+
+  private
+
+  def system_deregistered_error
+    logger.info(N_("System '%s' was deregistered while its update was in flight") % @system.login)
+    error = ActionController::TranslatedError.new(N_('Invalid system credentials'))
+    error.status = :unauthorized
+    error
+  end
+
+  def perform_update
     if params[:online_at].present?
       params[:online_at].each do |online_at|
         dthours = online_at.split(':')
@@ -63,15 +97,7 @@ class Api::Connect::V3::Systems::SystemsController < Api::Connect::BaseControlle
     if @system.save
       logger.info(N_("Updated system information for host '%s'") % @system.hostname)
     end
-
-    respond_with(@system, serializer: ::V3::SystemSerializer)
   end
-
-  def deregister
-    respond_with(@system.destroy, serializer: ::V3::SystemSerializer)
-  end
-
-  private
 
   def info_params(key)
     # Allow all attributes without validating the key structure

--- a/spec/requests/api/connect/v3/systems/systems_controller_locking_spec.rb
+++ b/spec/requests/api/connect/v3/systems/systems_controller_locking_spec.rb
@@ -1,0 +1,132 @@
+require 'rails_helper'
+
+RSpec.describe Api::Connect::V3::Systems::SystemsController do
+  subject(:update_action) { put url, params: payload, headers: headers }
+
+  include_context 'auth header', :system, :login, :password
+  include_context 'version header', 3
+
+  # both the request and the deleter need to see committed rows, so this file
+  # cannot run inside the transaction RSpec wraps around each example
+  self.use_transactional_tests = false
+
+  after do
+    SystemProfile.delete_all
+    Profile.delete_all
+    Activation.delete_all
+    System.delete_all
+    DeregisteredSystem.delete_all
+  end
+
+  let(:system) { FactoryBot.create(:system, hostname: 'initial') }
+  let(:url) { '/connect/systems' }
+  let(:headers) { auth_header.merge(version_header) }
+  let(:hwinfo) do
+    {
+      cpus: 16,
+      sockets: 1,
+      arch: 'x86_64',
+      hypervisor: 'XEN',
+      uuid: 'f46906c5-d87d-4e4c-894b-851e80376003',
+      cloud_provider: 'testcloud'
+    }
+  end
+  let(:payload) { { hostname: 'test', hwinfo: hwinfo } }
+
+  # a connection straight from the pool is useless here: it is the very session
+  # holding the lock, and a session never blocks on its own row locks
+  def second_session
+    config = ActiveRecord::Base.connection_db_config.configuration_hash
+    Mysql2::Client.new(config.slice(:host, :port, :socket, :username, :password, :database, :encoding).compact)
+  end
+
+  # asks the server whether the row is locked *right now* instead of timing a
+  # blocking statement. NOWAIT fails immediately with 1205 on MariaDB (3572 on
+  # MySQL) when the lock is held and returns the row when it is not, so nothing
+  # here depends on timing
+  def row_locked?(client)
+    client.query("SELECT id FROM systems WHERE id = #{system.id} FOR UPDATE NOWAIT")
+    false
+  rescue Mysql2::Error => e
+    raise unless [1205, 3572].include?(e.error_number)
+
+    true
+  end
+
+
+  describe '#update when the deregistration wins the race' do
+    # the deregistration commits after the credentials are checked but before the action takes the row lock
+    # the update must be rejected rather than write to a row that is on its way out
+    before do
+      allow_any_instance_of(described_class).to receive(:authenticate_system).and_wrap_original do |original, *args, **kwargs|
+        original.call(*args, **kwargs)
+
+        client = second_session
+        begin
+          client.query("DELETE FROM systems WHERE id = #{system.id}")
+        ensure
+          client.close
+        end
+      end
+    end
+
+    it 'rejects the update with 401 instead of writing to the deregistered system' do
+      update_action
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'leaves the system deregistered' do
+      update_action
+
+      expect(System.where(id: system.id)).to be_empty
+    end
+  end
+
+  describe '#update under concurrent deregistration' do
+    def capture_sql
+      statements = []
+      subscriber = ActiveSupport::Notifications.subscribe('sql.active_record') do |*, payload|
+        statements << payload[:sql]
+      end
+      yield
+      statements
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscriber)
+    end
+
+    # System.lock.find runs just before perform_update, so by the time this
+    # wrapper is entered the row lock is held and the transaction is still open.
+    # probing from right here needs no second thread, no queue and no sleep (NOWAIT
+    # answers immediately, so the action cannot deadlock against itself)
+    # a probe on its own thread reports the row unlocked even when it is not, so
+    # do not reach for one
+    def probe_from_inside_the_action
+      # a holder rather than a local, so the example reads the value the wrapper
+      # writes when the request runs, not the nil it starts out as
+      result = {}
+
+      allow_any_instance_of(described_class).to receive(:perform_update).and_wrap_original do |original, *args|
+        client = second_session
+        begin
+          result[:locked] = row_locked?(client)
+        ensure
+          client.close
+        end
+
+        original.call(*args)
+      end
+      # rubocop:enable RSpec/AnyInstance
+
+      result
+    end
+
+    it 'holds a row lock on the system while the action runs' do
+      result = probe_from_inside_the_action
+      statements = capture_sql { update_action }
+
+      expect(result[:locked]).not_to be_nil, 'the action never reached perform_update'
+      expect(result[:locked]).to be(true), "the row was not locked while the action held its transaction open\nsql=\n  #{statements.join("\n  ")}"
+    end
+  end
+end

--- a/spec/requests/api/connect/v3/systems/systems_controller_spec.rb
+++ b/spec/requests/api/connect/v3/systems/systems_controller_spec.rb
@@ -428,6 +428,74 @@ RSpec.describe Api::Connect::V3::Systems::SystemsController do
         expect(response.headers).not_to include('System-Token')
       end
     end
+
+    context 'when the system is deregistered mid-request' do
+      let(:profiles) { profile_set_all }
+      let(:payload) { { hostname: 'test', hwinfo: hwinfo, system_profiles: profiles } }
+
+      before do
+        # authentication has already loaded @system; drop the row just as the
+        # action reaches for the lock
+        allow(System).to receive(:lock).and_wrap_original do |original, *args|
+          System.find(system.id).destroy
+          original.call(*args)
+        end
+      end
+
+      it 'answers 401 rather than 500' do
+        update_action
+
+        expect(response).to have_http_status(:unauthorized)
+        expect(response.parsed_body['error']).to eq('Invalid system credentials')
+      end
+
+      it 'writes no orphaned profile links' do
+        expect { update_action }.not_to change(SystemProfile, :count)
+      end
+    end
+
+    context 'when a foreign key violation escapes the profile write' do
+      let(:profiles) { profile_set_all }
+      let(:payload) { { hostname: 'test', hwinfo: hwinfo, system_profiles: profiles } }
+
+      before do
+        allow(Profile).to receive(:ensure_complete_profiles_exist)
+                            .and_raise(ActiveRecord::InvalidForeignKey.new('fk_rails_4fc1eb8ffe'))
+      end
+
+      it 'answers 401 rather than 500' do
+        update_action
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'locking' do
+      let(:profiles) { profile_set_all }
+      let(:payload) { { hostname: 'test', hwinfo: hwinfo, system_profiles: profiles } }
+
+      def capture_sql
+        statements = []
+        subscriber = ActiveSupport::Notifications.subscribe('sql.active_record') do |*, payload|
+          statements << payload[:sql]
+        end
+        yield
+        statements
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscriber)
+      end
+
+      it 'locks the systems row before inserting system_profiles' do
+        statements = capture_sql { update_action }
+
+        lock_at = statements.index { |s| s.match?(/SELECT.+`systems`.+FOR UPDATE/mi) }
+        insert_at = statements.index { |s| s.match?(/INSERT INTO `system_profiles`/i) }
+
+        expect(lock_at).not_to be_nil, 'no SELECT ... FOR UPDATE on systems was issued'
+        expect(insert_at).not_to be_nil, 'the request never wrote a system_profiles row'
+        expect(lock_at).to be < insert_at
+      end
+    end
   end
 
   describe '#deregister' do


### PR DESCRIPTION
## Description

there is a race condition that when it happens,
the row it's inserting system_id for was gone by the time the INSERT
ran, the system was deleted between authentication and the profile write

so it could happen that a worker authenticated against a systems row
that another worker destroyed

authenticate_system does a plain SELECT
and the profile write happens with no lock and no transaction

this change aims to fix the race condition and not returning a 500

This fixes bsc#1274090

* Related Issue / Ticket / Trello card: [bsc#1274090](https://bugzilla.suse.com/show_bug.cgi?id=1274090)

## How to test 



## Change Type

*Please select the correct option.*

- [X] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [X] I have documented the `MANUAL.md` file with any changes to the user experience.
- [X] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

