### PR TITLE
Fix record changed

### DIFF
--- a/lib/rmt/cli/mirror.rb
+++ b/lib/rmt/cli/mirror.rb
@@ -1,9 +1,14 @@
 class RMT::CLI::Mirror < RMT::CLI::Base
   class_option :do_not_raise_unpublished, desc: _('Do not fail the command if product is in alpha or beta stage'), type: :boolean, required: false
 
+  # mirroring shares the rmt-cli lock with sync, which writes the same repositories rows
+  # Both run off timers with a nine hour randomised delay, so they overlap routinely,
+  # wait for the (shorter) sync to finish rather than drop a whole night of mirroring
+  LOCK_TIMEOUT = 1800
+
   desc 'all', _('Mirror all enabled repositories')
   def all
-    RMT::Lockfile.lock('mirror') do
+    RMT::Lockfile.lock(timeout: LOCK_TIMEOUT) do
       downloaded_files_count = 0
       downloaded_files_size = 0
       start_time = Time.current
@@ -46,7 +51,7 @@ class RMT::CLI::Mirror < RMT::CLI::Base
 
   desc 'repository IDS', _('Mirror enabled repositories with given repository IDs')
   def repository(*ids)
-    RMT::Lockfile.lock('mirror') do
+    RMT::Lockfile.lock(timeout: LOCK_TIMEOUT) do
       start_time = Time.current
 
       ids = clean_target_input(ids)
@@ -72,7 +77,7 @@ class RMT::CLI::Mirror < RMT::CLI::Base
 
   desc 'product IDS', _('Mirror enabled repositories for a product with given product IDs')
   def product(*targets)
-    RMT::Lockfile.lock('mirror') do
+    RMT::Lockfile.lock(timeout: LOCK_TIMEOUT) do
       start_time = Time.current
 
       targets = clean_target_input(targets)

--- a/lib/rmt/lockfile.rb
+++ b/lib/rmt/lockfile.rb
@@ -1,8 +1,13 @@
 class RMT::Lockfile
   ExecutionLockedError = Class.new(StandardError)
 
+  # an interactive command should report that the lock is taken rather than sit
+  # there silently, so the default is to give up almost at once
+  # Batch jobs pass a longer wait to queue behind whatever is running
+  DEFAULT_TIMEOUT = 1
+
   class << self
-    def lock(lock_name = nil)
+    def lock(lock_name = nil, timeout: DEFAULT_TIMEOUT)
       if ActiveRecord::Base.connection.adapter_name != 'Mysql2'
         yield
         return
@@ -10,24 +15,28 @@ class RMT::Lockfile
 
       lock_name = ['rmt-cli', lock_name].compact.join('-')
 
-      is_lock_obtained = obtain_lock(lock_name)
+      is_lock_obtained = obtain_lock(lock_name, timeout)
       unless is_lock_obtained
         raise ExecutionLockedError.new(
           _('Another instance of this command is already running. Terminate the other instance or wait for it to finish.')
         )
       end
 
-      yield
-
-      release_lock(lock_name)
+      begin
+        yield
+      ensure
+        # released here rather than after the block: an exception escaping the
+        # command would otherwise leave the lock held for the rest of the session
+        release_lock(lock_name)
+      end
     end
 
     protected
 
-    def obtain_lock(lock_name)
+    def obtain_lock(lock_name, timeout = DEFAULT_TIMEOUT)
       quoted_lock_name = ActiveRecord::Base.connection.quote(lock_name)
       # get_lock returns 1 if lock was obtained, 0 otherwise
-      result = ActiveRecord::Base.connection.execute("SELECT GET_LOCK(#{quoted_lock_name}, 1)")
+      result = ActiveRecord::Base.connection.execute("SELECT GET_LOCK(#{quoted_lock_name}, #{timeout.to_i})")
       result.first.first == 1
     end
 

--- a/spec/lib/rmt/lockfile_spec.rb
+++ b/spec/lib/rmt/lockfile_spec.rb
@@ -42,6 +42,28 @@ RSpec.describe RMT::Lockfile do
       end
     end
 
+    context 'with an explicit timeout' do
+      it 'waits that long for the lock' do
+        expect_any_instance_of(ActiveRecord::ConnectionAdapters::Mysql2Adapter).to receive(:execute)
+            .exactly(1).with("SELECT GET_LOCK('rmt-cli', 1800)").times.and_call_original
+        expect_any_instance_of(ActiveRecord::ConnectionAdapters::Mysql2Adapter).to receive(:execute)
+            .exactly(1).with("SELECT RELEASE_LOCK('rmt-cli')").times.and_call_original
+        described_class.lock(timeout: 1800) { nil }
+      end
+    end
+
+    context 'when the block raises' do
+      # the lock outlives the block otherwise, and a long-lived process would
+      # never get it back
+      it 'still releases the lock' do
+        expect_any_instance_of(ActiveRecord::ConnectionAdapters::Mysql2Adapter).to receive(:execute)
+            .exactly(1).with("SELECT GET_LOCK('rmt-cli', 1)").times.and_call_original
+        expect_any_instance_of(ActiveRecord::ConnectionAdapters::Mysql2Adapter).to receive(:execute)
+            .exactly(1).with("SELECT RELEASE_LOCK('rmt-cli')").times.and_call_original
+        expect { described_class.lock { raise 'boom' } }.to raise_error('boom')
+      end
+    end
+
     context 'with locked file' do
       it 'raises exception' do
         expect(described_class).to receive(:obtain_lock).exactly(1).times.and_return(false)


### PR DESCRIPTION
## Description

there is a race condition for sync and mirror commands

`RMT::Lockfile.lock` builds the name in a way that those build are two different MySQL advisory locks
Sync and mirror never contend for the same one and can run at the same time
Mirror is the only caller that passes a name, sync and import and the rest all use the bare rmt-cli lock

the timers guarantee they'll collide. `rmt-server-sync.timer` fires at 01:00 with RandomizedDelaySec=9h,
`rmt-server-mirror.timer` at 02:00 with the same 9h spread. So sync lands somewhere in 01:00–10:00, mirror in
02:00–11:00, meaning an 8 hour overlap window, the bug that raises at 06:57 is right in the middle of it


make rmt-cli sync and mirror share a lock

make mirror waits instead of dying

release the lock on exception, if any

* Related Issue / Ticket / Trello card: [bsc#1273349](https://bugzilla.suse.com/show_bug.cgi?id=1273349) 

## How to test 

<!-- Describe the steps how verify your change -->

## Change Type

*Please select the correct option.*

- [X] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [X] I have documented the `MANUAL.md` file with any changes to the user experience.
- [X] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

