### PR TITLE
Do not return 500s registry

### DIFF
--- a/engines/registry/app/controllers/registry/registry_controller.rb
+++ b/engines/registry/app/controllers/registry/registry_controller.rb
@@ -26,6 +26,11 @@ module Registry
       render json: { code: :bad_request, error: error.message }, status: error.status
     end
 
+    rescue_from Registry::Exceptions::RegistryUnavailable do |error|
+      logger.error("Registry is unavailable: #{error.message}")
+      render json: { code: :unauthorized, error: 'Registry is unavailable' }, status: error.status
+    end
+
     # AuthZ handler
     # AuthZ will validate which of the requested scope policies are fulfilled
     # with the current login access and prepare the token to be sent back to the client

--- a/engines/registry/app/controllers/registry/registry_controller.rb
+++ b/engines/registry/app/controllers/registry/registry_controller.rb
@@ -8,6 +8,24 @@ module Registry
     before_action :basic_auth, except: [ :catalog ]
     before_action :catalog_token_auth, only: [ :catalog ]
 
+    rescue_from StandardError do |error|
+      logger.error("Registry request failed: #{error.class}: #{error.message}")
+      logger.error(error.backtrace.join("\n")) if error.backtrace
+      render json: { code: :unauthorized, error: 'Registry authentication failed' }, status: :unauthorized
+    end
+
+    rescue_from Registry::Exceptions::RegistryUnavailable do |error|
+      logger.error("Registry is unavailable: #{error.message}")
+      render json: { code: :unauthorized, error: 'Registry is unavailable' }, status: error.status
+    end
+
+    # the scope comes straight off the query string, so a malformed one is the
+    # client's mistake to correct and the message is safe to hand back
+    rescue_from Registry::Exceptions::InvalidScope do |error|
+      logger.info("Rejected registry scope: #{error.message}")
+      render json: { code: :bad_request, error: error.message }, status: error.status
+    end
+
     # Raised from before_action callbacks, which run outside the action body, so
     # a rescue clause on an action structurally cannot see them, i.e.
     # a missing registry section reached the client as a 500 with a stack trace and
@@ -19,27 +37,12 @@ module Registry
       render json: { code: :unauthorized, error: 'Registry authentication failed' }, status: :unauthorized
     end
 
-    # the scope comes straight off the query string, so a malformed one is the
-    # client's mistake to correct and the message is safe to hand back
-    rescue_from Registry::Exceptions::InvalidScope do |error|
-      logger.info("Rejected registry scope: #{error.message}")
-      render json: { code: :bad_request, error: error.message }, status: error.status
-    end
-
-    rescue_from Registry::Exceptions::RegistryUnavailable do |error|
-      logger.error("Registry is unavailable: #{error.message}")
-      render json: { code: :unauthorized, error: 'Registry is unavailable' }, status: error.status
-    end
-
     # AuthZ handler
     # AuthZ will validate which of the requested scope policies are fulfilled
     # with the current login access and prepare the token to be sent back to the client
     def authorize
       token = AccessToken.new(@client&.account, params['service'], @requested_scopes.map { |s| s.granted(request.remote_ip, client: @client) }).token
       render json: { token: token }, status: :ok
-    rescue StandardError => e
-      Rails.logger.error "Could not authorize: #{e.message}"
-      render json: { error: e.message }, status: :unauthorized
     end
 
     # Catalog handler

--- a/engines/registry/app/controllers/registry/registry_controller.rb
+++ b/engines/registry/app/controllers/registry/registry_controller.rb
@@ -19,6 +19,13 @@ module Registry
       render json: { code: :unauthorized, error: 'Registry authentication failed' }, status: :unauthorized
     end
 
+    # the scope comes straight off the query string, so a malformed one is the
+    # client's mistake to correct and the message is safe to hand back
+    rescue_from Registry::Exceptions::InvalidScope do |error|
+      logger.info("Rejected registry scope: #{error.message}")
+      render json: { code: :bad_request, error: error.message }, status: error.status
+    end
+
     # AuthZ handler
     # AuthZ will validate which of the requested scope policies are fulfilled
     # with the current login access and prepare the token to be sent back to the client

--- a/engines/registry/app/controllers/registry/registry_controller.rb
+++ b/engines/registry/app/controllers/registry/registry_controller.rb
@@ -8,6 +8,17 @@ module Registry
     before_action :basic_auth, except: [ :catalog ]
     before_action :catalog_token_auth, only: [ :catalog ]
 
+    # Raised from before_action callbacks, which run outside the action body, so
+    # a rescue clause on an action structurally cannot see them, i.e.
+    # a missing registry section reached the client as a 500 with a stack trace and
+    # nothing they can do about it
+    rescue_from RegistryAuthError do |error|
+      # only the log gets the detail: it names a server-side path, and it is read
+      # on the same host that needs the fix
+      logger.error("Registry authentication failed: #{error.message}")
+      render json: { code: :unauthorized, error: 'Registry authentication failed' }, status: :unauthorized
+    end
+
     # AuthZ handler
     # AuthZ will validate which of the requested scope policies are fulfilled
     # with the current login access and prepare the token to be sent back to the client
@@ -69,7 +80,7 @@ module Registry
       return unless request.authorization
 
       realm = Settings.try(:registry).try(:realm)
-      raise RegistryAuthError, 'registry not configured properly in /etc/rmt.conf' if realm.blank?
+      raise RegistryAuthError, 'registry realm not configured properly in /etc/rmt.conf' if realm.blank?
 
       authenticate_or_request_with_http_basic(realm) do |login, password|
         begin
@@ -104,7 +115,7 @@ module Registry
     # is called by authenticate_or_request_with_http_token when client provides no token
     def request_http_token_authentication(realm = authorize_url, message = 'authentication required')
       service = Settings.try(:registry).try(:service)
-      raise RegistryAuthError, 'registry not configured properly in /etc/rmt.conf' if service.blank?
+      raise RegistryAuthError, 'registry service not configured properly in /etc/rmt.conf' if service.blank?
 
       www_authenticate = [
         %(Bearer realm="#{realm.delete('"')}"),

--- a/engines/registry/app/models/access_scope.rb
+++ b/engines/registry/app/models/access_scope.rb
@@ -82,10 +82,10 @@ class AccessScope
   end
 
   def allowed_paths(system, remote_ip)
+    return @allowed_paths = [] if system.nil?
+
     repo_list = RegistryCatalogService.new.repos(system, reload: false)
-    access_policies_yml = YAML.unsafe_load(
-      File.read(Rails.application.config.access_policies)
-    )
+    access_policies_yml = access_policies
     active_product_classes = system.activations.includes(:product).pluck(:product_class)
     allowed_product_classes = (active_product_classes & access_policies_yml.keys)
     if system && system.hybrid?
@@ -118,6 +118,16 @@ class AccessScope
     end
     allowed_glob_paths = access_policies_yml.values_at(*allowed_product_classes).flatten
     @allowed_paths = parse_repos(repo_list, allowed_glob_paths)
+  end
+
+  def access_policies
+    policies_path = Rails.application.config.access_policies
+    access_policies_yml = YAML.unsafe_load(File.read(policies_path))
+    raise Registry::Exceptions::RegistryUnavailable.new("#{policies_path} is not a mapping of product classes to paths") unless access_policies_yml.is_a?(Hash)
+
+    access_policies_yml
+  rescue SystemCallError, IOError, Psych::Exception => e
+    raise Registry::Exceptions::RegistryUnavailable.new("could not read #{policies_path}: #{e.class}: #{e.message}")
   end
 
   def parse_repos(repos, allowed_paths)

--- a/engines/registry/app/models/access_token.rb
+++ b/engines/registry/app/models/access_token.rb
@@ -44,6 +44,10 @@ class AccessToken
   end
 
   def private_key
+    missing_key = Rails.application.config.registry_private_key.blank? && @private_key.blank?
+
+    raise Registry::Exceptions::RegistryUnavailable.new('registry signing key is missing') if missing_key
+
     @private_key ||= Rails.application.config.registry_private_key
   end
 end

--- a/engines/registry/app/models/catalog_client.rb
+++ b/engines/registry/app/models/catalog_client.rb
@@ -19,6 +19,9 @@ class CatalogClient
   private
 
   def public_key
-    Rails.application.config.registry_private_key.public_key
+    key = Rails.application.config.registry_private_key
+    raise Registry::Exceptions::RegistryUnavailable.new('registry signing key is missing') if key.blank?
+
+    key.public_key
   end
 end

--- a/engines/registry/app/models/registry/exceptions.rb
+++ b/engines/registry/app/models/registry/exceptions.rb
@@ -17,4 +17,19 @@ module Registry::Exceptions
       super(message)
     end
   end
+
+  # the registry cannot serve the request for a reason on this host: a signing
+  # key or policy file that was never installed, or the registry itself not
+  # answering
+  # Kept apart from the errors above because the cause is entirely server-side,
+  # even though it does not return 5XX,
+  # so the distinction lives in the log rather than in the status
+  class RegistryUnavailable < StandardError
+    attr_accessor :status
+
+    def initialize(message = nil, status = 401)
+      @status = status
+      super(message)
+    end
+  end
 end

--- a/engines/registry/app/services/registry_catalog_service.rb
+++ b/engines/registry/app/services/registry_catalog_service.rb
@@ -30,16 +30,22 @@ class RegistryCatalogService
   def fetch_registry_repos(system)
     Rails.logger.info('Fetch registry repos')
     response = catalog_token(system)
-    catalog_auth_token = JSON.parse(response.body).fetch('token', '')
+    catalog_auth_token = JSON.parse(response.body.to_s).fetch('token', '')
     response = all_repos(catalog_auth_token)
-    JSON.parse(response.body).fetch('repositories', [])
+    JSON.parse(response.body.to_s).fetch('repositories', [])
+  rescue JSON::ParserError, SystemCallError, SocketError, OpenSSL::SSL::SSLError, Net::OpenTimeout, Net::ReadTimeout => e
+    # the registry not answering, or answering with something that is not the JSON we expect,
+    # is an outage and not a bug in the caller
+    # Both of these calls cross the network,
+    # so it is the ordinary failure mode rather than something exceptional
+    raise Registry::Exceptions::RegistryUnavailable.new("could not read the registry catalog: #{e.class}: #{e.message}")
   end
 
   def catalog_token(system)
     framework = InstanceVerification.provider.name.rpartition('::')[2].downcase
     uri = URI.parse(URI.join("https://registry-#{framework}.susecloud.net", AUTH_URL).to_s)
     service = Settings.try(:registry).try(:service)
-    raise StandardError, 'registry not configured properly in /etc/rmt.conf' if service.blank?
+    raise Registry::Exceptions::RegistryUnavailable.new('registry service not configured properly in /etc/rmt.conf') if service.blank?
 
     catalog_token_params = {
       service: service,

--- a/engines/registry/spec/app/controllers/registry_controller_spec.rb
+++ b/engines/registry/spec/app/controllers/registry_controller_spec.rb
@@ -66,6 +66,39 @@ module Registry
           expect(response.body).not_to include('/etc/rmt.conf')
         end
       end
+
+      context 'login request with a malformed scope' do
+        it 'rejects a scope that is not colon separated' do
+          get('/api/registry/authorize', params: { scope: 'foo' })
+
+          expect(response).to have_http_status(:bad_request)
+          expect(json_response[:error]).to eq('Invalid scope format')
+        end
+
+        it 'rejects a scope with too few parts' do
+          get('/api/registry/authorize', params: { scope: 'repository:name' })
+
+          expect(response).to have_http_status(:bad_request)
+          expect(json_response[:error]).to eq('Invalid scope format')
+        end
+
+        it 'rejects a scope with too many parts' do
+          get('/api/registry/authorize', params: { scope: 'a:b:c:d' })
+
+          expect(response).to have_http_status(:bad_request)
+          expect(json_response[:error]).to eq('Invalid scope format')
+        end
+
+        it 'rejects a scope with a character outside the allowed set' do
+          get('/api/registry/authorize', params: { scope: 'repository:name:pull;drop' })
+
+          expect(response).to have_http_status(:bad_request)
+          expect(json_response[:error]).to eq('Invalid scope format')
+        end
+
+        it 'never reaches the controller with invalid UTF-8' do                                          expect { get('/api/registry/authorize?scope=repository%3Aname%3A%FFpull') }                      .to raise_error(ActionController::BadRequest)
+        end
+      end
     end
 
     describe '#catalog without access token' do

--- a/engines/registry/spec/app/controllers/registry_controller_spec.rb
+++ b/engines/registry/spec/app/controllers/registry_controller_spec.rb
@@ -96,7 +96,8 @@ module Registry
           expect(json_response[:error]).to eq('Invalid scope format')
         end
 
-        it 'never reaches the controller with invalid UTF-8' do                                          expect { get('/api/registry/authorize?scope=repository%3Aname%3A%FFpull') }                      .to raise_error(ActionController::BadRequest)
+        it 'never reaches the controller with invalid UTF-8' do
+          expect { get('/api/registry/authorize?scope=repository%3Aname%3A%FFpull') }.to raise_error(ActionController::BadRequest)
         end
       end
 

--- a/engines/registry/spec/app/controllers/registry_controller_spec.rb
+++ b/engines/registry/spec/app/controllers/registry_controller_spec.rb
@@ -305,6 +305,47 @@ module Registry
             expect(Rails.logger).to have_received(:error).with(/could not read the registry catalog: JSON::ParserError/)
           end
         end
+
+        context 'when the access policy file cannot be read' do
+          before do
+            allow(Settings).to receive(:try).with(:registry).and_return(settings_registry)
+            allow(settings_registry).to receive(:try).with(:realm).and_return(registry_realm)
+            allow(settings_registry).to receive(:try).with(:service).and_return(registry_service)
+            allow_any_instance_of(AuthenticatedClient).to receive(:cache_file_exist?).and_return(true)
+            allow(Rails.logger).to receive(:error)
+          end
+
+          it 'denies the access when the file is not valid YAML' do
+            get(
+              '/api/registry/authorize',
+              params: { service: registry_service, scope: 'registry:catalog:*' },
+              headers: auth_headers
+              )
+
+            auth_headers_token['Authorization'] = format("Bearer #{json_response[:token]}")
+            # a tab cannot be used for indentation in YAML
+            allow(File).to receive(:read).and_return("policies:\n\t- unindentable")
+            get('/api/registry/catalog', headers: auth_headers_token)
+
+            expect(response).to have_http_status(:unauthorized)
+            expect(Rails.logger).to have_received(:error).with(/could not read .*: Psych::SyntaxError/)
+          end
+
+          it 'denies the access when the file is not a mapping of product classes to paths' do
+            get(
+              '/api/registry/authorize',
+              params: { service: registry_service, scope: 'registry:catalog:*' },
+              headers: auth_headers
+              )
+
+            auth_headers_token['Authorization'] = format("Bearer #{json_response[:token]}")
+            allow(File).to receive(:read).and_return("- one\n- two\n")
+            get('/api/registry/catalog', headers: auth_headers_token)
+
+            expect(response).to have_http_status(:unauthorized)
+            expect(Rails.logger).to have_received(:error).with(/is not a mapping of product classes to paths/)
+          end
+        end
       end
 
       context 'with invalid credentials' do

--- a/engines/registry/spec/app/controllers/registry_controller_spec.rb
+++ b/engines/registry/spec/app/controllers/registry_controller_spec.rb
@@ -262,6 +262,49 @@ module Registry
             expect(response).to have_http_status(:unauthorized)
           end
         end
+
+        context 'when the registry backend is unreachable' do
+          before do
+            allow(Settings).to receive(:try).with(:registry).and_return(settings_registry)
+            allow(settings_registry).to receive(:try).with(:realm).and_return(registry_realm)
+            allow(settings_registry).to receive(:try).with(:service).and_return(registry_service)
+            allow_any_instance_of(AuthenticatedClient).to receive(:cache_file_exist?).and_return(true)
+            allow(Rails.logger).to receive(:error)
+          end
+
+          it 'denies the access when the registry refuses the connection' do
+            stub_request(:get, "#{RegistryCatalogService.new.catalog_api_url}?n=1000").to_raise(Errno::ECONNREFUSED)
+
+            get(
+              '/api/registry/authorize',
+              params: { service: registry_service, scope: 'registry:catalog:*' },
+              headers: auth_headers
+              )
+
+            auth_headers_token['Authorization'] = format("Bearer #{json_response[:token]}")
+            get('/api/registry/catalog', headers: auth_headers_token)
+
+            expect(response).to have_http_status(:unauthorized)
+            expect(Rails.logger).to have_received(:error).with(/could not read the registry catalog: Errno::ECONNREFUSED/)
+          end
+
+          it 'denies the access when the registry answers with something that is not JSON' do
+            stub_request(:get, "#{RegistryCatalogService.new.catalog_api_url}?n=1000")
+              .to_return(body: '<html>502 Bad Gateway</html>', status: 200, headers: { 'Content-type' => 'text/html' })
+
+            get(
+              '/api/registry/authorize',
+              params: { service: registry_service, scope: 'registry:catalog:*' },
+              headers: auth_headers
+              )
+
+            auth_headers_token['Authorization'] = format("Bearer #{json_response[:token]}")
+            get('/api/registry/catalog', headers: auth_headers_token)
+
+            expect(response).to have_http_status(:unauthorized)
+            expect(Rails.logger).to have_received(:error).with(/could not read the registry catalog: JSON::ParserError/)
+          end
+        end
       end
 
       context 'with invalid credentials' do

--- a/engines/registry/spec/app/controllers/registry_controller_spec.rb
+++ b/engines/registry/spec/app/controllers/registry_controller_spec.rb
@@ -55,13 +55,15 @@ module Registry
         let(:system) { create(:system) }
         let(:auth_headers) { { 'Authorization' => ActionController::HttpAuthentication::Basic.encode_credentials(system.login, system.password) } }
 
-        it 'raise an error with a clear message' do
+        it 'refuses the request instead of raising' do
           allow(Settings).to receive(:try).with(:registry).and_return({})
-          # allow(settings_registry).to receive(:try).with(:realm).and_return(registry_realm)
           allow_any_instance_of(AuthenticatedClient).to receive(:cache_file_exist?).and_return(true)
-          expect { get('/api/registry/authorize', headers: auth_headers) }.to raise_error(
-            RegistryAuthError, 'registry not configured properly in /etc/rmt.conf'
-          )
+          allow(Rails.logger).to receive(:error)
+          get('/api/registry/authorize', headers: auth_headers)
+          expect(response).to have_http_status(:unauthorized)
+          # the detail is what the operator needs and the client must not see
+          expect(Rails.logger).to have_received(:error).with(%r{registry realm not configured properly in /etc/rmt\.conf})
+          expect(response.body).not_to include('/etc/rmt.conf')
         end
       end
     end
@@ -95,9 +97,13 @@ module Registry
       let(:system) { create(:system) }
       let(:auth_headers) { { 'Authorization' => ActionController::HttpAuthentication::Basic.encode_credentials(system.login, system.password) } }
 
-      it 'raise an error with a clear message' do
+      it 'refue the request instead of raising' do
         allow(Settings).to receive(:try).with(:registry).and_return({})
-        expect { get('/api/registry/catalog') }.to raise_error(RegistryAuthError, 'registry not configured properly in /etc/rmt.conf')
+        allow(Rails.logger).to receive(:error)
+        get('/api/registry/catalog')
+        expect(response).to have_http_status(:unauthorized)
+        expect(Rails.logger).to have_received(:error).with(%r{registry service not configured properly in /etc/rmt\.conf})
+        expect(response.body).not_to include('/etc/rmt.conf')
       end
     end
 

--- a/engines/registry/spec/app/controllers/registry_controller_spec.rb
+++ b/engines/registry/spec/app/controllers/registry_controller_spec.rb
@@ -99,6 +99,24 @@ module Registry
         it 'never reaches the controller with invalid UTF-8' do                                          expect { get('/api/registry/authorize?scope=repository%3Aname%3A%FFpull') }                      .to raise_error(ActionController::BadRequest)
         end
       end
+
+      context 'when the registry signing key was never installed' do
+        let(:system) { create(:system) }
+        let(:auth_headers) { { 'Authorization' => ActionController::HttpAuthentication::Basic.encode_credentials(system.login, system.password) } }
+
+        it 'reports the missing key rather than a NoMethodError on String' do
+          allow(Settings).to receive(:try).with(:registry).and_return(settings_registry)
+          allow(settings_registry).to receive(:try).with(:realm).and_return(registry_realm)
+          allow_any_instance_of(AuthenticatedClient).to receive(:cache_file_exist?).and_return(true)
+          allow(Rails.application.config).to receive(:registry_private_key).and_return('')
+          allow(Rails.logger).to receive(:error)
+
+          get('/api/registry/authorize', headers: auth_headers)
+
+          expect(response).to have_http_status(:unauthorized)
+          expect(Rails.logger).to have_received(:error).with(/registry signing key is missing/)
+        end
+      end
     end
 
     describe '#catalog without access token' do
@@ -137,6 +155,20 @@ module Registry
         expect(response).to have_http_status(:unauthorized)
         expect(Rails.logger).to have_received(:error).with(%r{registry service not configured properly in /etc/rmt\.conf})
         expect(response.body).not_to include('/etc/rmt.conf')
+      end
+    end
+
+    describe '#catalog when the registry signing key was never installed' do
+      it 'refuses the request instead of raising' do
+        allow(Settings).to receive(:try).with(:registry).and_return(settings_registry)
+        allow(settings_registry).to receive(:try).with(:service).and_return(registry_service)
+        allow(Rails.application.config).to receive(:registry_private_key).and_return('')
+        allow(Rails.logger).to receive(:error)
+
+        get('/api/registry/catalog', headers: { 'Authorization' => 'Bearer irrelevant' })
+
+        expect(response).to have_http_status(:unauthorized)
+        expect(Rails.logger).to have_received(:error).with(/registry signing key is missing/)
       end
     end
 

--- a/engines/registry/spec/app/services/registry_catalog_service_spec.rb
+++ b/engines/registry/spec/app/services/registry_catalog_service_spec.rb
@@ -49,7 +49,7 @@ describe RegistryCatalogService do
 
     it 'raise an error with a clear message' do
       allow(System).to receive(:where).and_return([system])
-      expect { registry.repos(system) }.to raise_error(StandardError, 'registry not configured properly in /etc/rmt.conf')
+      expect { registry.repos(system) }.to raise_error(StandardError, 'registry service not configured properly in /etc/rmt.conf')
     end
   end
 end


### PR DESCRIPTION
## Description

registry in RMT must not return 500 to the client

* Related Issue / Ticket / Trello card: <link reference>

## How to test 

try the registry with a misconfigured update server or wrong registry command and it should not return 500

## Change Type

*Please select the correct option.*

- [X] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [X] I have reviewed my own code and believe that it's ready for an external review.
- [X] I have provided comments for any hard-to-understand code.
- [X] I have documented the `MANUAL.md` file with any changes to the user experience.
- [X] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) 
and get in touch with the author to get a shared understanding of the change. 

