### PR TITLE
Fix statement invalid

### DIFF
--- a/engines/registration_sharing/app/controllers/registration_sharing/rmt_to_rmt_controller.rb
+++ b/engines/registration_sharing/app/controllers/registration_sharing/rmt_to_rmt_controller.rb
@@ -8,6 +8,14 @@ module RegistrationSharing
     # reaches us the locks are already released and there is nothing left to
     # rescue from within
     DEADLOCK_RETRIES = 3
+    DEADLOCK_BACKOFF = 0.1
+
+    # MariaDB error 1020, raised when a locking statement under READ COMMITTED
+    # waits for a row and finds it changed by the time the lock is granted. It
+    # means the same thing as a deadlock, start the transaction over, but
+    # ActiveRecord has no class for it, so it surfaces as a bare StatementInvalid
+    # and has to be recognised by the driver's error number
+    ER_CHECKREAD = 1020
 
     before_action :authenticate
 
@@ -16,14 +24,20 @@ module RegistrationSharing
       begin
         attempts += 1
         create_or_update_system
-      rescue ActiveRecord::Deadlocked, ActiveRecord::LockWaitTimeout => e
+      rescue ActiveRecord::StatementInvalid => e
+        # StatementInvalid rather than the two contention classes by name: it is
+        # their common ancestor, so Deadlocked and LockWaitTimeout are still caught
+        # here, and ER_CHECKREAD - which has no class of its own
+        # contention? re-raises everything else untouched
+
+        raise unless contention?(e)
         raise if attempts >= DEADLOCK_RETRIES
 
         Rails.logger.warn(
           "regsharing: #{e.class} for login #{params[:login]}, attempt #{attempts}/#{DEADLOCK_RETRIES}, retrying"
         )
         # jittered so two transactions that just collided do not line up again
-        sleep(rand(0.02..0.1) * attempts)
+        sleep(rand * DEADLOCK_BACKOFF * attempts)
         retry
       end
     end
@@ -34,6 +48,15 @@ module RegistrationSharing
     end
 
     protected
+
+    # deadlocks and lock wait timeouts get their own ActiveRecord classes;
+    # ER_CHECKREAD does not, so it is identified through the wrapped driver error
+    def contention?(error)
+      return true if error.is_a?(ActiveRecord::Deadlocked) || error.is_a?(ActiveRecord::LockWaitTimeout)
+
+      cause = error.cause
+      cause.respond_to?(:error_number) && cause.error_number == ER_CHECKREAD
+    end
 
     def fetch_system
       credentials = {

--- a/engines/registration_sharing/app/controllers/registration_sharing/rmt_to_rmt_controller.rb
+++ b/engines/registration_sharing/app/controllers/registration_sharing/rmt_to_rmt_controller.rb
@@ -8,7 +8,9 @@ module RegistrationSharing
     # reaches us the locks are already released and there is nothing left to
     # rescue from within
     DEADLOCK_RETRIES = 3
-    DEADLOCK_BACKOFF = 0.1
+    # a range rather than a ceiling: the lower bound is what actually separates
+    # two transactions that just collided, so a retry must never be immediate
+    DEADLOCK_BACKOFF = (0.02..0.1)
 
     # MariaDB error 1020, raised when a locking statement under READ COMMITTED
     # waits for a row and finds it changed by the time the lock is granted. It
@@ -37,7 +39,7 @@ module RegistrationSharing
           "regsharing: #{e.class} for login #{params[:login]}, attempt #{attempts}/#{DEADLOCK_RETRIES}, retrying"
         )
         # jittered so two transactions that just collided do not line up again
-        sleep(rand * DEADLOCK_BACKOFF * attempts)
+        sleep(rand(DEADLOCK_BACKOFF) * attempts)
         retry
       end
     end

--- a/engines/registration_sharing/app/controllers/registration_sharing/rmt_to_rmt_controller.rb
+++ b/engines/registration_sharing/app/controllers/registration_sharing/rmt_to_rmt_controller.rb
@@ -56,8 +56,7 @@ module RegistrationSharing
     def contention?(error)
       return true if error.is_a?(ActiveRecord::Deadlocked) || error.is_a?(ActiveRecord::LockWaitTimeout)
 
-      cause = error.cause
-      cause.respond_to?(:error_number) && cause.error_number == ER_CHECKREAD
+      error.cause.try(:error_number).eql?(ER_CHECKREAD)
     end
 
     def fetch_system

--- a/engines/registration_sharing/spec/requests/registration_sharing/rmt_to_rmt_controller_spec.rb
+++ b/engines/registration_sharing/spec/requests/registration_sharing/rmt_to_rmt_controller_spec.rb
@@ -273,6 +273,35 @@ module RegistrationSharing
         end
       end
 
+      def record_changed_message
+        "Record has changed since last read in table 'activations'"
+      end
+
+      # the controller recognises the error by number through whatever the
+      # adapter wrapped, so the stand-in only has to answer error_number. Naming
+      # a concrete driver class here would tie the spec to one adapter
+      def driver_error(error_number)
+        StandardError.new(record_changed_message).tap do |error|
+          error.define_singleton_method(:error_number) { error_number }
+        end
+      end
+
+      # the adapter wraps the driver error instead of raising it, and the wrapper
+      # only carries a `cause` when it is raised from inside the rescue. That
+      # cause is the only thing identifying ER_CHECKREAD, so the fake has to be
+      # built the same way rather than instantiated directly
+      def checkread_error
+        raise driver_error(described_class::ER_CHECKREAD)
+      rescue StandardError
+        wrap_current_error
+      end
+
+      def wrap_current_error
+        raise ActiveRecord::StatementInvalid, record_changed_message
+      rescue ActiveRecord::StatementInvalid => e
+        e
+      end
+
       {
         'a deadlock' => ActiveRecord::Deadlocked,
         'a lock wait timeout' => ActiveRecord::LockWaitTimeout
@@ -307,6 +336,38 @@ module RegistrationSharing
               )
             )
           end
+        end
+      end
+
+      context 'when a read committed record change clears on the second attempt' do
+        before do
+          fail_first(System, :find_or_create_by, checkread_error, 1)
+          post_regsharing
+        end
+
+        it 'performs HTTP request successfully' do
+          expect(response).to have_http_status(204)
+        end
+
+        it 'retried exactly once' do
+          expect(System).to have_received(:find_or_create_by).twice
+        end
+
+        it 'creates exactly one system' do
+          expect(System.where(login: login_payg).count).to eq(1)
+        end
+
+        it 'creates the activation' do
+          expect(System.find_by(login: login_payg).activations.count).to eq(1)
+        end
+      end
+
+      context 'when a StatementInvalid is not contention' do
+        before { fail_first(System, :find_or_create_by, ActiveRecord::StatementInvalid.new('syntax error'), 1) }
+
+        it 'does not retry' do
+          expect { post_regsharing }.to raise_error(ActiveRecord::StatementInvalid)
+          expect(System).to have_received(:find_or_create_by).once
         end
       end
 


### PR DESCRIPTION
## Description

handle db statement invalid

there is a race condition producing that error,
the error is that the record has changed since last read
same as Deadlock error

it was not captured with this change that race condition scenario
should retry and not raise a 500

This fixes bsc#1274088

Co-authored: Claude Opus 5 [claude-opus-5@anthropic.com](mailto:claude-opus-5@anthropic.com)

* Related Issue / Ticket / Trello card: [bsc#1274088)](https://bugzilla.suse.com/show_bug.cgi?id=1274088)

## How to test 


## Change Type

*Please select the correct option.*

- [X] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [X] I have documented the `MANUAL.md` file with any changes to the user experience.
- [X] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

